### PR TITLE
Update helper text for PF app - S3->region field

### DIFF
--- a/.changeset/eighty-boxes-exist.md
+++ b/.changeset/eighty-boxes-exist.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": minor
+---
+
+Improved helper text in S3 form - region field. Now it should be more explicit that only region code (like "eu-west-1") should be provided.

--- a/apps/products-feed/src/modules/app-configuration/s3-configuration-form.tsx
+++ b/apps/products-feed/src/modules/app-configuration/s3-configuration-form.tsx
@@ -44,7 +44,14 @@ export const S3ConfigurationForm = (props: Props) => {
 
       <Input size={"small"} name={"bucketName"} control={control} label="Bucket name" />
 
-      <Input size={"small"} name={"region"} control={control} label="Bucket region" />
+      <Input
+        size={"small"}
+        name={"region"}
+        control={control}
+        label="Bucket region"
+        helperText={"Use the region code, e.g. 'eu-west-1'"}
+        placeholder={"eu-west-1"}
+      />
 
       <Button type="submit" variant="primary" alignSelf={"end"}>
         Save bucket configuration


### PR DESCRIPTION
## Scope of the PR

Makes helper text more explicit. Change after QA feedback where it was mistaken with longer string. In S3 dashboard its something like the screen shot

![image](https://github.com/saleor/apps/assets/9268745/4e4b21ba-287e-4731-8164-8baedef35728)

Which doesn't work - should be only code.

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
