### PR TITLE
Add metadata and privateMetadata to webhook payloads

### DIFF
--- a/.changeset/healthy-bobcats-confess.md
+++ b/.changeset/healthy-bobcats-confess.md
@@ -1,0 +1,6 @@
+---
+"saleor-app-emails-and-messages": patch
+---
+
+Added `metadata` and `privateMetadata` to email payloads.
+

--- a/apps/emails-and-messages/graphql/fragments/OrderDetails.graphql
+++ b/apps/emails-and-messages/graphql/fragments/OrderDetails.graphql
@@ -5,6 +5,14 @@ fragment OrderDetails on Order {
   channel {
     slug
   }
+  metadata {
+    key
+    value
+  }
+  privateMetadata {
+    key
+    value
+  }
   user {
     email
     firstName

--- a/apps/emails-and-messages/src/modules/event-handlers/default-payloads.ts
+++ b/apps/emails-and-messages/src/modules/event-handlers/default-payloads.ts
@@ -15,6 +15,18 @@ const exampleOrderPayload: OrderDetailsFragment = {
   id: "T3JkZXI6NTdiNTBhNDAtYzRmYi00YjQzLWIxODgtM2JhZmRlMTc3MGQ5",
   number: "198",
   userEmail: "adrian.king@example.com",
+  metadata: [
+    {
+      key: "metadata-example",
+      value: "Example value",
+    },
+  ],
+  privateMetadata: [
+    {
+      key: "private-metadata-example",
+      value: "Example value for private metadata",
+    },
+  ],
   channel: {
     slug: "default-channel",
   },
@@ -128,6 +140,18 @@ const orderFullyPaidPayload: OrderFullyPaidWebhookPayloadFragment = {
 const invoiceSentPayload: InvoiceSentWebhookPayloadFragment = {
   invoice: {
     id: "SW52b2ljZToxMDE=",
+    metadata: [
+      {
+        key: "metadata-example",
+        value: "Example value",
+      },
+    ],
+    privateMetadata: [
+      {
+        key: "private-metadata-example",
+        value: "Example value for private metadata",
+      },
+    ],
     message: null,
     externalUrl: null,
     url: "https://example.com/media/invoices/invoice-1032023-order-57b50a40-c4fb-4b43-b188-3bafde1770d9-fa968541-02fa-4317-b121-7205.pdf",
@@ -254,6 +278,18 @@ const giftCardSentPayload: GiftCardSentWebhookPayloadFragment = {
   sentToEmail: "user@example.com",
   giftCard: {
     code: "XXXX",
+    metadata: [
+      {
+        key: "metadata-example",
+        value: "Example value",
+      },
+    ],
+    privateMetadata: [
+      {
+        key: "private-metadata-example",
+        value: "Example value for private metadata",
+      },
+    ],
     tags: [],
     created: "2021-03-16T13:12:00+00:00",
     currentBalance: {

--- a/apps/emails-and-messages/src/modules/webhook-management/webhook-management-service.test.ts
+++ b/apps/emails-and-messages/src/modules/webhook-management/webhook-management-service.test.ts
@@ -121,7 +121,7 @@ describe("WebhookManagementService", function () {
         name: invoiceSentWebhook.name,
         targetUrl: "https://example.com/api/webhooks/invoice-sent",
         query:
-          "subscription InvoiceSent { event { ...InvoiceSentWebhookPayload }}fragment InvoiceSentWebhookPayload on InvoiceSent { invoice { id message externalUrl url order { id } } order { ...OrderDetails }}fragment OrderDetails on Order { id number userEmail channel { slug } user { email firstName lastName } billingAddress { streetAddress1 city postalCode country { country } } shippingAddress { streetAddress1 city postalCode country { country } } lines { id productName variantName quantity thumbnail { url alt } unitPrice { gross { currency amount } } totalPrice { gross { currency amount } } } subtotal { gross { amount currency } } shippingPrice { gross { amount currency } } total { gross { amount currency } }}",
+          "subscription InvoiceSent { event { ...InvoiceSentWebhookPayload }}fragment InvoiceSentWebhookPayload on InvoiceSent { invoice { id metadata { key value } privateMetadata { key value } message externalUrl url order { id } } order { ...OrderDetails }}fragment OrderDetails on Order { id number userEmail channel { slug } metadata { key value } privateMetadata { key value } user { email firstName lastName } billingAddress { streetAddress1 city postalCode country { country } } shippingAddress { streetAddress1 city postalCode country { country } } lines { id productName variantName quantity thumbnail { url alt } unitPrice { gross { currency amount } } totalPrice { gross { currency amount } } } subtotal { gross { amount currency } } shippingPrice { gross { amount currency } } total { gross { amount currency } }}",
       },
     });
   });

--- a/apps/emails-and-messages/src/pages/api/webhooks/gift-card-sent.ts
+++ b/apps/emails-and-messages/src/pages/api/webhooks/gift-card-sent.ts
@@ -15,6 +15,14 @@ const GiftCardSentWebhookPayload = gql`
       created
       usedByEmail
       isActive
+      metadata {
+        key
+        value
+      }
+      privateMetadata {
+        key
+        value
+      }
       initialBalance {
         currency
         amount

--- a/apps/emails-and-messages/src/pages/api/webhooks/invoice-sent.ts
+++ b/apps/emails-and-messages/src/pages/api/webhooks/invoice-sent.ts
@@ -13,6 +13,14 @@ const InvoiceSentWebhookPayload = gql`
   fragment InvoiceSentWebhookPayload on InvoiceSent {
     invoice {
       id
+      metadata {
+        key
+        value
+      }
+      privateMetadata {
+        key
+        value
+      }
       message
       externalUrl
       url


### PR DESCRIPTION
## Scope of the PR

Add metadata and Private metadata to event payloads for feature parity with the customer emails plugin.

## Related issues

Related #313

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
