### PR TITLE
feat: address validation suggestions

### DIFF
--- a/.changeset/many-parrots-sleep.md
+++ b/.changeset/many-parrots-sleep.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": minor
+---
+
+Changed the avatax configuration flow. Previously, the configuration was validated when trying to create it. Now, you have to verify the credentials and address separately by clicking the "verify" buttons. If the address was resolved successfully, formatting suggestions provided by Avatax address resolution service will be displayed. The user can apply or reject the suggestions. If the address is incorrect, an error will be thrown.

--- a/.changeset/many-parrots-sleep.md
+++ b/.changeset/many-parrots-sleep.md
@@ -2,4 +2,4 @@
 "saleor-app-taxes": minor
 ---
 
-Changed the avatax configuration flow. Previously, the configuration was validated when trying to create it. Now, you have to verify the credentials and address separately by clicking the "verify" buttons. If the address was resolved successfully, formatting suggestions provided by Avatax address resolution service will be displayed. The user can apply or reject the suggestions. If the address is incorrect, an error will be thrown.
+Changed the avatax configuration flow. Previously, the configuration was validated when trying to create it. Now, you have to verify the credentials and address manually by clicking the "verify" buttons. If the address was resolved successfully, formatting suggestions provided by Avatax address resolution service may be displayed. The user can apply or reject the suggestions. If the address was not resolved correctly, an error will be thrown.

--- a/apps/taxes/src/lib/error-utils.ts
+++ b/apps/taxes/src/lib/error-utils.ts
@@ -1,0 +1,13 @@
+import { TRPCClientError } from "@trpc/client";
+
+function resolveTrpcClientError(error: unknown) {
+  if (error instanceof TRPCClientError) {
+    return error.message;
+  }
+
+  return "Unknown error";
+}
+
+export const errorUtils = {
+  resolveTrpcClientError,
+};

--- a/apps/taxes/src/modules/avatax/avatax-client.ts
+++ b/apps/taxes/src/modules/avatax/avatax-client.ts
@@ -1,12 +1,12 @@
 import Avatax from "avatax";
+import { DocumentType } from "avatax/lib/enums/DocumentType";
+import { AddressLocationInfo as AvataxAddress } from "avatax/lib/models/AddressLocationInfo";
+import { CommitTransactionModel } from "avatax/lib/models/CommitTransactionModel";
 import { CreateTransactionModel } from "avatax/lib/models/CreateTransactionModel";
 import packageJson from "../../../package.json";
 import { createLogger, Logger } from "../../lib/logger";
-import { AvataxConfig } from "./avatax-connection-schema";
-import { CommitTransactionModel } from "avatax/lib/models/CommitTransactionModel";
-import { DocumentType } from "avatax/lib/enums/DocumentType";
-import { AddressLocationInfo as AvataxAddress } from "avatax/lib/models/AddressLocationInfo";
 import { AvataxClientTaxCodeService } from "./avatax-client-tax-code.service";
