### PR TITLE
Remove urql codegen plugin

### DIFF
--- a/.changeset/big-frogs-rest.md
+++ b/.changeset/big-frogs-rest.md
@@ -1,0 +1,15 @@
+---
+"saleor-app-emails-and-messages": patch
+"saleor-app-data-importer": patch
+"saleor-app-products-feed": patch
+"saleor-app-monitoring": patch
+"saleor-app-invoices": patch
+"saleor-app-klaviyo": patch
+"saleor-app-search": patch
+"saleor-app-slack": patch
+"saleor-app-taxes": patch
+"saleor-app-cms": patch
+"saleor-app-crm": patch
+---
+
+Removed `typescript-urql` package. All packages use `TypedDocument` for making GraphQL operations.

--- a/apps/cms/.graphqlrc.yml
+++ b/apps/cms/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -44,7 +44,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@types/react": "18.2.5",

--- a/apps/crm/.graphqlrc.yml
+++ b/apps/crm/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -47,7 +47,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/apps/data-importer/.graphqlrc.yml
+++ b/apps/data-importer/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/data-importer/package.json
+++ b/apps/data-importer/package.json
@@ -46,7 +46,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/apps/emails-and-messages/.graphqlrc.yml
+++ b/apps/emails-and-messages/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/emails-and-messages/package.json
+++ b/apps/emails-and-messages/package.json
@@ -59,7 +59,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/apps/invoices/.graphqlrc.yml
+++ b/apps/invoices/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/invoices/package.json
+++ b/apps/invoices/package.json
@@ -47,7 +47,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/klaviyo/.graphqlrc.yml
+++ b/apps/klaviyo/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/klaviyo/package.json
+++ b/apps/klaviyo/package.json
@@ -40,7 +40,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
@@ -2,8 +2,8 @@ import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handl
 import { gql } from "urql";
 
 import {
+  CustomerCreatedDocument,
   CustomerCreatedWebhookPayloadFragment,
-  UntypedCustomerCreatedDocument,
 } from "../../../../generated/graphql";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
@@ -55,7 +55,7 @@ export const customerCreatedWebhook = new SaleorAsyncWebhook<CustomerCreatedWebh
     webhookPath: "api/webhooks/customer-created",
     event: "CUSTOMER_CREATED",
     apl: saleorApp.apl,
-    query: UntypedCustomerCreatedDocument,
+    query: CustomerCreatedDocument,
   }
 );
 

--- a/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
@@ -3,7 +3,7 @@ import { gql } from "urql";
 
 import {
   FulfillmentCreatedWebhookPayloadFragment,
-  UntypedFulfillmentCreatedDocument,
+  FulfillmentCreatedDocument,
 } from "../../../../generated/graphql";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
@@ -62,7 +62,7 @@ export const fulfillmentCreatedWebhook =
     webhookPath: "api/webhooks/fulfillment-created",
     event: "FULFILLMENT_CREATED",
     apl: saleorApp.apl,
