### PR TITLE
Add about field in manifest of all apps. Sorted fields

### DIFF
--- a/.changeset/chilled-kiwis-type.md
+++ b/.changeset/chilled-kiwis-type.md
@@ -1,0 +1,14 @@
+---
+"saleor-app-emails-and-messages": minor
+"saleor-app-data-importer": minor
+"saleor-app-products-feed": minor
+"saleor-app-invoices": minor
+"saleor-app-klaviyo": minor
+"saleor-app-search": minor
+"saleor-app-slack": minor
+"saleor-app-taxes": minor
+"saleor-app-cms": minor
+"saleor-app-crm": minor
+---
+
+Filled "about" field in App Manifest. Dashboard will display it in app details page now.

--- a/apps/cms/src/pages/api/manifest.ts
+++ b/apps/cms/src/pages/api/manifest.ts
@@ -10,11 +10,23 @@ import { productUpdatedWebhook } from "./webhooks/product-updated";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "CMS",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "CMS App is a multi-integration app that connects Saleor with popular Content Management Systems.",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_PRODUCTS"],
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
       id: "saleor.app.cms",
+      name: "CMS",
+      permissions: ["MANAGE_PRODUCTS"],
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         productVariantCreatedWebhook.getWebhookManifest(context.appBaseUrl),
@@ -22,16 +34,6 @@ export default createManifestHandler({
         productVariantDeletedWebhook.getWebhookManifest(context.appBaseUrl),
         productUpdatedWebhook.getWebhookManifest(context.appBaseUrl),
       ],
-      extensions: [],
-      author: "Saleor Commerce",
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;

--- a/apps/crm/src/pages/api/manifest.ts
+++ b/apps/crm/src/pages/api/manifest.ts
@@ -8,9 +8,24 @@ import { customerMetadataUpdatedWebhook } from "./webhooks/customer-updated";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "CRM",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about: "CRM App allows synchronization of customers from Saleor to other platforms",
       appUrl: context.appBaseUrl,
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [
+        /**
+         * Optionally, extend Dashboard with custom UIs
+         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
+         */
+      ],
+      homepageUrl: "https://github.com/saleor/apps",
+      id: "saleor.app.crm",
+      name: "CRM",
       permissions: [
         "MANAGE_USERS",
         /**
@@ -18,27 +33,13 @@ export default createManifestHandler({
          * https://docs.saleor.io/docs/3.x/developer/permissions
          */
       ],
-      id: "saleor.app.crm",
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         customerCreatedWebhook.getWebhookManifest(context.appBaseUrl),
         customerMetadataUpdatedWebhook.getWebhookManifest(context.appBaseUrl),
       ],
-      extensions: [
-        /**
-         * Optionally, extend Dashboard with custom UIs
-         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
-         */
-      ],
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      author: "Saleor Commerce",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;

--- a/apps/data-importer/src/pages/api/manifest.ts
+++ b/apps/data-importer/src/pages/api/manifest.ts
@@ -6,11 +6,28 @@ import packageJson from "../../../package.json";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Data Importer",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "Data Importer allows batch import of shop data to Saleor from sources like CSV or Excel",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_USERS"],
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [
+        /**
+         * Optionally, extend Dashboard with custom UIs
+         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
+         */
+      ],
+      homepageUrl: "https://github.com/saleor/apps",
       id: "saleor.app.data-importer",
+      name: "Data Importer",
+      permissions: ["MANAGE_USERS"],
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         /**
@@ -19,21 +36,6 @@ export default createManifestHandler({
          * https://docs.saleor.io/docs/3.x/developer/api-reference/objects/webhook
          */
       ],
-      extensions: [
-        /**
-         * Optionally, extend Dashboard with custom UIs
-         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
-         */
-      ],
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      author: "Saleor Commerce",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;

--- a/apps/emails-and-messages/src/pages/api/manifest.ts
+++ b/apps/emails-and-messages/src/pages/api/manifest.ts
@@ -6,31 +6,33 @@ import packageJson from "../../../package.json";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Emails & Messages",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "Emails & Messages App is a multi-vendor Saleor app that integrates with notification services.",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_ORDERS", "MANAGE_USERS"],
-      id: "saleor.app.emails-and-messages",
-      version: packageJson.version,
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
       extensions: [
         /**
          * Optionally, extend Dashboard with custom UIs
          * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
          */
       ],
-      supportUrl: "https://github.com/saleor/apps/discussions",
       homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      author: "Saleor Commerce",