+import { BaseAvataxConfig } from "./avatax-connection-schema";
 
 type AvataxSettings = {
   appName: string;
@@ -29,10 +29,10 @@ const defaultAvataxSettings: AvataxSettings = {
   timeout: 5000,
 };
 
-const createAvataxSettings = (config: AvataxConfig): AvataxSettings => {
+const createAvataxSettings = ({ isSandbox }: { isSandbox: boolean }): AvataxSettings => {
   const settings: AvataxSettings = {
     ...defaultAvataxSettings,
-    environment: config.isSandbox ? "sandbox" : "production",
+    environment: isSandbox ? "sandbox" : "production",
   };
 
   return settings;
@@ -57,10 +57,10 @@ export class AvataxClient {
   private client: Avatax;
   private logger: Logger;
 
-  constructor(config: AvataxConfig) {
+  constructor(baseConfig: BaseAvataxConfig) {
     this.logger = createLogger({ name: "AvataxClient" });
-    const settings = createAvataxSettings(config);
-    const avataxClient = new Avatax(settings).withSecurity(config.credentials);
+    const settings = createAvataxSettings({ isSandbox: baseConfig.isSandbox });
+    const avataxClient = new Avatax(settings).withSecurity(baseConfig.credentials);
 
     this.client = avataxClient;
   }

--- a/apps/taxes/src/modules/avatax/avatax-client.ts
+++ b/apps/taxes/src/modules/avatax/avatax-client.ts
@@ -82,4 +82,8 @@ export class AvataxClient {
 
     return taxCodeService.getTaxCodes();
   }
+
+  async ping() {
+    return this.client.ping();
+  }
 }

--- a/apps/taxes/src/modules/avatax/avatax-connection-schema.ts
+++ b/apps/taxes/src/modules/avatax/avatax-connection-schema.ts
@@ -13,15 +13,23 @@ const avataxCredentialsSchema = z.object({
   password: z.string().min(1, { message: "Password requires at least one character." }),
 });
 
-export const avataxConfigSchema = z.object({
-  name: z.string().min(1, { message: "Name requires at least one character." }),
+// All that is needed to create Avatax configuration.
+export const baseAvataxConfigSchema = z.object({
   isSandbox: z.boolean(),
-  companyCode: z.string().optional(),
-  isAutocommit: z.boolean(),
-  shippingTaxCode: z.string().optional(),
   credentials: avataxCredentialsSchema,
-  address: addressSchema,
 });
+
+export type BaseAvataxConfig = z.infer<typeof baseAvataxConfigSchema>;
+
+export const avataxConfigSchema = z
+  .object({
+    name: z.string().min(1, { message: "Name requires at least one character." }),
+    companyCode: z.string().optional(),
+    isAutocommit: z.boolean(),
+    shippingTaxCode: z.string().optional(),
+    address: addressSchema,
+  })
+  .merge(baseAvataxConfigSchema);
 
 export type AvataxConfig = z.infer<typeof avataxConfigSchema>;
 

--- a/apps/taxes/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/taxes/src/modules/avatax/avatax-connection.router.ts
@@ -4,6 +4,8 @@ import { protectedClientProcedure } from "../trpc/protected-client-procedure";
 import { router } from "../trpc/trpc-server";
 import { avataxConfigSchema } from "./avatax-connection-schema";
 import { PublicAvataxConnectionService } from "./configuration/public-avatax-connection.service";
+import { AvataxAddressValidationService } from "./configuration/avatax-address-validation.service";
+import { AvataxAuthValidationService } from "./configuration/avatax-auth-validation.service";
 
 const getInputSchema = z.object({
   id: z.string(),
@@ -106,6 +108,42 @@ export const avataxConnectionRouter = router({
       const result = await ctx.connectionService.update(input.id, input.value);
 
       logger.info(`Avatax configuration with an id: ${input.id} was successfully updated`);
+
+      return result;
+    }),
+  validateAddress: protectedClientProcedure
+    .input(z.object({ value: avataxConfigSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const logger = createLogger({
+        saleorApiUrl: ctx.saleorApiUrl,
+        procedure: "avataxConnectionRouter.validateAddress",
+      });
+
+      logger.debug("Route validateAddress called");
+
+      const addressValidation = new AvataxAddressValidationService();
+
+      const result = await addressValidation.validate(input.value);
+
+      logger.info(`Avatax address was successfully validated`);
+
+      return result;
+    }),
+  validateAuth: protectedClientProcedure
+    .input(z.object({ value: avataxConfigSchema }))
+    .mutation(async ({ ctx, input }) => {
+      const logger = createLogger({
+        saleorApiUrl: ctx.saleorApiUrl,
+        procedure: "avataxConnectionRouter.validateAuth",
+      });
+
+      logger.debug("Route called");
+
+      const authValidation = new AvataxAuthValidationService();
+
+      const result = await authValidation.validate(input.value);
+
+      logger.info(`Avatax client was successfully validated`);
 
       return result;
     }),

--- a/apps/taxes/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/taxes/src/modules/avatax/avatax-connection.router.ts
@@ -30,11 +30,11 @@ const postInputSchema = z.object({
 const protectedWithConnectionService = protectedClientProcedure.use(({ next, ctx }) =>
   next({
     ctx: {
-      connectionService: new PublicAvataxConnectionService(
-        ctx.apiClient,
-        ctx.appId!,
-        ctx.saleorApiUrl
-      ),
+      connectionService: new PublicAvataxConnectionService({
+        appId: ctx.appId!,
+        client: ctx.apiClient,
+        saleorApiUrl: ctx.saleorApiUrl,
+      }),
     },
   })
 );
@@ -129,11 +129,11 @@ export const avataxConnectionRouter = router({
 
       logger.debug("Route called");
 
-      const addressValidationService = new AvataxEditAddressValidationService(
-        ctx.apiClient,
-        ctx.appId!,
-        ctx.saleorApiUrl
-      );
+      const addressValidationService = new AvataxEditAddressValidationService({
+        appId: ctx.appId!,
+        client: ctx.apiClient,
+        saleorApiUrl: ctx.saleorApiUrl,
+      });
 
       const result = await addressValidationService.validate(input.id, input.value);
 

--- a/apps/taxes/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/taxes/src/modules/avatax/avatax-connection.router.ts
@@ -176,11 +176,11 @@ export const avataxConnectionRouter = router({
         procedure: "avataxConnectionRouter.validateAuth",
       });
 
-      const authValidation = new AvataxEditAuthValidationService(
-        ctx.apiClient,
-        ctx.appId!,
-        ctx.saleorApiUrl
-      );
+      const authValidation = new AvataxEditAuthValidationService({
+        appId: ctx.appId!,
+        client: ctx.apiClient,
+        saleorApiUrl: ctx.saleorApiUrl,
+      });
 
       await authValidation.validate(input.id, input.value);
 
@@ -194,9 +194,11 @@ export const avataxConnectionRouter = router({
         procedure: "avataxConnectionRouter.createValidateAuth",
       });
 
-      const authValidation = new AvataxAuthValidationService();
+      const avataxClient = new AvataxClient(input.value);
 
-      const result = await authValidation.validate(input.value);
+      const authValidation = new AvataxAuthValidationService(avataxClient);
+
+      const result = await authValidation.validate();
 
       logger.info(`Avatax client was successfully validated`);
 

--- a/apps/taxes/src/modules/avatax/avatax-obfuscator.test.ts
+++ b/apps/taxes/src/modules/avatax/avatax-obfuscator.test.ts
@@ -1,11 +1,11 @@
 import { AvataxConfigMockGenerator } from "./avatax-config-mock-generator";
-import { AvataxConnectionObfuscator } from "./avatax-connection-obfuscator";
+import { AvataxObfuscator } from "./avatax-obfuscator";
 import { expect, it, describe } from "vitest";
 
 const mockAvataxConfig = new AvataxConfigMockGenerator().generateAvataxConfig();
-const obfuscator = new AvataxConnectionObfuscator();
+const obfuscator = new AvataxObfuscator();
 
-describe("AvataxConnectionObfuscator", () => {
+describe("AvataxObfuscator", () => {
   it("obfuscated avatax config", () => {
     const obfuscatedConfig = obfuscator.obfuscateAvataxConfig(mockAvataxConfig);
 

--- a/apps/taxes/src/modules/avatax/avatax-obfuscator.ts
+++ b/apps/taxes/src/modules/avatax/avatax-obfuscator.ts
@@ -1,7 +1,7 @@
 import { Obfuscator } from "../../lib/obfuscator";
 import { AvataxConfig, AvataxConnection } from "./avatax-connection-schema";
 
-export class AvataxConnectionObfuscator {
+export class AvataxObfuscator {
   private obfuscator = new Obfuscator();
 
   obfuscateAvataxConfig = (config: AvataxConfig): AvataxConfig => {

--- a/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -1,9 +1,7 @@
-import { z } from "zod";
 import { createLogger, Logger } from "../../../lib/logger";
 import { avataxAddressFactory } from "../address-factory";
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
-import { AvataxValidationResponseResolver } from "./avatax-validation-response-resolver";
 import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolver";
 
 export class AvataxAddressValidationService {
@@ -15,16 +13,14 @@ export class AvataxAddressValidationService {
     });
   }
 
-  async validate(config: AvataxConfig): Promise<void> {
+  async validate(config: AvataxConfig) {
     const avataxClient = new AvataxClient(config);
     const address = avataxAddressFactory.fromChannelAddress(config.address);
 
     try {
-      const validation = await avataxClient.validateAddress({ address });
+      return avataxClient.validateAddress({ address });
 
-      const responseResolver = new AvataxValidationResponseResolver();
-
-      responseResolver.resolve(validation);
+      // const responseResolver = new AvataxValidationResponseResolver();
     } catch (error) {
       const errorResolver = new AvataxValidationErrorResolver();
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -6,12 +6,12 @@ import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxValidationResponseResolver } from "./avatax-validation-response-resolver";
 import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolver";
 
-export class AvataxValidationService {
+export class AvataxAddressValidationService {
   private logger: Logger;
 
   constructor() {
     this.logger = createLogger({
-      name: "AvataxValidationService",
+      name: "AvataxAddressValidationService",
     });
   }
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -17,7 +17,11 @@ export class AvataxAddressValidationService {
     const formattedAddress = avataxAddressFactory.fromChannelAddress(address);
 
     try {
-      return this.avataxClient.validateAddress({ address: formattedAddress });
+      const response = await this.avataxClient.validateAddress({ address: formattedAddress });
+
+      this.logger.debug({ response }, "Address validation response");
+
+      return response;
 
       // const responseResolver = new AvataxValidationResponseResolver();
     } catch (error) {

--- a/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -17,13 +17,7 @@ export class AvataxAddressValidationService {
     const formattedAddress = avataxAddressFactory.fromChannelAddress(address);
 
     try {
-      const response = await this.avataxClient.validateAddress({ address: formattedAddress });
-
-      this.logger.debug({ response }, "Address validation response");
-
-      return response;
-
-      // const responseResolver = new AvataxValidationResponseResolver();
+      return this.avataxClient.validateAddress({ address: formattedAddress });
     } catch (error) {
       const errorResolver = new AvataxValidationErrorResolver();
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -7,18 +7,17 @@ import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolve
 export class AvataxAddressValidationService {
   private logger: Logger;
 
-  constructor() {
+  constructor(private avataxClient: AvataxClient) {
     this.logger = createLogger({
       name: "AvataxAddressValidationService",
     });
   }
 
-  async validate(config: AvataxConfig) {
-    const avataxClient = new AvataxClient(config);
-    const address = avataxAddressFactory.fromChannelAddress(config.address);
+  async validate(address: AvataxConfig["address"]) {
+    const formattedAddress = avataxAddressFactory.fromChannelAddress(address);
 
     try {
-      return avataxClient.validateAddress({ address });
+      return this.avataxClient.validateAddress({ address: formattedAddress });
 
       // const responseResolver = new AvataxValidationResponseResolver();
     } catch (error) {

--- a/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
@@ -12,11 +12,11 @@ export class AvataxAuthValidationService {
     });
   }
 
-  async validate(config: AvataxConfig): Promise<void> {
+  async validate(config: AvataxConfig) {
     const avataxClient = new AvataxClient(config);
 
     try {
-      avataxClient.ping();
+      return avataxClient.ping();
     } catch (error) {
       const errorResolver = new AvataxValidationErrorResolver();
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
@@ -1,22 +1,19 @@
 import { createLogger, Logger } from "../../../lib/logger";
 import { AvataxClient } from "../avatax-client";
-import { BaseAvataxConfig } from "../avatax-connection-schema";
 import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolver";
 
 export class AvataxAuthValidationService {
   private logger: Logger;
 
-  constructor() {
+  constructor(private avataxClient: AvataxClient) {
     this.logger = createLogger({
       name: "AvataxAuthValidationService",
     });
   }
 
-  async validate(input: BaseAvataxConfig) {
-    const avataxClient = new AvataxClient(input);
-
+  async validate() {
     try {
-      const result = await avataxClient.ping();
+      const result = await this.avataxClient.ping();
 
       if (!result.authenticated) {
         throw new Error("Invalid Avatax credentials.");

--- a/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
@@ -1,0 +1,26 @@
+import { createLogger, Logger } from "../../../lib/logger";
+import { AvataxClient } from "../avatax-client";
+import { AvataxConfig } from "../avatax-connection-schema";
+import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolver";
+
+export class AvataxAuthValidationService {
+  private logger: Logger;
+
+  constructor() {
+    this.logger = createLogger({
+      name: "AvataxAuthValidationService",
+    });
+  }
+
+  async validate(config: AvataxConfig): Promise<void> {
+    const avataxClient = new AvataxClient(config);
+
+    try {
+      avataxClient.ping();
+    } catch (error) {
+      const errorResolver = new AvataxValidationErrorResolver();
+
+      throw errorResolver.resolve(error);
+    }
+  }
+}

--- a/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-auth-validation.service.ts
@@ -1,6 +1,6 @@
 import { createLogger, Logger } from "../../../lib/logger";
 import { AvataxClient } from "../avatax-client";
-import { AvataxConfig } from "../avatax-connection-schema";
+import { BaseAvataxConfig } from "../avatax-connection-schema";
 import { AvataxValidationErrorResolver } from "./avatax-validation-error-resolver";
 
 export class AvataxAuthValidationService {
@@ -12,11 +12,15 @@ export class AvataxAuthValidationService {
     });
   }
 
-  async validate(config: AvataxConfig) {
-    const avataxClient = new AvataxClient(config);
+  async validate(input: BaseAvataxConfig) {
+    const avataxClient = new AvataxClient(input);
 
     try {
-      return avataxClient.ping();
+      const result = await avataxClient.ping();
+
+      if (!result.authenticated) {
+        throw new Error("Invalid Avatax credentials.");
+      }
     } catch (error) {
       const errorResolver = new AvataxValidationErrorResolver();
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -4,7 +4,7 @@ import { Logger, createLogger } from "../../../lib/logger";
 import { createSettingsManager } from "../../app/metadata-manager";
 import { AvataxConfig, AvataxConnection } from "../avatax-connection-schema";
 import { AvataxConnectionRepository } from "./avatax-connection-repository";
-import { AvataxValidationService } from "./avatax-validation.service";
+import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
 
 export class AvataxConnectionService {
   private logger: Logger;
@@ -28,11 +28,11 @@ export class AvataxConnectionService {
   }
 
   async create(config: AvataxConfig): Promise<{ id: string }> {
-    const validationService = new AvataxValidationService();
+    const validationService = new AvataxAuthValidationService();
 
     await validationService.validate(config);
 
-    return await this.avataxConnectionRepository.post(config);
+    return this.avataxConnectionRepository.post(config);
   }
 
   async update(id: string, nextConfigPartial: DeepPartial<AvataxConfig>): Promise<void> {
@@ -41,7 +41,7 @@ export class AvataxConnectionService {
     const { id: _, ...setting } = data;
     const prevConfig = setting.config;
 
-    const validationService = new AvataxValidationService();
+    const validationService = new AvataxAuthValidationService();
 
     // todo: add deepRightMerge
     const input: AvataxConfig = {

--- a/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -5,11 +5,11 @@ import { createSettingsManager } from "../../app/metadata-manager";
 import { AvataxConfig, AvataxConnection } from "../avatax-connection-schema";
 import { AvataxConnectionRepository } from "./avatax-connection-repository";
 import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
+import { AvataxClient } from "../avatax-client";
 
 export class AvataxConnectionService {
   private logger: Logger;
   private avataxConnectionRepository: AvataxConnectionRepository;
-  private authValidationService: AvataxAuthValidationService;
 
   constructor(client: Client, appId: string, saleorApiUrl: string) {
     this.logger = createLogger({
@@ -19,11 +19,13 @@ export class AvataxConnectionService {
     const settingsManager = createSettingsManager(client, appId);
 
     this.avataxConnectionRepository = new AvataxConnectionRepository(settingsManager, saleorApiUrl);
-    this.authValidationService = new AvataxAuthValidationService();
   }
 
   private async checkIfAuthorized(input: AvataxConfig) {
-    await this.authValidationService.validate(input);
+    const avataxClient = new AvataxClient(input);
+    const authValidationService = new AvataxAuthValidationService(avataxClient);
+
+    await authValidationService.validate();
   }
 
   getAll(): Promise<AvataxConnection[]> {

--- a/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -11,7 +11,15 @@ export class AvataxConnectionService {
   private logger: Logger;
   private avataxConnectionRepository: AvataxConnectionRepository;
 
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
     this.logger = createLogger({
       name: "AvataxConnectionService",
     });

--- a/apps/taxes/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
@@ -5,10 +5,30 @@ import { AvataxAddressValidationService } from "./avatax-address-validation.serv
 import { AvataxPatchInputTransformer } from "./avatax-patch-input-transformer";
 
 export class AvataxEditAddressValidationService {
-  constructor(private client: Client, private appId: string, private saleorApiUrl: string) {}
+  private client: Client;
+  private appId: string;
+  private saleorApiUrl: string;
+
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
+    this.client = client;
+    this.appId = appId;
+    this.saleorApiUrl = saleorApiUrl;
+  }
 
   async validate(id: string, input: AvataxConfig) {
-    const transformer = new AvataxPatchInputTransformer(this.client, this.appId, this.saleorApiUrl);
+    const transformer = new AvataxPatchInputTransformer({
+      client: this.client,
+      appId: this.appId,
+      saleorApiUrl: this.saleorApiUrl,
+    });
 
     const config = await transformer.patchInput(id, input);
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
@@ -1,0 +1,20 @@
+import { Client } from "urql";
+import { AvataxClient } from "../avatax-client";
+import { AvataxConfig } from "../avatax-connection-schema";
+import { AvataxAddressValidationService } from "./avatax-address-validation.service";
+import { AvataxPatchInputTransformer } from "./avatax-patch-input-transformer";
+
+export class AvataxEditAddressValidationService {
+  constructor(private client: Client, private appId: string, private saleorApiUrl: string) {}
+
+  async validate(id: string, input: AvataxConfig) {
+    const transformer = new AvataxPatchInputTransformer(this.client, this.appId, this.saleorApiUrl);
+
+    const config = await transformer.patchInput(id, input);
+
+    const avataxClient = new AvataxClient(config);
+    const addressValidation = new AvataxAddressValidationService(avataxClient);
+
+    return addressValidation.validate(input.address);
+  }
+}

--- a/apps/taxes/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
@@ -29,7 +29,11 @@ export class AvataxEditAuthValidationService {
   }
 
   async validate(id: string, input: Pick<AvataxConfig, "credentials" | "isSandbox">) {
-    const transformer = new AvataxPatchInputTransformer(this.client, this.appId, this.saleorApiUrl);
+    const transformer = new AvataxPatchInputTransformer({
+      client: this.client,
+      appId: this.appId,
+      saleorApiUrl: this.saleorApiUrl,
+    });
     const credentials = await transformer.patchCredentials(id, input.credentials);
     const avataxClient = new AvataxClient({ ...input, credentials });
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
@@ -1,0 +1,24 @@
+import { Client } from "urql";
+import { createLogger, Logger } from "../../../lib/logger";
+import { AvataxConfig } from "../avatax-connection-schema";
+import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
+import { AvataxPatchInputTransformer } from "./avatax-patch-input-transformer";
+
+export class AvataxEditAuthValidationService {
+  private logger: Logger;
+
+  constructor(private client: Client, private appId: string, private saleorApiUrl: string) {
+    this.logger = createLogger({
+      name: "AvataxAuthValidationService",
+    });
+  }
+
+  async validate(id: string, input: Pick<AvataxConfig, "credentials" | "isSandbox">) {
+    const transformer = new AvataxPatchInputTransformer(this.client, this.appId, this.saleorApiUrl);
+    const credentials = await transformer.patchCredentials(id, input.credentials);
+
+    const authValidationService = new AvataxAuthValidationService();
+
+    return authValidationService.validate({ credentials, isSandbox: input.isSandbox });
+  }
+}

--- a/apps/taxes/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
@@ -13,11 +13,19 @@ export class AvataxPatchInputTransformer {
   private connection: AvataxConnectionService;
   private obfuscator: Obfuscator;
 
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
     this.logger = createLogger({
       name: "AvataxPatchInputTransformer",
     });
-    this.connection = new AvataxConnectionService(client, appId, saleorApiUrl);
+    this.connection = new AvataxConnectionService({ client, appId, saleorApiUrl });
     this.obfuscator = new Obfuscator();
   }
 

--- a/apps/taxes/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
+++ b/apps/taxes/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
@@ -1,0 +1,60 @@
+import { Client } from "urql";
+import { Logger, createLogger } from "../../../lib/logger";
+import { Obfuscator } from "../../../lib/obfuscator";
+import { AvataxConfig } from "../avatax-connection-schema";
+import { AvataxConnectionService } from "./avatax-connection.service";
+
+/*
+ * This class is used to merge the given input with the existing configuration.
+ * The input from the edit UI is obfuscated, so we need to filter out those fields, and merge it with the existing configuration.
+ */
+export class AvataxPatchInputTransformer {
+  private logger: Logger;
+  private connection: AvataxConnectionService;
+  private obfuscator: Obfuscator;
+
+  constructor(client: Client, appId: string, saleorApiUrl: string) {
+    this.logger = createLogger({
+      name: "AvataxPatchInputTransformer",
+    });
+    this.connection = new AvataxConnectionService(client, appId, saleorApiUrl);
+    this.obfuscator = new Obfuscator();
+  }
+
+  private checkIfNotObfuscated(config: AvataxConfig) {
+    return (
+      !this.obfuscator.isObfuscated(config.credentials.password) &&
+      !this.obfuscator.isObfuscated(config.credentials.username)
+    );
+  }
+
+  async patchCredentials(id: string, input: AvataxConfig["credentials"]) {
+    const connection = await this.connection.getById(id);
+
+    const credentials: AvataxConfig["credentials"] = {
+      ...connection.config.credentials,
+      username: this.obfuscator.isObfuscated(input.username)
+        ? connection.config.credentials.username
+        : input.username,
+      password: this.obfuscator.isObfuscated(input.password)
+        ? connection.config.credentials.password
+        : input.password,
+    };
+
+    return credentials;
+  }
+
+  async patchInput(id: string, input: AvataxConfig) {
+    // We can use the input straight away if it's not obfuscated.
+    if (this.checkIfNotObfuscated(input)) {
+      return input;
+    }
+
+    const mergedConfig: AvataxConfig = {
+      ...input,
+      credentials: await this.patchCredentials(id, input.credentials),
+    };
+
+    return mergedConfig;
+  }
+}

--- a/apps/taxes/src/modules/avatax/configuration/public-avatax-connection.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/public-avatax-connection.service.ts
@@ -7,8 +7,16 @@ import { AvataxConnectionService } from "./avatax-connection.service";
 export class PublicAvataxConnectionService {
   private readonly connectionService: AvataxConnectionService;
   private readonly obfuscator: AvataxObfuscator;
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
-    this.connectionService = new AvataxConnectionService(client, appId, saleorApiUrl);
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
+    this.connectionService = new AvataxConnectionService({ client, appId, saleorApiUrl });
     this.obfuscator = new AvataxObfuscator();
   }
 

--- a/apps/taxes/src/modules/avatax/configuration/public-avatax-connection.service.ts
+++ b/apps/taxes/src/modules/avatax/configuration/public-avatax-connection.service.ts
@@ -1,15 +1,15 @@
 import { DeepPartial } from "@trpc/server";
 import { Client } from "urql";
-import { AvataxConnectionObfuscator } from "../avatax-connection-obfuscator";
 import { AvataxConfig } from "../avatax-connection-schema";
+import { AvataxObfuscator } from "../avatax-obfuscator";
 import { AvataxConnectionService } from "./avatax-connection.service";
 
 export class PublicAvataxConnectionService {
   private readonly connectionService: AvataxConnectionService;
-  private readonly obfuscator: AvataxConnectionObfuscator;
+  private readonly obfuscator: AvataxObfuscator;
   constructor(client: Client, appId: string, saleorApiUrl: string) {
     this.connectionService = new AvataxConnectionService(client, appId, saleorApiUrl);
-    this.obfuscator = new AvataxConnectionObfuscator();
+    this.obfuscator = new AvataxObfuscator();
   }
 
   async getAll() {

--- a/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
+++ b/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
@@ -14,11 +14,11 @@ export const avataxTaxCodesRouter = router({
       name: "avataxTaxCodesRouter.getAllForId",
     });
 
-    const connectionService = new AvataxConnectionService(
-      ctx.apiClient,
-      ctx.appId!,
-      ctx.saleorApiUrl
-    );
+    const connectionService = new AvataxConnectionService({
+      appId: ctx.appId!,
+      client: ctx.apiClient,
+      saleorApiUrl: ctx.saleorApiUrl,
+    });
 
     const connection = await connectionService.getById(input.connectionId);
     const taxCodesService = new AvataxTaxCodesService(connection.config);

--- a/apps/taxes/src/modules/avatax/ui/avatax-address-resolution-processor.test.ts
+++ b/apps/taxes/src/modules/avatax/ui/avatax-address-resolution-processor.test.ts
@@ -1,0 +1,134 @@
+import { AddressResolutionModel } from "avatax/lib/models/AddressResolutionModel";
+import { AvataxAddressResolutionProcessor } from "./avatax-address-resolution-processor";
+import { describe, it, expect } from "vitest";
+import { ResolutionQuality } from "avatax/lib/enums/ResolutionQuality";
+import { JurisdictionType } from "avatax/lib/enums/JurisdictionType";
+
+const mockedSuccessResponse: AddressResolutionModel = {
+  address: {
+    line1: "20 COOPER ST",
+    city: "NEW YORK",
+    region: "NY",
+    country: "US",
+    postalCode: "10034",
+  },
+  validatedAddresses: [
+    {
+      addressType: "UnknownAddressType",
+      line1: "20 COOPER ST",
+      line2: "",
+      line3: "",
+      city: "NEW YORK",
+      region: "NY",
+      country: "US",
+      postalCode: "10034",
+      latitude: 40.86758,
+      longitude: -73.924502,
+    },
+  ],
+  coordinates: {
+    latitude: 40.86758,
+    longitude: -73.924502,
+  },
+  resolutionQuality: ResolutionQuality.Intersection,
+  taxAuthorities: [
+    {
+      avalaraId: "42",
+      jurisdictionName: "NEW YORK",
+      jurisdictionType: JurisdictionType.State,
+      signatureCode: "BFEQ",
+    },
+    {
+      avalaraId: "359071",
+      jurisdictionName: "METROPOLITAN COMMUTER TRANSPORTATION DISTRICT",
+      jurisdictionType: JurisdictionType.Special,
+      signatureCode: "BGJP",
+    },
+    {
+      avalaraId: "2001053475",
+      jurisdictionName: "NEW YORK CITY",
+      jurisdictionType: JurisdictionType.City,
+      signatureCode: "EHTG",
+    },
+  ],
+};
+
+const mockedUnresolvedResponse: AddressResolutionModel = {
+  address: {
+    line1: "42069 COOPER ST  ",
+    city: "NEW YORK",
+    region: "NY",
+    country: "US",
+    postalCode: "10034",
+  },
+  validatedAddresses: [
+    {
+      addressType: "UnknownAddressType",
+      line1: "42069 COOPER ST",
+      line2: "",
+      line3: "",
+      city: "NEW YORK",
+      region: "NY",
+      country: "US",
+      postalCode: "10034",
+      latitude: 40.866728,
+      longitude: -73.921445,
+    },
+  ],
+  coordinates: {
+    latitude: 40.866728,
+    longitude: -73.921445,
+  },
+  resolutionQuality: ResolutionQuality.Intersection,
+  messages: [
+    {
+      summary: "The address number is out of range",
+      details:
+        "The address was found but the street number in the input address was not between the low and high range of the post office database.",
+      refersTo: "Address.Line0",
+      severity: "Error",
+      source: "Avalara.AvaTax.Common",
+    },
+  ],
+};
+
+const processor = new AvataxAddressResolutionProcessor();
+
+describe("AvataxAddressResolutionProcessor", () => {
+  describe("resolveAddressResolutionMessage", () => {
+    it("returns success when no messages", () => {
+      const result = processor.resolveAddressResolutionMessage(mockedSuccessResponse);
+
+      expect(result).toEqual({
+        type: "success",
+        message: "The address was resolved successfully.",
+      });
+    });
+    it("returns info when messages", () => {
+      const result = processor.resolveAddressResolutionMessage(mockedUnresolvedResponse);
+
+      expect(result).toEqual({
+        type: "info",
+        message: "The address number is out of range",
+      });
+    });
+  });
+  describe("extractSuggestionsFromResponse", () => {
+    it("throws an error when no address", () => {
+      expect(() => processor.extractSuggestionsFromResponse({} as any)).toThrowError(
+        "No address found"
+      );
+    });
+    it("returns suggestions when address", () => {
+      const result = processor.extractSuggestionsFromResponse(mockedSuccessResponse);
+
+      expect(result).toEqual({
+        street: "20 COOPER ST",
+        city: "NEW YORK",
+        state: "NY",
+        country: "US",
+        zip: "10034",
+      });
+    });
+  });
+});

--- a/apps/taxes/src/modules/avatax/ui/avatax-address-resolution-processor.ts
+++ b/apps/taxes/src/modules/avatax/ui/avatax-address-resolution-processor.ts
@@ -1,0 +1,43 @@
+import { AddressResolutionModel } from "avatax/lib/models/AddressResolutionModel";
+import { AddressSuggestions } from "./avatax-configuration-address-fragment";
+
+export class AvataxAddressResolutionProcessor {
+  extractSuggestionsFromResponse(response: AddressResolutionModel): AddressSuggestions {
+    const address = response.validatedAddresses?.[0];
+
+    if (!address) {
+      throw new Error("No address found");
+    }
+
+    const lines = [address.line1, address.line2, address.line3].filter(Boolean);
+    const street = lines.join(" ");
+
+    return {
+      street,
+      city: address.city ?? "",
+      state: address.region ?? "",
+      country: address.country ?? "",
+      zip: address.postalCode ?? "",
+    };
+  }
+
+  resolveAddressResolutionMessage(response: AddressResolutionModel): {
+    type: "success" | "info";
+    message: string;
+  } {
+    if (!response.messages) {
+      // When address was resolved completely, it has no messages.
+      return {
+        type: "success",
+        message: "The address was resolved successfully.",
+      };
+    }
+
+    const message = response.messages?.[0];
+
+    return {
+      type: "info",
+      message: message?.summary ?? "The address was not resolved completely.",
+    };
+  }
+}

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -2,45 +2,53 @@ import { Input } from "@saleor/react-hook-form-macaw";
 import { useFormContext } from "react-hook-form";
 import { CountrySelect } from "../../ui/country-select";
 import { AvataxConfig } from "../avatax-connection-schema";
+import { useAvataxConfigurationStatus } from "./avatax-configuration-form";
 import { FormSection } from "./form-section";
 
 export const AvataxConfigurationAddressFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();
+  const [status] = useAvataxConfigurationStatus();
+
+  const disabled = status === "not_authenticated";
 
   return (
     <>
-      <FormSection title="Address">
+      <FormSection
+        title="Address"
+        disabled={disabled}
+        subtitle={disabled ? "You must verify your Credentials first." : ""}
+      >
         <Input
           control={control}
-          required
+          disabled={disabled}
           name="address.street"
           label="Street"
           helperText={formState.errors.address?.street?.message}
         />
         <Input
           control={control}
-          required
+          disabled={disabled}
           name="address.city"
           label="City"
           helperText={formState.errors.address?.city?.message}
         />
         <Input
           control={control}
-          required
+          disabled={disabled}
           name="address.state"
           label="State"
           helperText={formState.errors.address?.state?.message}
         />
         <CountrySelect
           control={control}
-          required
+          disabled={disabled}
           name="address.country"
           label="Country"
           helperText={formState.errors.address?.country?.message}
         />
         <Input
           control={control}
-          required
+          disabled={disabled}
           name="address.zip"
           label="Zip"
           helperText={formState.errors.address?.zip?.message}

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -1,54 +1,51 @@
-import { Box, Text } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import { useFormContext } from "react-hook-form";
 import { CountrySelect } from "../../ui/country-select";
 import { AvataxConfig } from "../avatax-connection-schema";
+import { FormSection } from "./form-section";
 
 export const AvataxConfigurationAddressFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();
 
   return (
     <>
-      <Text marginBottom={4} as="h3" variant="heading">
-        Address
-      </Text>
-      <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
+      <FormSection title="Address">
         <Input
           control={control}
           required
           name="address.street"
-          label="Street *"
+          label="Street"
           helperText={formState.errors.address?.street?.message}
         />
         <Input
           control={control}
           required
           name="address.city"
-          label="City *"
+          label="City"
           helperText={formState.errors.address?.city?.message}
         />
         <Input
           control={control}
           required
           name="address.state"
-          label="State *"
+          label="State"
           helperText={formState.errors.address?.state?.message}
         />
         <CountrySelect
           control={control}
           required
           name="address.country"
-          label="Country *"
+          label="Country"
           helperText={formState.errors.address?.country?.message}
         />
         <Input
           control={control}
           required
           name="address.zip"
-          label="Zip *"
+          label="Zip"
           helperText={formState.errors.address?.zip?.message}
         />
-      </Box>
+      </FormSection>
     </>
   );
 };

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -34,7 +34,7 @@ export const AvataxConfigurationAddressFragment = (
   props: AvataxConfigurationAddressFragmentProps
 ) => {
   const { control, formState, getValues, setValue, watch } = useFormContext<AvataxConfig>();
-  const [status, setStatus] = useAvataxConfigurationStatus();
+  const { status, setStatus } = useAvataxConfigurationStatus();
   const [suggestions, setSuggestions] = React.useState<AddressSuggestions>();
 
   const { notifyError, notifySuccess, notifyInfo } = useDashboardNotification();

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -1,0 +1,54 @@
+import { Box, Text } from "@saleor/macaw-ui/next";
+import { Input } from "@saleor/react-hook-form-macaw";
+import { useFormContext } from "react-hook-form";
+import { CountrySelect } from "../../ui/country-select";
+import { AvataxConfig } from "../avatax-connection-schema";
+
+export const AvataxConfigurationAddressFragment = () => {
+  const { control, formState } = useFormContext<AvataxConfig>();
+
+  return (
+    <>
+      <Text marginBottom={4} as="h3" variant="heading">
+        Address
+      </Text>
+      <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
+        <Input
+          control={control}
+          required
+          name="address.street"
+          label="Street *"
+          helperText={formState.errors.address?.street?.message}
+        />
+        <Input
+          control={control}
+          required
+          name="address.city"
+          label="City *"
+          helperText={formState.errors.address?.city?.message}
+        />
+        <Input
+          control={control}
+          required
+          name="address.state"
+          label="State *"
+          helperText={formState.errors.address?.state?.message}
+        />
+        <CountrySelect
+          control={control}
+          required
+          name="address.country"
+          label="Country *"
+          helperText={formState.errors.address?.country?.message}
+        />
+        <Input
+          control={control}
+          required
+          name="address.zip"
+          label="Zip *"
+          helperText={formState.errors.address?.zip?.message}
+        />
+      </Box>
+    </>
+  );
+};

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -1,13 +1,88 @@
+import { useDashboardNotification } from "@saleor/apps-shared";
+import { Box, Button, Text } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
+import { AddressResolutionModel } from "avatax/lib/models/AddressResolutionModel";
+import React from "react";
 import { useFormContext } from "react-hook-form";
 import { CountrySelect } from "../../ui/country-select";
 import { AvataxConfig } from "../avatax-connection-schema";
-import { useAvataxConfigurationStatus } from "./avatax-configuration-form";
 import { FormSection } from "./form-section";
+import { useAvataxConfigurationStatus } from "./configuration-status";
 
-export const AvataxConfigurationAddressFragment = () => {
-  const { control, formState } = useFormContext<AvataxConfig>();
-  const [status] = useAvataxConfigurationStatus();
+const FieldSuggestion = ({ suggestion }: { suggestion: string }) => {
+  return (
+    <Box alignItems={"center"} display={"flex"} justifyContent={"space-between"} marginTop={1}>
+      <Text paddingLeft={2} color="textNeutralSubdued" variant="caption">
+        {suggestion}
+      </Text>
+    </Box>
+  );
+};
+
+type AddressSuggestions = AvataxConfig["address"];
+
+// todo: test
+function extractSuggestionsFromResponse(response: AddressResolutionModel): AddressSuggestions {
+  const address = response.validatedAddresses?.[0];
+
+  if (!address) {
+    throw new Error("No address found");
+  }
+
+  return {
+    street: address.line1 + " " + address.line2 + " " + address.line3,
+    city: address.city ?? "",
+    state: address.region ?? "",
+    country: address.country ?? "",
+    zip: address.postalCode ?? "",
+  };
+}
+
+type AvataxConfigurationAddressFragmentProps = {
+  onValidateAddress: (address: AvataxConfig) => Promise<AddressResolutionModel>;
+  isLoading: boolean;
+};
+
+export const AvataxConfigurationAddressFragment = (
+  props: AvataxConfigurationAddressFragmentProps
+) => {
+  const { control, formState, getValues, setValue } = useFormContext<AvataxConfig>();
+  const [status, setStatus] = useAvataxConfigurationStatus();
+  const [suggestions, setSuggestions] = React.useState<AddressSuggestions>();
+
+  const { notifyError, notifySuccess } = useDashboardNotification();
+
+  const verifyClickHandler = React.useCallback(async () => {
+    const config = getValues();
+
+    try {
+      const result = await props.onValidateAddress(config);
+
+      notifySuccess("Address verified");
+      setSuggestions(extractSuggestionsFromResponse(result));
+      setStatus("address_valid");
+    } catch (error) {
+      setStatus("address_invalid");
+      notifyError("Invalid address");
+    }
+  }, [getValues, notifyError, notifySuccess, props, setStatus]);
+
+  const applyClickHandler = React.useCallback(() => {
+    setStatus("address_verified");
+    setSuggestions(undefined);
+    setValue("address", {
+      city: suggestions?.city ?? "",
+      country: suggestions?.country ?? "",
+      state: suggestions?.state ?? "",
+      street: suggestions?.street ?? "",
+      zip: suggestions?.zip ?? "",
+    });
+  }, [setStatus, setValue, suggestions]);
+
+  const rejectClickHandler = React.useCallback(() => {
+    setStatus("address_verified");
+    setSuggestions(undefined);
+  }, [setStatus]);
 
   const disabled = status === "not_authenticated";
 
@@ -18,27 +93,37 @@ export const AvataxConfigurationAddressFragment = () => {
         disabled={disabled}
         subtitle={disabled ? "You must verify your Credentials first." : ""}
       >
-        <Input
-          control={control}
-          disabled={disabled}
-          name="address.street"
-          label="Street"
-          helperText={formState.errors.address?.street?.message}
-        />
-        <Input
-          control={control}
-          disabled={disabled}
-          name="address.city"
-          label="City"
-          helperText={formState.errors.address?.city?.message}
-        />
-        <Input
-          control={control}
-          disabled={disabled}
-          name="address.state"
-          label="State"
-          helperText={formState.errors.address?.state?.message}
-        />
+        <Box display="flex" flexDirection={"column"}>
+          <Input
+            control={control}
+            disabled={disabled}
+            name="address.street"
+            label="Street"
+            helperText={formState.errors.address?.street?.message}
+          />
+          {suggestions?.street && <FieldSuggestion suggestion={suggestions.street} />}
+        </Box>
+        <Box>
+          <Input
+            control={control}
+            disabled={disabled}
+            name="address.city"
+            label="City"
+            helperText={formState.errors.address?.city?.message}
+          />
+          {suggestions?.city && <FieldSuggestion suggestion={suggestions.city} />}
+        </Box>
+        <Box>
+          <Input
+            control={control}
+            disabled={disabled}
+            name="address.state"
+            label="State"
+            helperText={formState.errors.address?.state?.message}
+          />
+          {suggestions?.state && <FieldSuggestion suggestion={suggestions.state} />}
+        </Box>
+
         <CountrySelect
           control={control}
           disabled={disabled}
@@ -46,14 +131,42 @@ export const AvataxConfigurationAddressFragment = () => {
           label="Country"
           helperText={formState.errors.address?.country?.message}
         />
-        <Input
-          control={control}
-          disabled={disabled}
-          name="address.zip"
-          label="Zip"
-          helperText={formState.errors.address?.zip?.message}
-        />
+        <Box>
+          <Input
+            control={control}
+            disabled={disabled}
+            name="address.zip"
+            label="Zip"
+            helperText={formState.errors.address?.zip?.message}
+          />
+          {suggestions?.zip && <FieldSuggestion suggestion={suggestions.zip} />}
+        </Box>
       </FormSection>
+      <Box display={"flex"} flexDirection={"column"} gap={6} marginTop={8}>
+        {status !== "address_valid" && (
+          <Box alignItems={"center"} display="flex" justifyContent={"flex-end"}>
+            <Button
+              disabled={props.isLoading || status === "not_authenticated"}
+              onClick={verifyClickHandler}
+              variant="secondary"
+            >
+              {props.isLoading ? "Verifying..." : "Verify"}
+            </Button>
+          </Box>
+        )}
+        {suggestions && (
+          <Box display={"flex"} justifyContent={"flex-end"}>
+            <Box display={"flex"} gap={4}>
+              <Button variant="secondary" onClick={rejectClickHandler}>
+                Reject suggestions
+              </Button>
+              <Button onClick={applyClickHandler} variant="primary">
+                Apply suggestions
+              </Button>
+            </Box>
+          </Box>
+        )}
+      </Box>
     </>
   );
 };

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -9,6 +9,7 @@ import { AvataxConfig, BaseAvataxConfig } from "../avatax-connection-schema";
 import { useAvataxConfigurationStatus } from "./configuration-status";
 import { HelperText } from "./form-helper-text";
 import { FormSection } from "./form-section";
+import { errorUtils } from "../../../lib/error-utils";
 
 type AvataxConfigurationCredentialsFragmentProps = {
   onValidateCredentials: (input: BaseAvataxConfig) => Promise<void>;
@@ -44,8 +45,9 @@ export const AvataxConfigurationCredentialsFragment = (
       });
       notifySuccess("Credentials verified");
       setStatus("authenticated");
-    } catch (error) {
-      notifyError("Invalid credentials");
+    } catch (e) {
+      notifyError("Invalid credentials", errorUtils.resolveTrpcClientError(e));
+
       setStatus("not_authenticated");
     }
   }, [getValues, notifyError, notifySuccess, props, setStatus]);

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "@saleor/macaw-ui/next";
+import { Box } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
 import { HelperText } from "./form-helper-text";
@@ -6,16 +6,14 @@ import { TextLink } from "@saleor/apps-ui";
 import { AppToggle } from "../../ui/app-toggle";
 import { useFormContext } from "react-hook-form";
 import { AvataxConfig } from "../avatax-connection-schema";
+import { FormSection } from "./form-section";
 
 export const AvataxConfigurationCredentialsFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();
 
   return (
     <>
-      <Text marginBottom={4} as="h3" variant="heading">
-        Credentials
-      </Text>
-      <Box display="grid" gridTemplateColumns={2} gap={12}>
+      <FormSection title="Credentials">
         <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
           <div>
             <Input
@@ -100,7 +98,7 @@ export const AvataxConfigurationCredentialsFragment = () => {
             name="isAutocommit"
           />
         </Box>
-      </Box>
+      </FormSection>
     </>
   );
 };

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
-import { HelperText } from "./avatax-configuration-form";
+import { HelperText } from "./form-helper-text";
 import { TextLink } from "@saleor/apps-ui";
 import { AppToggle } from "../../ui/app-toggle";
 import { useFormContext } from "react-hook-form";

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -4,12 +4,12 @@ import { Box, Button } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
 import { useFormContext } from "react-hook-form";
+import { errorUtils } from "../../../lib/error-utils";
 import { AppToggle } from "../../ui/app-toggle";
 import { AvataxConfig, BaseAvataxConfig } from "../avatax-connection-schema";
 import { useAvataxConfigurationStatus } from "./configuration-status";
 import { HelperText } from "./form-helper-text";
 import { FormSection } from "./form-section";
-import { errorUtils } from "../../../lib/error-utils";
 
 type AvataxConfigurationCredentialsFragmentProps = {
   onValidateCredentials: (input: BaseAvataxConfig) => Promise<void>;
@@ -20,7 +20,7 @@ export const AvataxConfigurationCredentialsFragment = (
   props: AvataxConfigurationCredentialsFragmentProps
 ) => {
   const { control, formState, getValues, watch } = useFormContext<AvataxConfig>();
-  const [_, setStatus] = useAvataxConfigurationStatus();
+  const { setStatus } = useAvataxConfigurationStatus();
 
   const { notifyError, notifySuccess } = useDashboardNotification();
 

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -1,0 +1,106 @@
+import { Box, Text } from "@saleor/macaw-ui/next";
+import { Input } from "@saleor/react-hook-form-macaw";
+import React from "react";
+import { HelperText } from "./avatax-configuration-form";
+import { TextLink } from "@saleor/apps-ui";
+import { AppToggle } from "../../ui/app-toggle";
+import { useFormContext } from "react-hook-form";
+import { AvataxConfig } from "../avatax-connection-schema";
+
+export const AvataxConfigurationCredentialsFragment = () => {
+  const { control, formState } = useFormContext<AvataxConfig>();
+
+  return (
+    <>
+      <Text marginBottom={4} as="h3" variant="heading">
+        Credentials
+      </Text>
+      <Box display="grid" gridTemplateColumns={2} gap={12}>
+        <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
+          <div>
+            <Input
+              control={control}
+              name="credentials.username"
+              required
+              label="Username *"
+              helperText={formState.errors.credentials?.username?.message}
+            />
+            <HelperText>
+              You can obtain it in the <i>API Keys</i> section of <i>Settings</i> → <i>License</i>{" "}
+              in your Avalara Dashboard.
+            </HelperText>
+          </div>
+          <div>
+            <Input
+              control={control}
+              name="credentials.password"
+              type="password"
+              required
+              label="Password *"
+              helperText={formState.errors.credentials?.password?.message}
+            />
+            <HelperText>
+              You can obtain it in the <i>API Keys</i> section of <i>Settings</i> → <i>License</i>{" "}
+              in your Avalara Dashboard.
+            </HelperText>
+          </div>
+
+          <div>
+            <Input
+              control={control}
+              name="companyCode"
+              label="Company name"
+              helperText={formState.errors.companyCode?.message}
+            />
+            <HelperText>
+              When not provided, the default company will be used.{" "}
+              <TextLink
+                newTab
+                href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/simple-transactions/company-codes/"
+              >
+                Read more
+              </TextLink>{" "}
+              about company codes.
+            </HelperText>
+          </div>
+        </Box>
+        <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
+          <AppToggle
+            control={control}
+            label="Use sandbox mode"
+            helperText={
+              <HelperText>
+                Toggling between{" "}
+                <TextLink
+                  href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/authentication-in-avatax/sandbox-vs-production/"
+                  newTab
+                >
+                  <q>Production</q> and <q>Sandbox</q>
+                </TextLink>{" "}
+                environment.
+              </HelperText>
+            }
+            name="isSandbox"
+          />
+
+          <AppToggle
+            control={control}
+            label="Autocommit"
+            helperText={
+              <HelperText>
+                If enabled, the order will be automatically{" "}
+                <TextLink
+                  href="https://developer.avalara.com/communications/dev-guide_rest_v2/commit-uncommit/"
+                  newTab
+                >
+                  commited to Avalara.
+                </TextLink>{" "}
+              </HelperText>
+            }
+            name="isAutocommit"
+          />
+        </Box>
+      </Box>
+    </>
+  );
+};

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -3,14 +3,14 @@ import { TextLink } from "@saleor/apps-ui";
 import { Box, Button, Divider, Text } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
-import { useForm } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import { AppCard } from "../../ui/app-card";
 import { AppToggle } from "../../ui/app-toggle";
-import { CountrySelect } from "../../ui/country-select";
 import { ProviderLabel } from "../../ui/provider-label";
 import { AvataxConfig, avataxConfigSchema, defaultAvataxConfig } from "../avatax-connection-schema";
+import { AvataxConfigurationAddressFragment } from "./avatax-configuration-address-fragment";
 
-const HelperText = ({ children }: { children: React.ReactNode }) => {
+export const HelperText = ({ children }: { children: React.ReactNode }) => {
   return (
     <Text color="textNeutralSubdued" fontWeight={"captionLarge"}>
       {children}
@@ -26,10 +26,12 @@ type AvataxConfigurationFormProps = {
 };
 
 export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => {
-  const { handleSubmit, control, formState, reset } = useForm({
+  const formMethods = useForm({
     defaultValues: defaultAvataxConfig,
     resolver: zodResolver(avataxConfigSchema),
   });
+
+  const { handleSubmit, control, formState, reset } = formMethods;
 
   React.useEffect(() => {
     reset(props.defaultValues);
@@ -47,182 +49,144 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
       <Box marginBottom={8}>
         <ProviderLabel name="avatax" />
       </Box>
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(submitHandler)} data-testid="avatax-configuration-form">
+          <Input
+            control={control}
+            name="name"
+            required
+            label="Configuration name *"
+            helperText={formState.errors.name?.message}
+          />
+          <HelperText>Unique identifier for your provider.</HelperText>
+          <Divider marginY={8} />
+          <Text marginBottom={4} as="h3" variant="heading">
+            Credentials
+          </Text>
+          <Box display="grid" gridTemplateColumns={2} gap={12}>
+            <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
+              <div>
+                <Input
+                  control={control}
+                  name="credentials.username"
+                  required
+                  label="Username *"
+                  helperText={formState.errors.credentials?.username?.message}
+                />
+                <HelperText>
+                  You can obtain it in the <i>API Keys</i> section of <i>Settings</i> →{" "}
+                  <i>License</i> in your Avalara Dashboard.
+                </HelperText>
+              </div>
+              <div>
+                <Input
+                  control={control}
+                  name="credentials.password"
+                  type="password"
+                  required
+                  label="Password *"
+                  helperText={formState.errors.credentials?.password?.message}
+                />
+                <HelperText>
+                  You can obtain it in the <i>API Keys</i> section of <i>Settings</i> →{" "}
+                  <i>License</i> in your Avalara Dashboard.
+                </HelperText>
+              </div>
 
-      <form onSubmit={handleSubmit(submitHandler)} data-testid="avatax-configuration-form">
-        <Input
-          control={control}
-          name="name"
-          required
-          label="Configuration name *"
-          helperText={formState.errors.name?.message}
-        />
-        <HelperText>Unique identifier for your provider.</HelperText>
-        <Divider marginY={8} />
-        <Text marginBottom={4} as="h3" variant="heading">
-          Credentials
-        </Text>
-        <Box display="grid" gridTemplateColumns={2} gap={12}>
-          <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
-            <div>
-              <Input
+              <div>
+                <Input
+                  control={control}
+                  name="companyCode"
+                  label="Company name"
+                  helperText={formState.errors.companyCode?.message}
+                />
+                <HelperText>
+                  When not provided, the default company will be used.{" "}
+                  <TextLink
+                    newTab
+                    href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/simple-transactions/company-codes/"
+                  >
+                    Read more
+                  </TextLink>{" "}
+                  about company codes.
+                </HelperText>
+              </div>
+            </Box>
+            <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
+              <AppToggle
                 control={control}
-                name="credentials.username"
-                required
-                label="Username *"
-                helperText={formState.errors.credentials?.username?.message}
+                label="Use sandbox mode"
+                helperText={
+                  <HelperText>
+                    Toggling between{" "}
+                    <TextLink
+                      href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/authentication-in-avatax/sandbox-vs-production/"
+                      newTab
+                    >
+                      <q>Production</q> and <q>Sandbox</q>
+                    </TextLink>{" "}
+                    environment.
+                  </HelperText>
+                }
+                name="isSandbox"
               />
-              <HelperText>
-                You can obtain it in the <i>API Keys</i> section of <i>Settings</i> → <i>License</i>{" "}
-                in your Avalara Dashboard.
-              </HelperText>
-            </div>
-            <div>
-              <Input
-                control={control}
-                name="credentials.password"
-                type="password"
-                required
-                label="Password *"
-                helperText={formState.errors.credentials?.password?.message}
-              />
-              <HelperText>
-                You can obtain it in the <i>API Keys</i> section of <i>Settings</i> → <i>License</i>{" "}
-                in your Avalara Dashboard.
-              </HelperText>
-            </div>
 
+              <AppToggle
+                control={control}
+                label="Autocommit"
+                helperText={
+                  <HelperText>
+                    If enabled, the order will be automatically{" "}
+                    <TextLink
+                      href="https://developer.avalara.com/communications/dev-guide_rest_v2/commit-uncommit/"
+                      newTab
+                    >
+                      commited to Avalara.
+                    </TextLink>{" "}
+                  </HelperText>
+                }
+                name="isAutocommit"
+              />
+            </Box>
+          </Box>
+          <Divider marginY={8} />
+          <AvataxConfigurationAddressFragment />
+          <Divider marginY={8} />
+          <Text marginBottom={4} as="h3" variant="heading">
+            Tax codes
+          </Text>
+          <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
             <div>
               <Input
                 control={control}
-                name="companyCode"
-                label="Company name"
-                helperText={formState.errors.companyCode?.message}
+                name="shippingTaxCode"
+                label="Shipping tax code"
+                helperText={formState.errors.shippingTaxCode?.message}
               />
               <HelperText>
-                When not provided, the default company will be used.{" "}
-                <TextLink
-                  newTab
-                  href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/simple-transactions/company-codes/"
-                >
-                  Read more
-                </TextLink>{" "}
-                about company codes.
+                Tax code that for the shipping line sent to Avatax.{" "}
+                <TextLink newTab href="https://taxcode.avatax.avalara.com">
+                  Must match Avatax tax codes format.
+                </TextLink>
               </HelperText>
             </div>
           </Box>
-          <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
-            <AppToggle
-              control={control}
-              label="Use sandbox mode"
-              helperText={
-                <HelperText>
-                  Toggling between{" "}
-                  <TextLink
-                    href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/authentication-in-avatax/sandbox-vs-production/"
-                    newTab
-                  >
-                    <q>Production</q> and <q>Sandbox</q>
-                  </TextLink>{" "}
-                  environment.
-                </HelperText>
-              }
-              name="isSandbox"
-            />
+          <Divider marginY={8} />
 
-            <AppToggle
-              control={control}
-              label="Autocommit"
-              helperText={
-                <HelperText>
-                  If enabled, the order will be automatically{" "}
-                  <TextLink
-                    href="https://developer.avalara.com/communications/dev-guide_rest_v2/commit-uncommit/"
-                    newTab
-                  >
-                    commited to Avalara.
-                  </TextLink>{" "}
-                </HelperText>
-              }
-              name="isAutocommit"
-            />
+          <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"}>
+            {props.leftButton}
+
+            <Button
+              disabled={props.isLoading}
+              type="submit"
+              variant="primary"
+              data-testid="avatax-configuration-save-button"
+            >
+              {props.isLoading ? "Saving..." : "Save"}
+            </Button>
           </Box>
-        </Box>
-        <Divider marginY={8} />
-        <Text marginBottom={4} as="h3" variant="heading">
-          Address
-        </Text>
-        <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
-          <Input
-            control={control}
-            required
-            name="address.street"
-            label="Street *"
-            helperText={formState.errors.address?.street?.message}
-          />
-          <Input
-            control={control}
-            required
-            name="address.city"
-            label="City *"
-            helperText={formState.errors.address?.city?.message}
-          />
-          <Input
-            control={control}
-            required
-            name="address.state"
-            label="State *"
-            helperText={formState.errors.address?.state?.message}
-          />
-          <CountrySelect
-            control={control}
-            required
-            name="address.country"
-            label="Country *"
-            helperText={formState.errors.address?.country?.message}
-          />
-          <Input
-            control={control}
-            required
-            name="address.zip"
-            label="Zip *"
-            helperText={formState.errors.address?.zip?.message}
-          />
-        </Box>
-        <Divider marginY={8} />
-        <Text marginBottom={4} as="h3" variant="heading">
-          Tax codes
-        </Text>
-        <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
-          <div>
-            <Input
-              control={control}
-              name="shippingTaxCode"
-              label="Shipping tax code"
-              helperText={formState.errors.shippingTaxCode?.message}
-            />
-            <HelperText>
-              Tax code that for the shipping line sent to Avatax.{" "}
-              <TextLink newTab href="https://taxcode.avatax.avalara.com">
-                Must match Avatax tax codes format.
-              </TextLink>
-            </HelperText>
-          </div>
-        </Box>
-        <Divider marginY={8} />
-
-        <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"}>
-          {props.leftButton}
-
-          <Button
-            disabled={props.isLoading}
-            type="submit"
-            variant="primary"
-            data-testid="avatax-configuration-save-button"
-          >
-            {props.isLoading ? "Saving..." : "Save"}
-          </Button>
-        </Box>
-      </form>
+        </form>
+      </FormProvider>
     </AppCard>
   );
 };

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { TextLink } from "@saleor/apps-ui";
 import { Box, Button, Divider, Text } from "@saleor/macaw-ui/next";
 import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
@@ -10,7 +9,7 @@ import { AvataxConfig, avataxConfigSchema, defaultAvataxConfig } from "../avatax
 import { AvataxConfigurationAddressFragment } from "./avatax-configuration-address-fragment";
 import { AvataxConfigurationCredentialsFragment } from "./avatax-configuration-credentials-fragment";
 import { HelperText } from "./form-helper-text";
-import { FormSection } from "./form-section";
+import { AvataxConfigurationTaxesFragment } from "./avatax-configuration-taxes-fragment";
 
 type AvataxConfigurationFormProps = {
   onSubmit: (data: AvataxConfig) => void;
@@ -58,22 +57,7 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
           <Divider marginY={8} />
           <AvataxConfigurationAddressFragment />
           <Divider marginY={8} />
-          <FormSection title="Tax codes">
-            <div>
-              <Input
-                control={control}
-                name="shippingTaxCode"
-                label="Shipping tax code"
-                helperText={formState.errors.shippingTaxCode?.message}
-              />
-              <HelperText>
-                Tax code that for the shipping line sent to Avatax.{" "}
-                <TextLink newTab href="https://taxcode.avatax.avalara.com">
-                  Must match Avatax tax codes format.
-                </TextLink>
-              </HelperText>
-            </div>
-          </FormSection>
+          <AvataxConfigurationTaxesFragment />
           <Divider marginY={8} />
 
           <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"}>

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -5,10 +5,10 @@ import { Input } from "@saleor/react-hook-form-macaw";
 import React from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { AppCard } from "../../ui/app-card";
-import { AppToggle } from "../../ui/app-toggle";
 import { ProviderLabel } from "../../ui/provider-label";
 import { AvataxConfig, avataxConfigSchema, defaultAvataxConfig } from "../avatax-connection-schema";
 import { AvataxConfigurationAddressFragment } from "./avatax-configuration-address-fragment";
+import { AvataxConfigurationCredentialsFragment } from "./avatax-configuration-credentials-fragment";
 
 export const HelperText = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -60,95 +60,7 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
           />
           <HelperText>Unique identifier for your provider.</HelperText>
           <Divider marginY={8} />
-          <Text marginBottom={4} as="h3" variant="heading">
-            Credentials
-          </Text>
-          <Box display="grid" gridTemplateColumns={2} gap={12}>
-            <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
-              <div>
-                <Input
-                  control={control}
-                  name="credentials.username"
-                  required
-                  label="Username *"
-                  helperText={formState.errors.credentials?.username?.message}
-                />
-                <HelperText>
-                  You can obtain it in the <i>API Keys</i> section of <i>Settings</i> →{" "}
-                  <i>License</i> in your Avalara Dashboard.
-                </HelperText>
-              </div>
-              <div>
-                <Input
-                  control={control}
-                  name="credentials.password"
-                  type="password"
-                  required
-                  label="Password *"
-                  helperText={formState.errors.credentials?.password?.message}
-                />
-                <HelperText>
-                  You can obtain it in the <i>API Keys</i> section of <i>Settings</i> →{" "}
-                  <i>License</i> in your Avalara Dashboard.
-                </HelperText>
-              </div>
-
-              <div>
-                <Input
-                  control={control}
-                  name="companyCode"
-                  label="Company name"
-                  helperText={formState.errors.companyCode?.message}
-                />
-                <HelperText>
-                  When not provided, the default company will be used.{" "}
-                  <TextLink
-                    newTab
-                    href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/simple-transactions/company-codes/"
-                  >
-                    Read more
-                  </TextLink>{" "}
-                  about company codes.
-                </HelperText>
-              </div>
-            </Box>
-            <Box paddingY={4} display={"flex"} flexDirection={"column"} gap={10}>
-              <AppToggle
-                control={control}
-                label="Use sandbox mode"
-                helperText={
-                  <HelperText>
-                    Toggling between{" "}
-                    <TextLink
-                      href="https://developer.avalara.com/erp-integration-guide/sales-tax-badge/authentication-in-avatax/sandbox-vs-production/"
-                      newTab
-                    >
-                      <q>Production</q> and <q>Sandbox</q>
-                    </TextLink>{" "}
-                    environment.
-                  </HelperText>
-                }
-                name="isSandbox"
-              />
-
-              <AppToggle
-                control={control}
-                label="Autocommit"
-                helperText={
-                  <HelperText>
-                    If enabled, the order will be automatically{" "}
-                    <TextLink
-                      href="https://developer.avalara.com/communications/dev-guide_rest_v2/commit-uncommit/"
-                      newTab
-                    >
-                      commited to Avalara.
-                    </TextLink>{" "}
-                  </HelperText>
-                }
-                name="isAutocommit"
-              />
-            </Box>
-          </Box>
+          <AvataxConfigurationCredentialsFragment />
           <Divider marginY={8} />
           <AvataxConfigurationAddressFragment />
           <Divider marginY={8} />

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -10,6 +10,7 @@ import { AvataxConfigurationAddressFragment } from "./avatax-configuration-addre
 import { AvataxConfigurationCredentialsFragment } from "./avatax-configuration-credentials-fragment";
 import { HelperText } from "./form-helper-text";
 import { AvataxConfigurationTaxesFragment } from "./avatax-configuration-taxes-fragment";
+import { atom, useAtom } from "jotai";
 
 type AvataxConfigurationFormProps = {
   onSubmit: (data: AvataxConfig) => void;
@@ -18,7 +19,14 @@ type AvataxConfigurationFormProps = {
   leftButton: React.ReactNode;
 };
 
+const statusAtom = atom<"not_authenticated" | "authenticated">("not_authenticated");
+
+export const useAvataxConfigurationStatus = () => {
+  return useAtom(statusAtom);
+};
+
 export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => {
+  const [status] = useAvataxConfigurationStatus();
   const formMethods = useForm({
     defaultValues: defaultAvataxConfig,
     resolver: zodResolver(avataxConfigSchema),
@@ -64,7 +72,7 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
             {props.leftButton}
 
             <Button
-              disabled={props.isLoading}
+              disabled={props.isLoading || status === "not_authenticated"}
               type="submit"
               variant="primary"
               data-testid="avatax-configuration-save-button"

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -36,7 +36,7 @@ type AvataxConfigurationFormProps = {
 };
 
 export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => {
-  const [status] = useAvataxConfigurationStatus();
+  const { status } = useAvataxConfigurationStatus();
   const formMethods = useForm({
     defaultValues: defaultAvataxConfig,
     resolver: zodResolver(avataxConfigSchema),

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -9,14 +9,7 @@ import { ProviderLabel } from "../../ui/provider-label";
 import { AvataxConfig, avataxConfigSchema, defaultAvataxConfig } from "../avatax-connection-schema";
 import { AvataxConfigurationAddressFragment } from "./avatax-configuration-address-fragment";
 import { AvataxConfigurationCredentialsFragment } from "./avatax-configuration-credentials-fragment";
-
-export const HelperText = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <Text color="textNeutralSubdued" fontWeight={"captionLarge"}>
-      {children}
-    </Text>
-  );
-};
+import { HelperText } from "./form-helper-text";
 
 type AvataxConfigurationFormProps = {
   onSubmit: (data: AvataxConfig) => void;

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-form.tsx
@@ -10,6 +10,7 @@ import { AvataxConfig, avataxConfigSchema, defaultAvataxConfig } from "../avatax
 import { AvataxConfigurationAddressFragment } from "./avatax-configuration-address-fragment";
 import { AvataxConfigurationCredentialsFragment } from "./avatax-configuration-credentials-fragment";
 import { HelperText } from "./form-helper-text";
+import { FormSection } from "./form-section";
 
 type AvataxConfigurationFormProps = {
   onSubmit: (data: AvataxConfig) => void;
@@ -57,10 +58,7 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
           <Divider marginY={8} />
           <AvataxConfigurationAddressFragment />
           <Divider marginY={8} />
-          <Text marginBottom={4} as="h3" variant="heading">
-            Tax codes
-          </Text>
-          <Box paddingY={4} display={"grid"} gridTemplateColumns={2} gap={12}>
+          <FormSection title="Tax codes">
             <div>
               <Input
                 control={control}
@@ -75,7 +73,7 @@ export const AvataxConfigurationForm = (props: AvataxConfigurationFormProps) => 
                 </TextLink>
               </HelperText>
             </div>
-          </Box>
+          </FormSection>
           <Divider marginY={8} />
 
           <Box display={"flex"} justifyContent={"space-between"} alignItems={"center"}>

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
@@ -5,20 +5,24 @@ import { useFormContext } from "react-hook-form";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { HelperText } from "./form-helper-text";
 import { FormSection } from "./form-section";
+import { useAvataxConfigurationStatus } from "./avatax-configuration-form";
 
 export const AvataxConfigurationTaxesFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();
+  const [status] = useAvataxConfigurationStatus();
+  const disabled = status === "not_authenticated";
 
   return (
-    <FormSection title="Tax codes">
+    <FormSection title="Tax codes" disabled={disabled}>
       <div>
         <Input
+          disabled={disabled}
           control={control}
           name="shippingTaxCode"
           label="Shipping tax code"
           helperText={formState.errors.shippingTaxCode?.message}
         />
-        <HelperText>
+        <HelperText disabled={disabled}>
           Tax code that for the shipping line sent to Avatax.{" "}
           <TextLink newTab href="https://taxcode.avatax.avalara.com">
             Must match Avatax tax codes format.

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
@@ -9,7 +9,7 @@ import { useAvataxConfigurationStatus } from "./configuration-status";
 
 export const AvataxConfigurationTaxesFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();
-  const [status] = useAvataxConfigurationStatus();
+  const { status } = useAvataxConfigurationStatus();
   const disabled = status === "not_authenticated";
 
   return (

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from "react-hook-form";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { HelperText } from "./form-helper-text";
 import { FormSection } from "./form-section";
-import { useAvataxConfigurationStatus } from "./avatax-configuration-form";
+import { useAvataxConfigurationStatus } from "./configuration-status";
 
 export const AvataxConfigurationTaxesFragment = () => {
   const { control, formState } = useFormContext<AvataxConfig>();

--- a/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-configuration-taxes-fragment.tsx
@@ -1,0 +1,30 @@
+import { TextLink } from "@saleor/apps-ui";
+import { Input } from "@saleor/react-hook-form-macaw";
+import React from "react";
+import { useFormContext } from "react-hook-form";
+import { AvataxConfig } from "../avatax-connection-schema";
+import { HelperText } from "./form-helper-text";
+import { FormSection } from "./form-section";
+
+export const AvataxConfigurationTaxesFragment = () => {
+  const { control, formState } = useFormContext<AvataxConfig>();
+
+  return (
+    <FormSection title="Tax codes">
+      <div>
+        <Input
+          control={control}
+          name="shippingTaxCode"
+          label="Shipping tax code"
+          helperText={formState.errors.shippingTaxCode?.message}
+        />
+        <HelperText>
+          Tax code that for the shipping line sent to Avatax.{" "}
+          <TextLink newTab href="https://taxcode.avatax.avalara.com">
+            Must match Avatax tax codes format.
+          </TextLink>
+        </HelperText>
+      </div>
+    </FormSection>
+  );
+};

--- a/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
@@ -12,7 +12,7 @@ export const AvataxInstructions = () => {
           <br />
           <br />
           <i>Credentials</i> will fail if:
-          <Box as="ol" margin={0}>
+          <Box as="ol" margin={1}>
             <li>
               <Text>- The username or password are incorrect.</Text>
             </li>
@@ -25,13 +25,15 @@ export const AvataxInstructions = () => {
           </Box>
           <br />
           <Text>
-            You must verify your credentials by clicking the <b>Verify</b> button.
+            You must verify the credentials by clicking the <b>Verify</b> button.
           </Text>
+          <br />
+          <br />
           <br />
           <br />
           <i>Address</i> will fail if:
           <br />
-          <Box as="ol" margin={0}>
+          <Box as="ol" margin={1}>
             <li>
               <Text>
                 - The address does not match{" "}
@@ -44,7 +46,7 @@ export const AvataxInstructions = () => {
           </Box>
           <br />
           <Text>
-            You must verify your credentials by clicking the <b>Verify</b> button.
+            You must verify the address by clicking the <b>Verify</b> button.
           </Text>
           <br />
           <br />

--- a/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
@@ -24,6 +24,10 @@ export const AvataxInstructions = () => {
             </li>
           </Box>
           <br />
+          <Text>
+            You must verify your credentials by clicking the <b>Verify</b> button.
+          </Text>
+          <br />
           <br />
           <i>Address</i> will fail if:
           <br />
@@ -39,12 +43,18 @@ export const AvataxInstructions = () => {
             </li>
           </Box>
           <br />
+          <Text>
+            You must verify your credentials by clicking the <b>Verify</b> button.
+          </Text>
           <br />
-          If the configuration fails, please visit the{" "}
-          <TextLink href="https://developer.avalara.com" newTab>
-            Avatax documentation
-          </TextLink>
-          .
+          <br />
+          <Text>
+            Verifying the Address will display suggestions that reflect the resolution of the
+            address by Avatax address validation service. Applying the suggestions is not required
+            but recommended. If the address is not valid, the calculation of taxes will fail.
+          </Text>
+          <br />
+          <br />
         </>
       }
     />

--- a/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
@@ -8,11 +8,13 @@ export const AvataxInstructions = () => {
       title="Avatax Configuration"
       description={
         <>
-          The form consists of two sections: <i>Credentials</i> and <i>Address</i>.
-          <br />
-          <br />
-          <i>Credentials</i> will fail if:
-          <Box as="ol" margin={1}>
+          <Text as="p" marginBottom={8}>
+            The form consists of two sections: <i>Credentials</i> and <i>Address</i>.
+          </Text>
+          <Text as="p">
+            <i>Credentials</i> will fail if:
+          </Text>
+          <Box as="ol" marginBottom={1}>
             <li>
               <Text>- The username or password are incorrect.</Text>
             </li>
@@ -23,17 +25,13 @@ export const AvataxInstructions = () => {
               </Text>
             </li>
           </Box>
-          <br />
-          <Text>
+          <Text as="p" marginBottom={8}>
             You must verify the credentials by clicking the <b>Verify</b> button.
           </Text>
-          <br />
-          <br />
-          <br />
-          <br />
-          <i>Address</i> will fail if:
-          <br />
-          <Box as="ol" margin={1}>
+          <Text as="p">
+            <i>Address</i> will fail if:
+          </Text>
+          <Box as="ol" marginTop={1} marginBottom={2} marginX={1}>
             <li>
               <Text>
                 - The address does not match{" "}
@@ -44,19 +42,14 @@ export const AvataxInstructions = () => {
               </Text>
             </li>
           </Box>
-          <br />
-          <Text>
+          <Text as="p" marginBottom={4}>
             You must verify the address by clicking the <b>Verify</b> button.
           </Text>
-          <br />
-          <br />
-          <Text>
+          <Text as="p" marginBottom={4}>
             Verifying the Address will display suggestions that reflect the resolution of the
             address by Avatax address validation service. Applying the suggestions is not required
             but recommended. If the address is not valid, the calculation of taxes will fail.
           </Text>
-          <br />
-          <br />
         </>
       }
     />

--- a/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-instructions.tsx
@@ -26,7 +26,8 @@ export const AvataxInstructions = () => {
             </li>
           </Box>
           <Text as="p" marginBottom={8}>
-            You must verify the credentials by clicking the <b>Verify</b> button.
+            You must verify the credentials by clicking the <Text variant="bodyStrong">Verify</Text>{" "}
+            button.
           </Text>
           <Text as="p">
             <i>Address</i> will fail if:
@@ -43,7 +44,8 @@ export const AvataxInstructions = () => {
             </li>
           </Box>
           <Text as="p" marginBottom={4}>
-            You must verify the address by clicking the <b>Verify</b> button.
+            You must verify the address by clicking the <Text variant="bodyStrong">Verify</Text>{" "}
+            button.
           </Text>
           <Text as="p" marginBottom={4}>
             Verifying the Address will display suggestions that reflect the resolution of the

--- a/apps/taxes/src/modules/avatax/ui/configuration-status.ts
+++ b/apps/taxes/src/modules/avatax/ui/configuration-status.ts
@@ -1,0 +1,9 @@
+import { atom, useAtom } from "jotai";
+
+const statusAtom = atom<
+  "not_authenticated" | "authenticated" | "address_valid" | "address_invalid" | "address_verified"
+>("not_authenticated");
+
+export const useAvataxConfigurationStatus = () => {
+  return useAtom(statusAtom);
+};

--- a/apps/taxes/src/modules/avatax/ui/configuration-status.ts
+++ b/apps/taxes/src/modules/avatax/ui/configuration-status.ts
@@ -5,5 +5,7 @@ const statusAtom = atom<
 >("not_authenticated");
 
 export const useAvataxConfigurationStatus = () => {
-  return useAtom(statusAtom);
+  const [status, setStatus] = useAtom(statusAtom);
+
+  return { status, setStatus };
 };

--- a/apps/taxes/src/modules/avatax/ui/create-avatax-configuration.tsx
+++ b/apps/taxes/src/modules/avatax/ui/create-avatax-configuration.tsx
@@ -51,20 +51,32 @@ export const CreateAvataxConfiguration = () => {
     [createMutation]
   );
 
+  const submit = React.useMemo(() => {
+    return {
+      isLoading: isCreateLoading,
+      handleFn: submitHandler,
+    };
+  }, [isCreateLoading, submitHandler]);
+
+  const validateAddress = React.useMemo(() => {
+    return {
+      isLoading: validateAddressMutation.isLoading,
+      handleFn: validateAddressHandler,
+    };
+  }, [validateAddressHandler, validateAddressMutation]);
+
+  const validateCredentials = React.useMemo(() => {
+    return {
+      isLoading: validateCredentialsMutation.isLoading,
+      handleFn: validateCredentialsHandler,
+    };
+  }, [validateCredentialsHandler, validateCredentialsMutation]);
+
   return (
     <AvataxConfigurationForm
-      submit={{
-        isLoading: isCreateLoading,
-        handleFn: submitHandler,
-      }}
-      validateAddress={{
-        isLoading: validateAddressMutation.isLoading,
-        handleFn: validateAddressHandler,
-      }}
-      validateCredentials={{
-        isLoading: validateCredentialsMutation.isLoading,
-        handleFn: validateCredentialsHandler,
-      }}
+      submit={submit}
+      validateAddress={validateAddress}
+      validateCredentials={validateCredentials}
       defaultValues={defaultAvataxConfig}
       leftButton={
         <Button

--- a/apps/taxes/src/modules/avatax/ui/create-avatax-configuration.tsx
+++ b/apps/taxes/src/modules/avatax/ui/create-avatax-configuration.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AvataxConfigurationForm } from "./avatax-configuration-form";
-import { AvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
+import { AvataxConfig, BaseAvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
 import { trpcClient } from "../../trpc/trpc-client";
 import { useDashboardNotification } from "@saleor/apps-shared";
 import { useRouter } from "next/router";
@@ -25,6 +25,25 @@ export const CreateAvataxConfiguration = () => {
       },
     });
 
+  const validateAddressMutation = trpcClient.avataxConnection.createValidateAddress.useMutation({});
+
+  const validateAddressHandler = React.useCallback(
+    async (config: AvataxConfig) => {
+      return validateAddressMutation.mutateAsync({ value: config });
+    },
+    [validateAddressMutation]
+  );
+
+  const validateCredentialsMutation =
+    trpcClient.avataxConnection.createValidateCredentials.useMutation({});
+
+  const validateCredentialsHandler = React.useCallback(
+    async (config: BaseAvataxConfig) => {
+      return validateCredentialsMutation.mutateAsync({ value: config });
+    },
+    [validateCredentialsMutation]
+  );
+
   const submitHandler = React.useCallback(
     (data: AvataxConfig) => {
       createMutation({ value: data });
@@ -34,8 +53,18 @@ export const CreateAvataxConfiguration = () => {
 
   return (
     <AvataxConfigurationForm
-      isLoading={isCreateLoading}
-      onSubmit={submitHandler}
+      submit={{
+        isLoading: isCreateLoading,
+        handleFn: submitHandler,
+      }}
+      validateAddress={{
+        isLoading: validateAddressMutation.isLoading,
+        handleFn: validateAddressHandler,
+      }}
+      validateCredentials={{
+        isLoading: validateCredentialsMutation.isLoading,
+        handleFn: validateCredentialsHandler,
+      }}
       defaultValues={defaultAvataxConfig}
       leftButton={
         <Button

--- a/apps/taxes/src/modules/avatax/ui/edit-avatax-configuration.tsx
+++ b/apps/taxes/src/modules/avatax/ui/edit-avatax-configuration.tsx
@@ -12,7 +12,7 @@ import { useAvataxConfigurationStatus } from "./configuration-status";
 const avataxObfuscator = new AvataxObfuscator();
 
 export const EditAvataxConfiguration = () => {
-  const [_, setStatus] = useAvataxConfigurationStatus();
+  const { setStatus } = useAvataxConfigurationStatus();
 
   const router = useRouter();
   const { id } = router.query;

--- a/apps/taxes/src/modules/avatax/ui/edit-avatax-configuration.tsx
+++ b/apps/taxes/src/modules/avatax/ui/edit-avatax-configuration.tsx
@@ -103,6 +103,27 @@ export const EditAvataxConfiguration = () => {
     [configurationId, validateCredentialsMutation]
   );
 
+  const submit = React.useMemo(() => {
+    return {
+      isLoading: isPatchLoading,
+      handleFn: submitHandler,
+    };
+  }, [isPatchLoading, submitHandler]);
+
+  const validateAddress = React.useMemo(() => {
+    return {
+      isLoading: validateAddressMutation.isLoading,
+      handleFn: validateAddressHandler,
+    };
+  }, [validateAddressHandler, validateAddressMutation]);
+
+  const validateCredentials = React.useMemo(() => {
+    return {
+      isLoading: validateCredentialsMutation.isLoading,
+      handleFn: validateCredentialsHandler,
+    };
+  }, [validateCredentialsHandler, validateCredentialsMutation]);
+
   if (isGetLoading) {
     // todo: replace with skeleton once its available in Macaw
     return (
@@ -119,20 +140,12 @@ export const EditAvataxConfiguration = () => {
       </Box>
     );
   }
+
   return (
     <AvataxConfigurationForm
-      submit={{
-        isLoading: isPatchLoading,
-        handleFn: submitHandler,
-      }}
-      validateAddress={{
-        isLoading: validateAddressMutation.isLoading,
-        handleFn: validateAddressHandler,
-      }}
-      validateCredentials={{
-        isLoading: validateCredentialsMutation.isLoading,
-        handleFn: validateCredentialsHandler,
-      }}
+      submit={submit}
+      validateAddress={validateAddress}
+      validateCredentials={validateCredentials}
       defaultValues={data.config}
       leftButton={
         <Button onClick={deleteHandler} variant="error" data-testid="delete-avatax-button">

--- a/apps/taxes/src/modules/avatax/ui/form-helper-text.tsx
+++ b/apps/taxes/src/modules/avatax/ui/form-helper-text.tsx
@@ -1,9 +1,18 @@
 import { Text } from "@saleor/macaw-ui/next";
 import React from "react";
 
-export const HelperText = ({ children }: { children: React.ReactNode }) => {
+export const HelperText = ({
+  children,
+  disabled = false,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean;
+}) => {
   return (
-    <Text color="textNeutralSubdued" fontWeight={"captionLarge"}>
+    <Text
+      color={disabled ? "textNeutralDisabled" : "textNeutralSubdued"}
+      fontWeight={"captionLarge"}
+    >
       {children}
     </Text>
   );

--- a/apps/taxes/src/modules/avatax/ui/form-helper-text.tsx
+++ b/apps/taxes/src/modules/avatax/ui/form-helper-text.tsx
@@ -1,0 +1,10 @@
+import { Text } from "@saleor/macaw-ui/next";
+import React from "react";
+
+export const HelperText = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Text color="textNeutralSubdued" fontWeight={"captionLarge"}>
+      {children}
+    </Text>
+  );
+};

--- a/apps/taxes/src/modules/avatax/ui/form-section.tsx
+++ b/apps/taxes/src/modules/avatax/ui/form-section.tsx
@@ -1,0 +1,15 @@
+import { Box, Text } from "@saleor/macaw-ui/next";
+import React, { PropsWithChildren } from "react";
+
+export const FormSection = ({ title, children }: PropsWithChildren<{ title: string }>) => {
+  return (
+    <>
+      <Text marginBottom={4} as="h3" variant="heading">
+        {title}
+      </Text>
+      <Box display="grid" gridTemplateColumns={2} gap={12}>
+        {children}
+      </Box>
+    </>
+  );
+};

--- a/apps/taxes/src/modules/avatax/ui/form-section.tsx
+++ b/apps/taxes/src/modules/avatax/ui/form-section.tsx
@@ -1,12 +1,27 @@
 import { Box, Text } from "@saleor/macaw-ui/next";
 import React, { PropsWithChildren } from "react";
 
-export const FormSection = ({ title, children }: PropsWithChildren<{ title: string }>) => {
+export const FormSection = ({
+  title,
+  subtitle,
+  children,
+  disabled = false,
+}: PropsWithChildren<{ title: string; subtitle?: string; disabled?: boolean }>) => {
   return (
     <>
-      <Text marginBottom={4} as="h3" variant="heading">
+      <Text
+        marginBottom={4}
+        as="h3"
+        variant="heading"
+        {...(disabled && { color: "textNeutralDisabled" })}
+      >
         {title}
       </Text>
+      {subtitle && (
+        <Text as="p" marginBottom={4} {...(disabled && { color: "textNeutralDisabled" })}>
+          {subtitle}
+        </Text>
+      )}
       <Box display="grid" gridTemplateColumns={2} gap={12}>
         {children}
       </Box>

--- a/apps/taxes/src/modules/provider-connections/provider-connections.router.ts
+++ b/apps/taxes/src/modules/provider-connections/provider-connections.router.ts
@@ -9,11 +9,11 @@ export const providerConnectionsRouter = router({
       name: "providerConnectionsRouter.getAll",
     });
 
-    const items = await new PublicProviderConnectionsService(
-      ctx.apiClient,
-      ctx.appId!,
-      ctx.saleorApiUrl
-    ).getAll();
+    const items = await new PublicProviderConnectionsService({
+      appId: ctx.appId!,
+      client: ctx.apiClient,
+      saleorApiUrl: ctx.saleorApiUrl,
+    }).getAll();
 
     logger.info("Returning tax providers configuration");
 

--- a/apps/taxes/src/modules/provider-connections/public-provider-connections.service.ts
+++ b/apps/taxes/src/modules/provider-connections/public-provider-connections.service.ts
@@ -9,9 +9,25 @@ export class PublicProviderConnectionsService {
   private avataxConnectionService: PublicAvataxConnectionService;
   private taxJarConnectionService: PublicTaxJarConnectionService;
   private logger: Logger;
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
-    this.avataxConnectionService = new PublicAvataxConnectionService(client, appId, saleorApiUrl);
-    this.taxJarConnectionService = new PublicTaxJarConnectionService(client, appId, saleorApiUrl);
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
+    this.avataxConnectionService = new PublicAvataxConnectionService({
+      client,
+      appId,
+      saleorApiUrl,
+    });
+    this.taxJarConnectionService = new PublicTaxJarConnectionService({
+      client,
+      appId,
+      saleorApiUrl,
+    });
     this.logger = createLogger({
       name: "PublicProviderConnectionsService",
       metadataKey: TAX_PROVIDER_KEY,

--- a/apps/taxes/src/modules/taxjar/configuration/public-taxjar-connection.service.ts
+++ b/apps/taxes/src/modules/taxjar/configuration/public-taxjar-connection.service.ts
@@ -7,8 +7,16 @@ import { TaxJarConnectionService } from "./taxjar-connection.service";
 export class PublicTaxJarConnectionService {
   private readonly connectionService: TaxJarConnectionService;
   private readonly obfuscator = new TaxJarConnectionObfuscator();
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
-    this.connectionService = new TaxJarConnectionService(client, appId, saleorApiUrl);
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
+    this.connectionService = new TaxJarConnectionService({ client, appId, saleorApiUrl });
     this.obfuscator = new TaxJarConnectionObfuscator();
   }
 

--- a/apps/taxes/src/modules/taxjar/configuration/taxjar-connection.service.ts
+++ b/apps/taxes/src/modules/taxjar/configuration/taxjar-connection.service.ts
@@ -9,7 +9,15 @@ import { TaxJarValidationService } from "./taxjar-validation.service";
 export class TaxJarConnectionService {
   private logger: Logger;
   private taxJarConnectionRepository: TaxJarConnectionRepository;
-  constructor(client: Client, appId: string, saleorApiUrl: string) {
+  constructor({
+    client,
+    appId,
+    saleorApiUrl,
+  }: {
+    client: Client;
+    appId: string;
+    saleorApiUrl: string;
+  }) {
     this.logger = createLogger({
       name: "TaxJarConnectionService",
     });

--- a/apps/taxes/src/modules/taxjar/tax-code/taxjar-tax-codes.router.ts
+++ b/apps/taxes/src/modules/taxjar/tax-code/taxjar-tax-codes.router.ts
@@ -15,11 +15,11 @@ export const taxJarTaxCodesRouter = router({
       name: "taxjarTaxCodesRouter.getAllForId",
     });
 
-    const connectionService = new TaxJarConnectionService(
-      ctx.apiClient,
-      ctx.appId!,
-      ctx.saleorApiUrl
-    );
+    const connectionService = new TaxJarConnectionService({
+      appId: ctx.appId!,
+      client: ctx.apiClient,
+      saleorApiUrl: ctx.saleorApiUrl,
+    });
 
     const connection = await connectionService.getById(input.connectionId);
     const taxCodesService = new TaxJarTaxCodesService(connection.config);

--- a/apps/taxes/src/modules/taxjar/taxjar-connection.router.ts
+++ b/apps/taxes/src/modules/taxjar/taxjar-connection.router.ts
@@ -25,11 +25,11 @@ const postInputSchema = z.object({
 const protectedWithConfigurationService = protectedClientProcedure.use(({ next, ctx }) =>
   next({
     ctx: {
-      connectionService: new PublicTaxJarConnectionService(
-        ctx.apiClient,
-        ctx.appId!,
-        ctx.saleorApiUrl
-      ),
+      connectionService: new PublicTaxJarConnectionService({
+        appId: ctx.appId!,
+        client: ctx.apiClient,
+        saleorApiUrl: ctx.saleorApiUrl,
+      }),
     },
   })
 );

--- a/apps/taxes/src/modules/ui/app-section.tsx
+++ b/apps/taxes/src/modules/ui/app-section.tsx
@@ -26,9 +26,9 @@ const Description = ({
       <Text as="h3" variant="heading">
         {title}
       </Text>
-      <Text as="p" variant="body">
+      <Box fontWeight={"bodyMedium"} fontSize={"bodyMedium"}>
         {description}
-      </Text>
+      </Box>
     </Box>
   );
 };

--- a/apps/taxes/src/pages/providers/avatax/[id].tsx
+++ b/apps/taxes/src/pages/providers/avatax/[id].tsx
@@ -1,3 +1,4 @@
+import { Provider } from "jotai";
 import { AvataxInstructions } from "../../../modules/avatax/ui/avatax-instructions";
 import { EditAvataxConfiguration } from "../../../modules/avatax/ui/edit-avatax-configuration";
 import { AppColumns } from "../../../modules/ui/app-columns";
@@ -12,7 +13,9 @@ const EditAvataxPage = () => {
     <main>
       <AppColumns top={<Header />}>
         <AvataxInstructions />
-        <EditAvataxConfiguration />
+        <Provider>
+          <EditAvataxConfiguration />
+        </Provider>
       </AppColumns>
     </main>
   );

--- a/apps/taxes/src/pages/providers/avatax/index.tsx
+++ b/apps/taxes/src/pages/providers/avatax/index.tsx
@@ -1,7 +1,8 @@
 import { Box, Text } from "@saleor/macaw-ui/next";
+import { Provider } from "jotai";
+import { AvataxInstructions } from "../../../modules/avatax/ui/avatax-instructions";
 import { CreateAvataxConfiguration } from "../../../modules/avatax/ui/create-avatax-configuration";
 import { AppColumns } from "../../../modules/ui/app-columns";
-import { AvataxInstructions } from "../../../modules/avatax/ui/avatax-instructions";
 
 const Header = () => {
   return (
@@ -18,7 +19,9 @@ const NewAvataxPage = () => {
     <main>
       <AppColumns top={<Header />}>
         <AvataxInstructions />
-        <CreateAvataxConfiguration />
+        <Provider>
+          <CreateAvataxConfiguration />
+        </Provider>
       </AppColumns>
     </main>
   );


### PR DESCRIPTION
## Scope of the PR
![Zrzut ekranu 2023-07-24 o 09 34 48](https://github.com/saleor/apps/assets/44495184/9a6a54c5-e603-47da-ae62-db4a45a2e46b)

- Used the response of the address resolve endpoint to display formatting suggestions.
- Changed the configuration validation flow. The form is allowed to be saved when the address is correct.

## Note
I am looking for ways to improve the architecture around obfuscation. I found myself creating two procedures for basically the same action (e.g. validating the address), only because in one context, the values may be obfuscated, and in another, they may be not. If you have an idea how to improve it, please let me know.

## Checklist

- [ ] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