-    query: UntypedFulfillmentCreatedDocument,
+    query: FulfillmentCreatedDocument,
   });
 
 const handler: NextWebhookApiHandler<FulfillmentCreatedWebhookPayloadFragment> = async (

--- a/apps/klaviyo/src/pages/api/webhooks/order-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-created.ts
@@ -3,7 +3,7 @@ import { gql } from "urql";
 
 import {
   OrderCreatedWebhookPayloadFragment,
-  UntypedOrderCreatedDocument,
+  OrderCreatedDocument,
 } from "../../../../generated/graphql";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
@@ -32,7 +32,7 @@ export const orderCreatedWebhook = new SaleorAsyncWebhook<OrderCreatedWebhookPay
   webhookPath: "api/webhooks/order-created",
   event: "ORDER_CREATED",
   apl: saleorApp.apl,
-  query: UntypedOrderCreatedDocument,
+  query: OrderCreatedDocument,
 });
 
 const handler: NextWebhookApiHandler<OrderCreatedWebhookPayloadFragment> = async (

--- a/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
@@ -3,7 +3,7 @@ import { gql } from "urql";
 
 import {
   OrderFullyPaidWebhookPayloadFragment,
-  UntypedOrderFullyPaidDocument,
+  OrderFullyPaidDocument,
 } from "../../../../generated/graphql";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
@@ -32,7 +32,7 @@ export const orderFullyPaidWebhook = new SaleorAsyncWebhook<OrderFullyPaidWebhoo
   webhookPath: "api/webhooks/order-fully-paid",
   event: "ORDER_FULLY_PAID",
   apl: saleorApp.apl,
-  query: UntypedOrderFullyPaidDocument,
+  query: OrderFullyPaidDocument,
 });
 
 const handler: NextWebhookApiHandler<OrderFullyPaidWebhookPayloadFragment> = async (

--- a/apps/monitoring/.graphqlrc.yml
+++ b/apps/monitoring/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/monitoring/package.json
+++ b/apps/monitoring/package.json
@@ -40,7 +40,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/apps/products-feed/.graphqlrc.yml
+++ b/apps/products-feed/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/products-feed/package.json
+++ b/apps/products-feed/package.json
@@ -53,7 +53,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/apps/search/.graphqlrc.yml
+++ b/apps/search/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/search/package.json
+++ b/apps/search/package.json
@@ -44,7 +44,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/slack/.graphqlrc.yml
+++ b/apps/slack/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/slack/package.json
+++ b/apps/slack/package.json
@@ -42,7 +42,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/taxes/.graphqlrc.yml
+++ b/apps/taxes/.graphqlrc.yml
@@ -10,9 +10,6 @@ extensions:
         plugins:
           - typescript
           - typescript-operations
-          - typescript-urql:
-              documentVariablePrefix: "Untyped"
-              fragmentVariablePrefix: "Untyped"
           - typed-document-node
       generated/schema.graphql:
         plugins:

--- a/apps/taxes/package.json
+++ b/apps/taxes/package.json
@@ -52,7 +52,6 @@
     "@graphql-codegen/typed-document-node": "3.0.2",
     "@graphql-codegen/typescript": "3.0.2",
     "@graphql-codegen/typescript-operations": "3.0.2",
-    "@graphql-codegen/typescript-urql": "3.7.3",
     "@graphql-typed-document-node/core": "3.2.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/react-hooks": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,9 +128,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -264,9 +261,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -397,9 +391,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -569,9 +560,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -708,9 +696,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -835,9 +820,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -953,9 +935,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -1101,9 +1080,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -1222,9 +1198,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -1346,9 +1319,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -1500,9 +1470,6 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: 3.0.2
         version: 3.0.2(graphql@16.6.0)
-      '@graphql-codegen/typescript-urql':
-        specifier: 3.7.3
-        version: 3.7.3(graphql-tag@2.12.6)(graphql@16.6.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.6.0)
@@ -1868,13 +1835,13 @@ packages:
     peerDependencies:
       graphql: '*'
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/generator': 7.22.3
-      '@babel/parser': 7.22.4
+      '@babel/core': 7.22.5
+      '@babel/generator': 7.22.5
+      '@babel/parser': 7.22.5
       '@babel/runtime': 7.22.5
-      '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
-      babel-preset-fbjs: 3.4.0(@babel/core@7.22.1)
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
+      babel-preset-fbjs: 3.4.0(@babel/core@7.22.5)
       chalk: 4.1.2
       fb-watchman: 2.0.2
       fbjs: 3.0.4
@@ -2861,6 +2828,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
+    dev: true
 
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
@@ -2957,7 +2925,7 @@ packages:
     resolution: {integrity: sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
@@ -2975,32 +2943,18 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor@7.21.5:
     resolution: {integrity: sha512-uNrjKztPLkUk7bpCNC0jEKDJzzkvel/W+HguzbN8krA+LPfC1CEobJEvAvGka2A/M+ViOqXdcRL0GqPUJSjx9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.22.3
-      '@babel/core': 7.21.8
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.7
-      lru-cache: 5.1.1
-      semver: 6.3.0
-    dev: true
-
-  /@babel/helper-compilation-targets@7.22.1(@babel/core@7.21.8):
-    resolution: {integrity: sha512-Rqx13UM3yVB5q0D/KwQ8+SPfX/+Rnsy1Lw1k/UwOC4KC6qrzIQoY3lYnBu5EHKBlEHHcj0M0W8ltPSkD8rqfsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3026,6 +2980,20 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.0
 
+  /@babel/helper-compilation-targets@7.22.5(@babel/core@7.21.8):
+    resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.22.5
+      '@babel/core': 7.21.8
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.8
+      lru-cache: 5.1.1
+      semver: 6.3.0
+    dev: true
+
   /@babel/helper-compilation-targets@7.22.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
     engines: {node: '>=6.9.0'}
@@ -3047,33 +3015,33 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.1
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.5
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-replace-supers': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.5
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.22.1):
+  /@babel/helper-create-class-features-plugin@7.21.8(@babel/core@7.22.5):
     resolution: {integrity: sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.1
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.5
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-replace-supers': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.5
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -3097,7 +3065,7 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.21.8)
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -3119,8 +3087,8 @@ packages:
     resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.21.9
-      '@babel/types': 7.22.4
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
 
   /@babel/helper-function-name@7.22.5:
     resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
@@ -3133,7 +3101,7 @@ packages:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-hoist-variables@7.22.5:
     resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
@@ -3145,14 +3113,14 @@ packages:
     resolution: {integrity: sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-module-imports@7.21.4:
     resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-module-imports@7.22.5:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
@@ -3184,10 +3152,10 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-simple-access': 7.21.5
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.21.9
+      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3210,7 +3178,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-plugin-utils@7.21.5:
@@ -3225,9 +3193,9 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.22.1
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3236,12 +3204,12 @@ packages:
     resolution: {integrity: sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.22.1
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-member-expression-to-functions': 7.21.5
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.21.9
-      '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3250,7 +3218,7 @@ packages:
     resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -3262,14 +3230,14 @@ packages:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-split-export-declaration@7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/helper-split-export-declaration@7.22.5:
     resolution: {integrity: sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==}
@@ -3305,10 +3273,10 @@ packages:
     resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.21.0
-      '@babel/template': 7.21.9
-      '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/helper-function-name': 7.22.5
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3328,9 +3296,9 @@ packages:
     resolution: {integrity: sha512-jBJ7jWblbgr7r6wYZHMdIqKc73ycaTcCaWRq4/2LpuPHcx7xMlZvpGQkOYc9HeSjn6rcx15CPlgVcBtZ4WZJ2w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.21.9
+      '@babel/template': 7.22.5
       '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3348,9 +3316,10 @@ packages:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
+    dev: true
 
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
@@ -3373,7 +3342,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
 
   /@babel/parser@7.22.5:
     resolution: {integrity: sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==}
@@ -3411,7 +3380,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-environment-visitor': 7.22.1
+      '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.8)
@@ -3432,14 +3401,14 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.1)
+      '@babel/core': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -3514,15 +3483,15 @@ packages:
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.8)
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.22.5)
     dev: true
 
   /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.8):
@@ -3542,26 +3511,26 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.3
+      '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.21.8)
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.8)
       '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.8)
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.22.1):
+  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.3
-      '@babel/core': 7.22.1
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.22.1)
+      '@babel/compat-data': 7.22.5
+      '@babel/core': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.1)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.22.1)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.22.5)
     dev: true
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.8):
@@ -3587,16 +3556,16 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.8)
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.22.1):
+  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.22.5)
     dev: true
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.8):
@@ -3656,12 +3625,12 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.1):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.22.5):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3693,13 +3662,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3759,7 +3728,6 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-    dev: false
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.8):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -3779,12 +3747,12 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.1):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3806,12 +3774,12 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.1):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3833,12 +3801,12 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.1):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3872,6 +3840,16 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
+  /@babel/plugin-syntax-typescript@7.21.4(@babel/core@7.22.5):
+    resolution: {integrity: sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-plugin-utils': 7.21.5
+    dev: true
+
   /@babel/plugin-transform-arrow-functions@7.21.5(@babel/core@7.21.8):
     resolution: {integrity: sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==}
     engines: {node: '>=6.9.0'}
@@ -3882,13 +3860,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.21.5(@babel/core@7.22.1):
+  /@babel/plugin-transform-arrow-functions@7.21.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3899,7 +3877,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.8)
     transitivePeerDependencies:
@@ -3916,13 +3894,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3936,13 +3914,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.22.1):
+  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -3954,33 +3932,33 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.21.8)
-      '@babel/helper-environment-visitor': 7.22.1
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-replace-supers': 7.21.5
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.22.1):
+  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.22.1)
-      '@babel/helper-environment-visitor': 7.22.1
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-replace-supers': 7.21.5
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-split-export-declaration': 7.22.5
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3994,18 +3972,18 @@ packages:
     dependencies:
       '@babel/core': 7.21.8
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/template': 7.21.9
+      '@babel/template': 7.22.5
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.21.5(@babel/core@7.22.1):
+  /@babel/plugin-transform-computed-properties@7.21.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-TR653Ki3pAwxBxUe8srfF3e4Pe3FTA46uaNHYyQwIoM4oWKSoOZiDNyHJ0oIoDIUPSRQbQG7jzgVBX3FPVne1Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/template': 7.21.9
+      '@babel/template': 7.22.5
     dev: true
 
   /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.8):
@@ -4018,13 +3996,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.22.1):
+  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4060,15 +4038,15 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-flow-strip-types@7.21.0(@babel/core@7.22.1):
+  /@babel/plugin-transform-flow-strip-types@7.21.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-FlFA2Mj87a6sDkW4gfGrQQqwY/dLlBAyJa2dJEZ+FHXUVHBflO2wyKvg+OOEzXfrKYIa4HWl0mgmbCzt0cMb7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.1)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.5)
     dev: true
 
   /@babel/plugin-transform-for-of@7.21.5(@babel/core@7.21.8):
