### PR TITLE
Extend release workflow with tagging and releasing on GitHub

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,7 +9,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 #
 # TODO
-# - Add tags for each app (e.g. search@3.0.1) for easier parsing
 # - Print versions name to commit, for easier Vercel deployments
 #
 jobs:
@@ -19,6 +18,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        # Tags are fetched for Changeset to distinguish from new ones while running `changeset tag`
+      - name: Git fetch tags 
+        run: git fetch --tags origin
       - name: Setup Node.js 16 # It was default for Changesets action, check if it can be bumped to v18
         uses: actions/setup-node@v3
         with:
@@ -32,6 +34,8 @@ jobs:
         with:
           title: Release apps
           commit: Release apps
+          publish: pnpm github:release
+          createGithubReleases: true
         env:
           # Use private access token so Github can trigger another workflow from this one
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:ci": "turbo run test:ci",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "generate": "turbo run generate",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "github:release": "pnpm changeset tag && git push --follow-tags"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",


### PR DESCRIPTION
I want to merge this change because, with every `Changeset` triggered release, new git tags in the format **app-name@version** will be added (for example, `saleor-app-invoices@1.13.1`), and a new GitHub release with auto-generated changelog will be created
Resolves: #454
Preview:
<img width="1151" alt="image" src="https://github.com/saleor/apps/assets/6453010/92f229e0-b475-411e-b981-b5e00b82d553">
