### PR TITLE
fix: tax not calculating

### DIFF
--- a/.changeset/dull-planets-dance.md
+++ b/.changeset/dull-planets-dance.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": patch
+---
+
+Fix invalid response format in `order-calculate-taxes`.

--- a/apps/taxes/src/modules/app/webhook-response.ts
+++ b/apps/taxes/src/modules/app/webhook-response.ts
@@ -20,9 +20,6 @@ export class WebhookResponse {
 
   success(data?: any) {
     this.logger.debug({ data }, "success called with:");
-    return this.res.status(200).json({
-      status: 200,
-      data,
-    });
+    return this.res.send(data);
   }
 }

--- a/apps/taxes/src/modules/app/webhook-response.ts
+++ b/apps/taxes/src/modules/app/webhook-response.ts
@@ -2,6 +2,11 @@ import { NextApiResponse } from "next";
 import { Logger } from "pino";
 import { createLogger } from "../../lib/logger";
 
+/*
+ * idea: distinguish between async and sync webhooks
+ * when sync webhooks, require passing the event and enforce the required response format using ctx.buildResponse
+ * when async webhooks, dont require anything
+ */
 export class WebhookResponse {
   private logger: Logger;
   constructor(private res: NextApiResponse) {

--- a/apps/taxes/src/modules/ui/country-select/country-select.tsx
+++ b/apps/taxes/src/modules/ui/country-select/country-select.tsx
@@ -37,7 +37,17 @@ export const CountrySelect = React.forwardRef((p: CountrySelectProps, ref) => {
         }) ?? null
       }
       getOptionLabel={(option) => option.label}
-      renderInput={(params) => <TextField {...params} inputRef={ref} placeholder={"Country"} />}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          inputRef={ref}
+          placeholder={"Country"}
+          inputProps={{
+            ...params.inputProps,
+            autoComplete: "new-password", // disable autocomplete and autofill
+          }}
+        />
+      )}
     />
   );
 });

--- a/apps/taxes/src/pages/api/webhooks/order-calculate-taxes.ts
+++ b/apps/taxes/src/pages/api/webhooks/order-calculate-taxes.ts
@@ -66,7 +66,7 @@ export default orderCalculateTaxesSyncWebhook.createHandler(async (req, res, ctx
     const calculatedTaxes = await taxProvider.calculateTaxes(payload.taxBase);
 
     logger.info({ calculatedTaxes }, "Taxes calculated");
-    return webhookResponse.success(calculatedTaxes);
+    return webhookResponse.success(ctx.buildResponse(calculatedTaxes));
   } catch (error) {
     return webhookResponse.failureRetry("Error while calculating taxes");
   }


### PR DESCRIPTION
## Featuring

After introducing the `WebhookResponse` class, we had a regression with the calculated taxes not showing in the Dashboard. It was caused by omitting the usage of `ctx.buildResponse` function for a sync webhook.

Besides the fix, the PR includes a small improvement to `CountrySelect` and a comment with an idea for future improvement (which would detect this issue).