@@ -4081,13 +4059,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-for-of@7.21.5(@babel/core@7.22.1):
+  /@babel/plugin-transform-for-of@7.21.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-nYWpjKW/7j/I/mZkGVgHJXh4bA1sfdFnJoOXwJuj4m3Q2EraO/8ZyrkCau9P5tbHQk01RMSt6KYLCsW7730SXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4098,20 +4076,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.21.8)
-      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.22.1):
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.22.5):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.22.1)
-      '@babel/helper-function-name': 7.21.0
+      '@babel/core': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.22.5)
+      '@babel/helper-function-name': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4125,13 +4103,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.22.1):
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.22.5):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4145,13 +4123,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4162,7 +4140,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.22.1
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -4175,23 +4153,23 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.22.1
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-simple-access': 7.21.5
+      '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.21.5(@babel/core@7.22.1):
+  /@babel/plugin-transform-modules-commonjs@7.21.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/helper-module-transforms': 7.22.1
+      '@babel/core': 7.22.5
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-simple-access': 7.21.5
+      '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4203,8 +4181,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.22.1
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-validator-identifier': 7.22.5
     transitivePeerDependencies:
@@ -4218,7 +4196,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.8
-      '@babel/helper-module-transforms': 7.22.1
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     transitivePeerDependencies:
       - supports-color
@@ -4258,13 +4236,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-replace-supers': 7.21.5
     transitivePeerDependencies:
@@ -4281,13 +4259,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.22.1):
+  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4301,23 +4279,23 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4347,10 +4325,24 @@ packages:
     dependencies:
       '@babel/core': 7.22.1
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.1)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.22.5):
+    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.21.5
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.5)
+      '@babel/types': 7.22.5
     dev: true
 
   /@babel/plugin-transform-regenerator@7.21.5(@babel/core@7.21.8):
@@ -4384,13 +4376,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.22.1):
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.22.5):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4405,13 +4397,13 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
 
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.22.1):
+  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.22.5):
     resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
@@ -4436,13 +4428,13 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.22.1):
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.22.5):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
@@ -4456,17 +4448,17 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
-  /@babel/plugin-transform-typescript@7.21.3(@babel/core@7.22.1):
+  /@babel/plugin-transform-typescript@7.21.3(@babel/core@7.22.5):
     resolution: {integrity: sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.1)
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.22.5)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.22.1)
+      '@babel/plugin-syntax-typescript': 7.21.4(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4498,11 +4490,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.3
+      '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.8
-      '@babel/helper-compilation-targets': 7.22.1(@babel/core@7.21.8)
+      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.21.8)
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.21.8)
@@ -4569,7 +4561,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.21.5(@babel/core@7.21.8)
       '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.21.8)
       '@babel/preset-modules': 0.1.5(@babel/core@7.21.8)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.8)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.8)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.8)
