### PR TITLE
📧 Downgrade EAM release to minor

### DIFF
--- a/.changeset/slimy-students-switch.md
+++ b/.changeset/slimy-students-switch.md
@@ -1,5 +1,5 @@
 ---
-"saleor-app-emails-and-messages": major
+"saleor-app-emails-and-messages": minor
 ---
 
 App UI has been redesigned to our new components library.


### PR DESCRIPTION
The next release of the EAM app should be marked as minor, not major.
Since data migration was implemented, the upgrade is not breaking anymore.