+      id: "saleor.app.emails-and-messages",
+      name: "Emails & Messages",
+      permissions: ["MANAGE_ORDERS", "MANAGE_USERS"],
       /**
        * Requires 3.10 due to invoices event payload - in previous versions, order reference was missing
        */
       requiredSaleorVersion: ">=3.10 <4",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      version: packageJson.version,
     };
 
     return manifest;

--- a/apps/invoices/src/pages/api/manifest.ts
+++ b/apps/invoices/src/pages/api/manifest.ts
@@ -8,22 +8,24 @@ import { REQUIRED_SALEOR_VERSION } from "../../saleor-app";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Invoices",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "An app that generates PDF invoices for Orders and stores them in Saleor file storage.",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_ORDERS"],
-      id: "saleor.app.invoices",
-      version: packageJson.version,
-      webhooks: [invoiceRequestedWebhook.getWebhookManifest(context.appBaseUrl)],
-      extensions: [],
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
       author: "Saleor Commerce",
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
+      id: "saleor.app.invoices",
+      name: "Invoices",
+      permissions: ["MANAGE_ORDERS"],
       /**
        * Requires 3.10 due to invoices event payload - in previous versions, order reference was missing
        */
       requiredSaleorVersion: REQUIRED_SALEOR_VERSION,
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      version: packageJson.version,
+      webhooks: [invoiceRequestedWebhook.getWebhookManifest(context.appBaseUrl)],
     };
 
     return manifest;