@@ -4579,16 +4571,16 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/preset-flow@7.21.4(@babel/core@7.22.1):
+  /@babel/preset-flow@7.21.4(@babel/core@7.22.5):
     resolution: {integrity: sha512-F24cSq4DIBmhq4OzK3dE63NHagb27OPE3eWR+HLekt4Z3Y5MzIIUGF3LlLgV0gN8vzbDViSY7HnrReNVCJXTeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-transform-flow-strip-types': 7.21.0(@babel/core@7.22.1)
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-flow-strip-types': 7.21.0(@babel/core@7.22.5)
     dev: true
 
   /@babel/preset-modules@0.1.5(@babel/core@7.21.8):
@@ -4600,33 +4592,33 @@ packages:
       '@babel/helper-plugin-utils': 7.21.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.8)
       '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.8)
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
       esutils: 2.0.3
     dev: true
 
-  /@babel/preset-typescript@7.21.5(@babel/core@7.22.1):
+  /@babel/preset-typescript@7.21.5(@babel/core@7.22.5):
     resolution: {integrity: sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@babel/helper-plugin-utils': 7.21.5
-      '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.1)
-      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.22.1)
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.22.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/register@7.21.0(@babel/core@7.22.1):
+  /@babel/register@7.21.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -4663,9 +4655,9 @@ packages:
     resolution: {integrity: sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/types': 7.22.5
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -4697,14 +4689,14 @@ packages:
     resolution: {integrity: sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.5
       '@babel/generator': 7.22.3
       '@babel/helper-environment-visitor': 7.22.1
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.5
+      '@babel/types': 7.22.5
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -5024,7 +5016,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.22.5
-      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-module-imports': 7.22.5
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.5)
       '@babel/runtime': 7.22.5
       '@emotion/hash': 0.9.0
@@ -5654,20 +5646,6 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-codegen/plugin-helpers@2.7.2(graphql@16.6.0):
-    resolution: {integrity: sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@graphql-tools/utils': 8.13.1(graphql@16.6.0)
-      change-case-all: 1.0.14
-      common-tags: 1.8.2
-      graphql: 16.6.0
-      import-from: 4.0.0
-      lodash: 4.17.21
-      tslib: 2.4.1
-    dev: true
-
   /@graphql-codegen/plugin-helpers@4.1.0(graphql@16.6.0):
     resolution: {integrity: sha512-xvSHJb9OGb5CODIls0AI1rCenLz+FuiaNPCsfHMCNsLDjOZK2u0jAQ9zUBdc/Wb+21YXZujBCc0Vm1QX+Zz0nw==}
     peerDependencies:
@@ -5725,23 +5703,6 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-codegen/typescript-urql@3.7.3(graphql-tag@2.12.6)(graphql@16.6.0):
-    resolution: {integrity: sha512-ndb3C/IZeLaZXI24OEQZnJ7OgzZJvBdw1xnU/ohL6/lMcC5xQgxHBpqM10MZgfTc9l9Ip7qZVCVQk3I4cvcGrA==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-      graphql-tag: ^2.0.0
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.6.0)
-      '@graphql-codegen/visitor-plugin-common': 2.13.1(graphql@16.6.0)
-      auto-bind: 4.0.0
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
-      tslib: 2.4.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
   /@graphql-codegen/typescript@3.0.2(graphql@16.6.0):
     resolution: {integrity: sha512-qD6QkTB+2eJmIaZ6Tihv6HRz7daWWLz9uw5vwCmPeZN6XL2RINZGLkR7D8BQzLDlNGMrpQ4SeSM9o3ZALSCIuQ==}
     peerDependencies:
@@ -5753,27 +5714,6 @@ packages:
       auto-bind: 4.0.0
       graphql: 16.6.0
       tslib: 2.5.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: true
-
-  /@graphql-codegen/visitor-plugin-common@2.13.1(graphql@16.6.0):
-    resolution: {integrity: sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      '@graphql-codegen/plugin-helpers': 2.7.2(graphql@16.6.0)
-      '@graphql-tools/optimize': 1.3.1(graphql@16.6.0)
-      '@graphql-tools/relay-operation-optimizer': 6.5.17(graphql@16.6.0)
-      '@graphql-tools/utils': 8.13.1(graphql@16.6.0)
-      auto-bind: 4.0.0
-      change-case-all: 1.0.14
-      dependency-graph: 0.11.0
-      graphql: 16.6.0
-      graphql-tag: 2.12.6(graphql@16.6.0)
-      parse-filepath: 1.0.2
-      tslib: 2.4.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5976,10 +5916,10 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.5
       '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.22.5)
-      '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.3
@@ -6125,15 +6065,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: true
-
-  /@graphql-tools/utils@8.13.1(graphql@16.6.0):
-    resolution: {integrity: sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      graphql: 16.6.0
-      tslib: 2.5.3
     dev: true
 
   /@graphql-tools/utils@9.2.1(graphql@16.6.0):
@@ -6291,7 +6222,7 @@ packages:
     resolution: {integrity: sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.18
       babel-plugin-istanbul: 6.1.1
@@ -9427,8 +9358,8 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.5
+      '@babel/types': 7.22.5
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.5
@@ -9437,20 +9368,20 @@ packages:
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/parser': 7.22.5
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/babel__traverse@7.18.5:
     resolution: {integrity: sha512-enCvTL8m/EHS/zIvJno9nE+ndYPh1/oNFzRYRmtUqJICG2VnCSBzMLW5VN2KCQU91f23tsNKR8v7VJJQMatl7Q==}
     dependencies:
-      '@babel/types': 7.22.4
+      '@babel/types': 7.22.5
     dev: true
 
   /@types/body-parser@1.19.2:
@@ -9992,7 +9923,7 @@ packages:
   /@vanilla-extract/babel-plugin-debug-ids@1.0.3:
     resolution: {integrity: sha512-vm4jYu1xhSa6ofQ9AhIpR3DkAp4c+eoR1Rpm8/TQI4DmWbmGbOjYRcqV0aWsfaIlNhN4kFuxFMKBNN9oG6iRzA==}
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10907,12 +10838,12 @@ packages:
     resolution: {integrity: sha512-L3nSu8GgF4iEyNYakCQSfL2F5GI5aCXcot9mNTf+4N0/BMhpxqqHyOb6jIR24iq2xLjQZLG8FOt3gnUcV+9NVg==}
     dev: false
 
-  /babel-core@7.0.0-bridge.0(@babel/core@7.22.1):
+  /babel-core@7.0.0-bridge.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.22.1
+      '@babel/core': 7.22.5
     dev: true
 
   /babel-plugin-istanbul@6.1.1:
@@ -10942,7 +10873,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.3
+      '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.8
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.8)
       semver: 6.3.0
@@ -10977,38 +10908,38 @@ packages:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
     dev: true
 
-  /babel-preset-fbjs@3.4.0(@babel/core@7.22.1):
+  /babel-preset-fbjs@3.4.0(@babel/core@7.22.5):
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.22.1)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.1)
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.1)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.1)
-      '@babel/plugin-transform-arrow-functions': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.22.1)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.22.1)
-      '@babel/plugin-transform-computed-properties': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.22.1)
-      '@babel/plugin-transform-flow-strip-types': 7.21.0(@babel/core@7.22.1)
-      '@babel/plugin-transform-for-of': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.22.1)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.22.1)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.1)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.22.1)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.22.1)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.22.1)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.22.1)
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.22.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.22.5)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.22.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.22.5)
+      '@babel/plugin-transform-arrow-functions': 7.21.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-computed-properties': 7.21.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.22.5)
+      '@babel/plugin-transform-flow-strip-types': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-for-of': 7.21.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.22.5)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.22.5)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.5)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.22.5)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.22.5)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.22.5)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.22.5)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -11202,7 +11133,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001503
-      electron-to-chromium: 1.4.416
+      electron-to-chromium: 1.4.430
       node-releases: 2.0.12
       update-browserslist-db: 1.0.11(browserslist@4.21.7)
 
