### PR TITLE
Set `requiredSaleorVersion` to >=3.10

### DIFF
--- a/.changeset/popular-trees-visit.md
+++ b/.changeset/popular-trees-visit.md
@@ -1,0 +1,6 @@
+---
+"saleor-app-emails-and-messages": minor
+"saleor-app-invoices": minor
+---
+
+App Manifest was extended to have minimum required Saleor version >= 3.10. Invoices events don't work correctly in older Saleor versions

--- a/apps/emails-and-messages/src/pages/api/manifest.ts
+++ b/apps/emails-and-messages/src/pages/api/manifest.ts
@@ -35,6 +35,10 @@ export default createManifestHandler({
       homepageUrl: "https://github.com/saleor/apps",
       supportUrl: "https://github.com/saleor/apps/discussions",
       author: "Saleor Commerce",
+      /**
+       * Requires 3.10 due to invoices event payload - in previous versions, order reference was missing
+       */
+      requiredSaleorVersion: ">=3.10 <4",
     };
 
     return manifest;

--- a/apps/invoices/src/pages/api/manifest.ts
+++ b/apps/invoices/src/pages/api/manifest.ts
@@ -18,6 +18,10 @@ export default createManifestHandler({
       homepageUrl: "https://github.com/saleor/apps",
       supportUrl: "https://github.com/saleor/apps/discussions",
       author: "Saleor Commerce",
+      /**
+       * Requires 3.10 due to invoices event payload - in previous versions, order reference was missing
+       */
+      requiredSaleorVersion: ">=3.10 <4",
     };
 
     return manifest;


### PR DESCRIPTION
Need to wait for Core to implement Semver coercion, otherwise Saleor pre-releases don't work

- [x] Test with Core with implemented Semver coercion