--- a/apps/invoices/src/pages/api/manifest.ts
+++ b/apps/invoices/src/pages/api/manifest.ts
@@ -26,6 +26,11 @@ export default createManifestHandler({
       tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [invoiceRequestedWebhook.getWebhookManifest(context.appBaseUrl)],
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
     };
 
     return manifest;

--- a/apps/klaviyo/src/pages/api/manifest.ts
+++ b/apps/klaviyo/src/pages/api/manifest.ts
@@ -13,7 +13,7 @@ const handler = createManifestHandler({
 
     return {
       about:
-        "Klaviyo integration allows to send Saleor events to Klaviyo, where notifications can be sent to customers.",
+        "Klaviyo integration allows sending Klaviyo notifications on Saleor events.",
       appUrl: appBaseUrl,
       author: "Saleor Commerce",
       brand: {

--- a/apps/klaviyo/src/pages/api/manifest.ts
+++ b/apps/klaviyo/src/pages/api/manifest.ts
@@ -12,27 +12,29 @@ const handler = createManifestHandler({
     const { appBaseUrl } = context;
 
     return {
-      id: "saleor.app.klaviyo",
-      version: pkg.version,
-      name: "Klaviyo",
-      permissions: ["MANAGE_USERS", "MANAGE_ORDERS"],
+      about:
+        "Klaviyo integration allows to send Saleor events to Klaviyo, where notifications can be sent to customers.",
       appUrl: appBaseUrl,
-      tokenTargetUrl: `${appBaseUrl}/api/register`,
-      webhooks: [
-        customerCreatedWebhook.getWebhookManifest(appBaseUrl),
-        fulfillmentCreatedWebhook.getWebhookManifest(appBaseUrl),
-        orderCreatedWebhook.getWebhookManifest(appBaseUrl),
-        orderFullyPaidWebhook.getWebhookManifest(appBaseUrl),
-      ],
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
       author: "Saleor Commerce",
       brand: {
         logo: {
           default: `${context.appBaseUrl}/logo.png`,
         },
       },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      homepageUrl: "https://github.com/saleor/apps",
+      id: "saleor.app.klaviyo",
+      name: "Klaviyo",
+      permissions: ["MANAGE_USERS", "MANAGE_ORDERS"],
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${appBaseUrl}/api/register`,
+      version: pkg.version,
+      webhooks: [
+        customerCreatedWebhook.getWebhookManifest(appBaseUrl),
+        fulfillmentCreatedWebhook.getWebhookManifest(appBaseUrl),
+        orderCreatedWebhook.getWebhookManifest(appBaseUrl),
+        orderFullyPaidWebhook.getWebhookManifest(appBaseUrl),
+      ],
     };
   },
 });

--- a/apps/products-feed/src/pages/api/manifest.ts
+++ b/apps/products-feed/src/pages/api/manifest.ts
@@ -11,11 +11,22 @@ import { webhookProductVariantUpdated } from "./webhooks/product_variant_updated
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Product Feed",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about: "Generate feeds consumed by Merchant Platforms",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_PRODUCTS"],
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
       id: "saleor.app.product-feed",
+      name: "Product Feed",
+      permissions: ["MANAGE_PRODUCTS"],
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         webhookProductCreated.getWebhookManifest(context.appBaseUrl),
@@ -24,16 +35,6 @@ export default createManifestHandler({
         webhookProductVariantDeleted.getWebhookManifest(context.appBaseUrl),
         webhookProductVariantUpdated.getWebhookManifest(context.appBaseUrl),
       ],
-      extensions: [],
-      author: "Saleor Commerce",
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;

--- a/apps/search/src/pages/api/manifest.ts
+++ b/apps/search/src/pages/api/manifest.ts
@@ -12,9 +12,24 @@ import { webhookProductVariantUpdated } from "./webhooks/saleor/product_variant_
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Search",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "Search App is a multi-integration app that connects your Saleor store with search engines.",
       appUrl: context.appBaseUrl,
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [
+        /**
+         * Optionally, extend Dashboard with custom UIs
+         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
+         */
+      ],
+      homepageUrl: "https://github.com/saleor/apps",
+      id: "saleor.app.search",
+      name: "Search",
       permissions: [
         /**
          * Set permissions for app if needed
@@ -23,7 +38,8 @@ export default createManifestHandler({
         "MANAGE_PRODUCTS",
         "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES",
       ],
-      id: "saleor.app.search",
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         /**
@@ -38,20 +54,6 @@ export default createManifestHandler({
         webhookProductVariantDeleted.getWebhookManifest(context.appBaseUrl),
         webhookProductVariantUpdated.getWebhookManifest(context.appBaseUrl),
       ],
-      extensions: [
-        /**
-         * Optionally, extend Dashboard with custom UIs
-         * https://docs.saleor.io/docs/3.x/developer/extending/apps/extending-dashboard-with-apps
-         */
-      ],
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;

--- a/apps/slack/src/pages/api/manifest.ts
+++ b/apps/slack/src/pages/api/manifest.ts
@@ -7,23 +7,25 @@ import { orderCreatedWebhook } from "./webhooks/order-created";
 const handler = createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Slack",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about:
+        "Saleor Slack integration allows you to get notifications on Slack channel from Saleor events.",
       appUrl: context.appBaseUrl,
-      permissions: ["MANAGE_ORDERS"],
-      id: "saleor.app.slack",
-      version: packageJson.version,
-      webhooks: [orderCreatedWebhook.getWebhookManifest(context.appBaseUrl)],
-      extensions: [],
       author: "Saleor Commerce",
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      homepageUrl: "https://github.com/saleor/apps",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
       brand: {
         logo: {
           default: `${context.appBaseUrl}/logo.png`,
         },
       },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
+      id: "saleor.app.slack",
+      name: "Slack",
+      permissions: ["MANAGE_ORDERS"],
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      version: packageJson.version,
+      webhooks: [orderCreatedWebhook.getWebhookManifest(context.appBaseUrl)],
     };
 
     return manifest;

--- a/apps/taxes/src/pages/api/manifest.ts
+++ b/apps/taxes/src/pages/api/manifest.ts
@@ -11,11 +11,23 @@ import { REQUIRED_SALEOR_VERSION } from "../../../saleor-app";
 export default createManifestHandler({
   async manifestFactory(context) {
     const manifest: AppManifest = {
-      name: "Taxes",
-      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
+      about: "Taxes App allows dynamic taxes calculations for orders",
       appUrl: context.appBaseUrl,
-      permissions: ["HANDLE_TAXES", "MANAGE_ORDERS"],
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${context.appBaseUrl}/logo.png`,
+        },
+      },
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
       id: "saleor.app.taxes",
+      name: "Taxes",
+      permissions: ["HANDLE_TAXES", "MANAGE_ORDERS"],
+      requiredSaleorVersion: REQUIRED_SALEOR_VERSION,
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${context.appBaseUrl}/api/register`,
       version: packageJson.version,
       webhooks: [
         orderCalculateTaxesSyncWebhook.getWebhookManifest(context.appBaseUrl),
@@ -23,17 +35,6 @@ export default createManifestHandler({
         orderCreatedAsyncWebhook.getWebhookManifest(context.appBaseUrl),
         orderFulfilledAsyncWebhook.getWebhookManifest(context.appBaseUrl),
       ],
-      extensions: [],
-      homepageUrl: "https://github.com/saleor/apps",
-      supportUrl: "https://github.com/saleor/apps/discussions",
-      author: "Saleor Commerce",
-      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-      requiredSaleorVersion: REQUIRED_SALEOR_VERSION,
-      brand: {
-        logo: {
-          default: `${context.appBaseUrl}/logo.png`,
-        },
-      },
     };
 
     return manifest;


### PR DESCRIPTION
## Scope of the PR

Apps never had "about" field in manifest filled - I pasted their description from Appstore now

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] `.github/dependabot.yaml` is up-to date.
- [ ] I added changesets and [read good practices](/.changeset/README.md).
