### PR TITLE
Fix missing MANAGE APPS permission when using client provided in context

### DIFF
--- a/.changeset/gorgeous-hats-learn.md
+++ b/.changeset/gorgeous-hats-learn.md
@@ -1,0 +1,8 @@
+---
+"saleor-app-emails-and-messages": patch
+"saleor-app-invoices": patch
+"saleor-app-crm": patch
+---
+
+Fixes "Not enough permissions" error during configuration management.
+

--- a/apps/crm/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/crm/src/modules/trpc/protected-client-procedure.ts
@@ -109,7 +109,7 @@ export const protectedClientProcedure = procedure
   .use(async ({ ctx, next }) => {
     const client = createGraphQLClient({
       saleorApiUrl: ctx.saleorApiUrl,
-      token: ctx.token,
+      token: ctx.appToken,
     });
 
     return next({

--- a/apps/emails-and-messages/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/emails-and-messages/src/modules/trpc/protected-client-procedure.ts
@@ -104,7 +104,7 @@ export const protectedClientProcedure = procedure
   .use(attachAppToken)
   .use(validateClientToken)
   .use(async ({ ctx, next }) => {
-    const client = createGraphQLClient({ saleorApiUrl: ctx.saleorApiUrl, token: ctx.token });
+    const client = createGraphQLClient({ saleorApiUrl: ctx.saleorApiUrl, token: ctx.appToken });
 
     return next({
       ctx: {

--- a/apps/invoices/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/invoices/src/modules/trpc/protected-client-procedure.ts
@@ -104,7 +104,7 @@ export const protectedClientProcedure = procedure
   .use(async ({ ctx, next }) => {
     const client = createGraphQLClient({
       saleorApiUrl: ctx.saleorApiUrl,
-      token: ctx.token,
+      token: ctx.appToken,
     });
 
     return next({


### PR DESCRIPTION
## Scope of the PR

During the last code change in the protected procedure, I've used the wrong token to create GQL client. Because of that some applications were not able to modify private metadata.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] `.github/dependabot.yaml` is up-to date.
- [ ] I added changesets and [read good practices](/.changeset/README.md).