@@ -11426,21 +11357,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /change-case-all@1.0.14:
-    resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
-    dependencies:
-      change-case: 4.1.2
-      is-lower-case: 2.0.2
-      is-upper-case: 2.0.2
-      lower-case: 2.0.2
-      lower-case-first: 2.0.2
-      sponge-case: 1.0.1
-      swap-case: 2.0.2
-      title-case: 3.0.3
-      upper-case: 2.0.2
-      upper-case-first: 2.0.2
-    dev: true
 
   /change-case-all@1.0.15:
     resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
@@ -11899,7 +11815,7 @@ packages:
   /core-js-compat@3.30.2:
     resolution: {integrity: sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==}
     dependencies:
-      browserslist: 4.21.7
+      browserslist: 4.21.8
     dev: true
 
   /core-js@3.27.2:
@@ -12569,6 +12485,7 @@ packages:
 
   /electron-to-chromium@1.4.416:
     resolution: {integrity: sha512-AUYh0XDTb2vrj0rj82jb3P9hHSyzQNdTPYWZIhPdCOui7/vpme7+HTE07BE5jwuqg/34TZ8ktlRz6GImJ4IXjA==}
+    dev: true
 
   /electron-to-chromium@1.4.430:
     resolution: {integrity: sha512-FytjTbGwz///F+ToZ5XSeXbbSaXalsVRXsz2mHityI5gfxft7ieW3HqFLkU5V1aIrY42aflICqbmFoDxW10etg==}
@@ -13181,8 +13098,8 @@ packages:
     resolution: {integrity: sha512-YNF+mZ/Wu2FU/gvmzuWtYc8rloubL7wfXCTgouFrnjGVXPA/EeYYA7pupXWrb3Iv1cTBeSSxxJIbK23l4MRNqg==}
     engines: {node: '>=8.3.0'}
     dependencies:
-      '@babel/traverse': 7.22.4
-      '@babel/types': 7.22.4
+      '@babel/traverse': 7.22.5
+      '@babel/types': 7.22.5
       c8: 7.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14958,8 +14875,8 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/parser': 7.22.4
+      '@babel/core': 7.22.5
+      '@babel/parser': 7.22.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.0
@@ -15154,17 +15071,17 @@ packages:
     peerDependencies:
       '@babel/preset-env': ^7.1.6
     dependencies:
-      '@babel/core': 7.22.1
-      '@babel/parser': 7.22.4
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.22.1)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.22.1)
-      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.1)
+      '@babel/core': 7.22.5
+      '@babel/parser': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-modules-commonjs': 7.21.5(@babel/core@7.22.5)
       '@babel/preset-env': 7.21.5(@babel/core@7.21.8)
-      '@babel/preset-flow': 7.21.4(@babel/core@7.22.1)
-      '@babel/preset-typescript': 7.21.5(@babel/core@7.22.1)
-      '@babel/register': 7.21.0(@babel/core@7.22.1)
-      babel-core: 7.0.0-bridge.0(@babel/core@7.22.1)
+      '@babel/preset-flow': 7.21.4(@babel/core@7.22.5)
+      '@babel/preset-typescript': 7.21.5(@babel/core@7.22.5)
+      '@babel/register': 7.21.0(@babel/core@7.22.5)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.22.5)
       chalk: 4.1.2
       flow-parser: 0.206.0
       graceful-fs: 4.2.11
@@ -17357,7 +17274,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -19950,10 +19867,6 @@ packages:
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
-  /tslib@2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: true
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}


### PR DESCRIPTION
## Scope of the PR

Maintenance PR. Codegen was previously generating frontend side helpers for urql. Since most of our code is executed server side, it was unused.
Both front and backend use TypedDocument to ensure type safety.

## Related issues

Related #381

## Checklist

- [ ] `.github/dependabot.yaml` is up-to date.
- [ ] I added changesets and [read good practices](/.changeset/README.md).
