### PR TITLE
feat: taxes map entity type

### DIFF
--- a/.changeset/chatty-mugs-accept.md
+++ b/.changeset/chatty-mugs-accept.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": minor
+---
+
+Added the possibility to pass entityUseCode as order `avataxEntityCode` metadata field. This makes tax exempting groups of customers possible.

--- a/apps/taxes/graphql/fragments/TaxBase.graphql
+++ b/apps/taxes/graphql/fragments/TaxBase.graphql
@@ -61,7 +61,7 @@ fragment TaxBase on TaxableObject {
   }
   sourceObject {
     ... on Checkout {
-      privateMetadata {
+      metadata {
         key
         value
       }
@@ -70,7 +70,7 @@ fragment TaxBase on TaxableObject {
       }
     }
     ... on Order {
-      privateMetadata {
+      metadata {
         key
         value
       }

--- a/apps/taxes/graphql/fragments/TaxBase.graphql
+++ b/apps/taxes/graphql/fragments/TaxBase.graphql
@@ -61,19 +61,13 @@ fragment TaxBase on TaxableObject {
   }
   sourceObject {
     ... on Checkout {
-      metadata {
-        key
-        value
-      }
+      avataxEntityCode: metafield(key: "avataxEntityCode")
       user {
         id
       }
     }
     ... on Order {
-      metadata {
-        key
-        value
-      }
+      avataxEntityCode: metafield(key: "avataxEntityCode")
       user {
         id
       }

--- a/apps/taxes/graphql/fragments/TaxBase.graphql
+++ b/apps/taxes/graphql/fragments/TaxBase.graphql
@@ -61,11 +61,19 @@ fragment TaxBase on TaxableObject {
   }
   sourceObject {
     ... on Checkout {
+      privateMetadata {
+        key
+        value
+      }
       user {
         id
       }
     }
     ... on Order {
+      privateMetadata {
+        key
+        value
+      }
       user {
         id
       }

--- a/apps/taxes/graphql/subscriptions/OrderCreated.graphql
+++ b/apps/taxes/graphql/subscriptions/OrderCreated.graphql
@@ -64,7 +64,7 @@ fragment OrderCreatedSubscription on Order {
       amount
     }
   }
-  privateMetadata {
+  metadata {
     key
     value
   }

--- a/apps/taxes/graphql/subscriptions/OrderCreated.graphql
+++ b/apps/taxes/graphql/subscriptions/OrderCreated.graphql
@@ -64,10 +64,7 @@ fragment OrderCreatedSubscription on Order {
       amount
     }
   }
-  metadata {
-    key
-    value
-  }
+  avataxEntityCode: metafield(key: "avataxEntityCode")
 }
 fragment OrderCreatedEventSubscription on Event {
   __typename

--- a/apps/taxes/graphql/subscriptions/OrderCreated.graphql
+++ b/apps/taxes/graphql/subscriptions/OrderCreated.graphql
@@ -64,6 +64,10 @@ fragment OrderCreatedSubscription on Order {
       amount
     }
   }
+  privateMetadata {
+    key
+    value
+  }
 }
 fragment OrderCreatedEventSubscription on Event {
   __typename

--- a/apps/taxes/src/mocks.ts
+++ b/apps/taxes/src/mocks.ts
@@ -6,7 +6,7 @@ export const defaultOrder: OrderCreatedSubscriptionFragment = {
     id: "VXNlcjoyMDg0NTEwNDEw",
     email: "happy.customer@saleor.io",
   },
-  privateMetadata: [],
+  metadata: [],
   created: "2023-05-25T09:18:55.203440+00:00",
   status: OrderStatus.Unfulfilled,
   channel: {

--- a/apps/taxes/src/mocks.ts
+++ b/apps/taxes/src/mocks.ts
@@ -6,6 +6,7 @@ export const defaultOrder: OrderCreatedSubscriptionFragment = {
     id: "VXNlcjoyMDg0NTEwNDEw",
     email: "happy.customer@saleor.io",
   },
+  privateMetadata: [],
   created: "2023-05-25T09:18:55.203440+00:00",
   status: OrderStatus.Unfulfilled,
   channel: {

--- a/apps/taxes/src/mocks.ts
+++ b/apps/taxes/src/mocks.ts
@@ -6,7 +6,7 @@ export const defaultOrder: OrderCreatedSubscriptionFragment = {
     id: "VXNlcjoyMDg0NTEwNDEw",
     email: "happy.customer@saleor.io",
   },
-  metadata: [],
+  avataxEntityCode: null,
   created: "2023-05-25T09:18:55.203440+00:00",
   status: OrderStatus.Unfulfilled,
   channel: {

--- a/apps/taxes/src/modules/avatax/avatax-client.ts
+++ b/apps/taxes/src/modules/avatax/avatax-client.ts
@@ -86,4 +86,11 @@ export class AvataxClient {
   async ping() {
     return this.client.ping();
   }
+
+  async getEntityUseCode(useCode: string) {
+    return this.client.listEntityUseCodes({
+      // https://developer.avalara.com/avatax/filtering-in-rest/
+      filter: `code eq ${useCode}`,
+    });
+  }
 }

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.test.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.test.ts
@@ -4,19 +4,8 @@ import { describe, expect, it, vi } from "vitest";
 
 const mockGetEntityUseCode = vi.fn();
 
-const mockedMetadata = [
-  {
-    key: "avataxEntityCode",
-    value: "entityCode",
-  },
-  {
-    key: "somethingElse",
-    value: "otherTestValue",
-  },
-];
-
 describe("AvataxEntityTypeMatcher", () => {
-  it("returns empty string when entity code is not present in metadata", async () => {
+  it("returns empty string when no entity code", async () => {
     const mockAvataxClient = {
       getEntityUseCode: mockGetEntityUseCode.mockReturnValue(
         Promise.resolve({ value: [{ code: "entityCode" }] })
@@ -24,7 +13,7 @@ describe("AvataxEntityTypeMatcher", () => {
     } as any as AvataxClient;
 
     const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
-    const result = await matcher.match([]);
+    const result = await matcher.match(null);
 
     expect(result).toBe("");
   });
@@ -35,7 +24,7 @@ describe("AvataxEntityTypeMatcher", () => {
 
     const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
 
-    const result = await matcher.match(mockedMetadata);
+    const result = await matcher.match("entityCode");
 
     expect(result).toBe("");
   });
@@ -48,7 +37,7 @@ describe("AvataxEntityTypeMatcher", () => {
 
     const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
 
-    const result = await matcher.match(mockedMetadata);
+    const result = await matcher.match("entityCode");
 
     expect(result).toBe("entityCode");
   });

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.test.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.test.ts
@@ -1,0 +1,55 @@
+import { AvataxClient } from "./avatax-client";
+import { AvataxEntityTypeMatcher } from "./avatax-entity-type-matcher";
+import { describe, expect, it, vi } from "vitest";
+
+const mockGetEntityUseCode = vi.fn();
+
+const mockedMetadata = [
+  {
+    key: "avataxEntityCode",
+    value: "entityCode",
+  },
+  {
+    key: "somethingElse",
+    value: "otherTestValue",
+  },
+];
+
+describe("AvataxEntityTypeMatcher", () => {
+  it("returns empty string when entity code is not present in metadata", async () => {
+    const mockAvataxClient = {
+      getEntityUseCode: mockGetEntityUseCode.mockReturnValue(
+        Promise.resolve({ value: [{ code: "entityCode" }] })
+      ),
+    } as any as AvataxClient;
+
+    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+    const result = await matcher.match([]);
+
+    expect(result).toBe("");
+  });
+  it("returns empty string when entity code is present in metadata but not in avatax", async () => {
+    const mockAvataxClient = {
+      getEntityUseCode: mockGetEntityUseCode.mockReturnValue(Promise.resolve({})),
+    } as any as AvataxClient;
+
+    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+
+    const result = await matcher.match(mockedMetadata);
+
+    expect(result).toBe("");
+  });
+  it("returns entity code when entity code is present in metadata and in avatax", async () => {
+    const mockAvataxClient = {
+      getEntityUseCode: mockGetEntityUseCode.mockReturnValue(
+        Promise.resolve({ value: [{ code: "entityCode" }] })
+      ),
+    } as any as AvataxClient;
+
+    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+
+    const result = await matcher.match(mockedMetadata);
+
+    expect(result).toBe("entityCode");
+  });
+});

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -2,8 +2,8 @@ import { Logger, createLogger } from "../../lib/logger";
 import { AvataxClient } from "./avatax-client";
 
 /*
- * // todo: document
  * Arbitrary key-value pair that is used to store the entity code in the metadata.
+ * see: https://docs.saleor.io/docs/3.x/developer/app-store/apps/taxes/avatax#mapping-the-entity-type
  */
 const AVATAX_ENTITY_CODE = "avataxEntityCode";
 
@@ -37,9 +37,10 @@ export class AvataxEntityTypeMatcher {
     return "";
   }
 
-  private async getEntityCode(entityCode: string) {
+  private async validateEntityCode(entityCode: string) {
     const result = await this.client.getEntityUseCode(entityCode);
 
+    // If verified, return the entity code. If not, return empty string.
     return result.value?.[0].code || this.returnFallback();
   }
 
@@ -51,9 +52,7 @@ export class AvataxEntityTypeMatcher {
     }
 
     try {
-      const value = await this.getEntityCode(entityCode);
-
-      return value;
+      return this.validateEntityCode(entityCode);
     } catch (error) {
       this.logger.debug({ error }, "Failed to verify entity code");
       return this.returnFallback();

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -7,7 +7,6 @@ import { AvataxClient } from "./avatax-client";
  */
 const AVATAX_ENTITY_CODE = "avataxEntityCode";
 
-// todo: test
 export class AvataxEntityTypeMatcher {
   private client: AvataxClient;
   private logger: Logger;

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -1,0 +1,62 @@
+import { Logger, createLogger } from "../../lib/logger";
+import { AvataxClient } from "./avatax-client";
+
+/*
+ * // todo: document
+ * Arbitrary key-value pair that is used to store the entity code in the metadata.
+ */
+const AVATAX_ENTITY_CODE = "avataxEntityCode";
+
+// todo: test
+export class AvataxEntityTypeMatcher {
+  private client: AvataxClient;
+  private logger: Logger;
+
+  constructor({ client }: { client: AvataxClient }) {
+    this.client = client;
+    this.logger = createLogger({
+      name: "AvataxEntityTypeMatcher",
+    });
+  }
+
+  private readEntityCodeFromMetadata(metadata: Array<{ key: string; value: string }>) {
+    const entityCodeMetadata = metadata.find(
+      (metadataItem) => metadataItem.key === AVATAX_ENTITY_CODE
+    );
+
+    if (!entityCodeMetadata) {
+      // Entity code will not always be present in the metadata. We don't want to throw an error.
+      return undefined;
+    }
+
+    return entityCodeMetadata.value;
+  }
+
+  private returnFallback() {
+    // Empty string will be treated as non existing entity code.
+    return "";
+  }
+
+  private async getEntityCode(entityCode: string) {
+    const result = await this.client.getEntityUseCode(entityCode);
+
+    return result.value?.[0].code || this.returnFallback();
+  }
+
+  async match(metadata: Array<{ key: string; value: string }> | undefined = []) {
+    const entityCode = this.readEntityCodeFromMetadata(metadata);
+
+    if (!entityCode) {
+      return this.returnFallback();
+    }
+
+    try {
+      const value = await this.getEntityCode(entityCode);
+
+      return value;
+    } catch (error) {
+      this.logger.debug({ error }, "Failed to verify entity code");
+      return this.returnFallback();
+    }
+  }
+}

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -18,19 +18,6 @@ export class AvataxEntityTypeMatcher {
     });
   }
 
-  private readEntityCodeFromMetadata(metadata: Array<{ key: string; value: string }>) {
-    const entityCodeMetadata = metadata.find(
-      (metadataItem) => metadataItem.key === AVATAX_ENTITY_CODE
-    );
-
-    if (!entityCodeMetadata) {
-      // Entity code will not always be present in the metadata. We don't want to throw an error.
-      return undefined;
-    }
-
-    return entityCodeMetadata.value;
-  }
-
   private returnFallback() {
     // Empty string will be treated as non existing entity code.
     return "";
@@ -43,9 +30,7 @@ export class AvataxEntityTypeMatcher {
     return result.value?.[0].code || this.returnFallback();
   }
 
-  async match(metadata: Array<{ key: string; value: string }> | undefined = []) {
-    const entityCode = this.readEntityCodeFromMetadata(metadata);
-
+  async match(entityCode: string | null | undefined) {
     if (!entityCode) {
       return this.returnFallback();
     }

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -106,7 +106,7 @@ const defaultTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    metadata: [],
+    avataxEntityCode: null,
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -106,7 +106,7 @@ const defaultTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    privateMetadata: [],
+    metadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -106,6 +106,7 @@ const defaultTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
+    privateMetadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -7,11 +7,11 @@ const mockGenerator = new AvataxCalculateTaxesMockGenerator();
 const avataxConfigMock = mockGenerator.generateAvataxConfig();
 
 describe("AvataxCalculateTaxesPayloadTransformer", () => {
-  it("returns document type of SalesInvoice", () => {
+  it("returns document type of SalesInvoice", async () => {
     const taxBaseMock = mockGenerator.generateTaxBase();
     const matchesMock = mockGenerator.generateTaxCodeMatches();
 
-    const payload = new AvataxCalculateTaxesPayloadTransformer().transform(
+    const payload = await new AvataxCalculateTaxesPayloadTransformer().transform(
       taxBaseMock,
       avataxConfigMock,
       matchesMock

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -19,11 +19,11 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
 
     expect(payload.model.type).toBe(DocumentType.SalesOrder);
   });
-  it("when discounts, calculates the sum of discounts", () => {
+  it("when discounts, calculates the sum of discounts", async () => {
     const taxBaseMock = mockGenerator.generateTaxBase({ discounts: [{ amount: { amount: 10 } }] });
     const matchesMock = mockGenerator.generateTaxCodeMatches();
 
-    const payload = new AvataxCalculateTaxesPayloadTransformer().transform(
+    const payload = await new AvataxCalculateTaxesPayloadTransformer().transform(
       taxBaseMock,
       avataxConfigMock,
       matchesMock
@@ -31,11 +31,13 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
 
     expect(payload.model.discount).toEqual(10);
   });
-  it("when no discounts, the sum of discount is 0", () => {
+  it("when no discounts, the sum of discount is 0", async () => {
+    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+    const avataxConfigMock = mockGenerator.generateAvataxConfig();
     const taxBaseMock = mockGenerator.generateTaxBase();
     const matchesMock = mockGenerator.generateTaxCodeMatches();
 
-    const payload = new AvataxCalculateTaxesPayloadTransformer().transform(
+    const payload = await new AvataxCalculateTaxesPayloadTransformer().transform(
       taxBaseMock,
       avataxConfigMock,
       matchesMock

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -27,7 +27,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
     const payloadLinesTransformer = new AvataxCalculateTaxesPayloadLinesTransformer();
     const avataxClient = new AvataxClient(avataxConfig);
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
-    const entityUseCode = await entityTypeMatcher.match(taxBase.sourceObject.metadata);
+    const entityUseCode = await entityTypeMatcher.match(taxBase.sourceObject.avataxEntityCode);
 
     return {
       model: {

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -13,7 +13,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
     /*
      * * For calculating taxes, we always use DocumentType.SalesOrder because it doesn't cause transaction recording.
      * * The full flow is described here: https://developer.avalara.com/ecommerce-integration-guide/sales-tax-badge/design-document-workflow/should-i-commit/
-     * * config.isDocumentRecordingEnabledEnabled is used to determine if the transaction should be recorded (hence if the document type should be SalesOrder).
+     * * config.isDocumentRecordingEnabled is used to determine if the transaction should be recorded (hence if the document type should be SalesOrder).
      * * Given that we never want to record the transaction in calculate taxes, we always return DocumentType.SalesOrder.
      */
     return DocumentType.SalesOrder;
@@ -27,7 +27,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
     const payloadLinesTransformer = new AvataxCalculateTaxesPayloadLinesTransformer();
     const avataxClient = new AvataxClient(avataxConfig);
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
-    const entityUseCode = await entityTypeMatcher.match(taxBase.sourceObject.privateMetadata);
+    const entityUseCode = await entityTypeMatcher.match(taxBase.sourceObject.metadata);
 
     return {
       model: {

--- a/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.test.ts
+++ b/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.test.ts
@@ -22,13 +22,13 @@ const transformer = new AvataxOrderCreatedPayloadTransformer();
 export const avataxConfigMock = mockGenerator.generateAvataxConfig();
 
 describe("AvataxOrderCreatedPayloadTransformer", () => {
-  it("returns document type of SalesInvoice when isDocumentRecordingEnabled is true", () => {
-    const payload = transformer.transform(orderMock, avataxConfigMock, []);
+  it("returns document type of SalesInvoice when isDocumentRecordingEnabled is true", async () => {
+    const payload = await transformer.transform(orderMock, avataxConfigMock, []);
 
     expect(payload.model.type).toBe(DocumentType.SalesInvoice);
   }),
-    it("returns document type of SalesOrder when isDocumentRecordingEnabled is false", () => {
-      const payload = transformer.transform(
+    it("returns document type of SalesOrder when isDocumentRecordingEnabled is false", async () => {
+      const payload = await transformer.transform(
         orderMock,
         {
           ...avataxConfigMock,
@@ -39,16 +39,17 @@ describe("AvataxOrderCreatedPayloadTransformer", () => {
 
       expect(payload.model.type).toBe(DocumentType.SalesOrder);
     });
-  it("returns lines with discounted: true when there are discounts", () => {
-    const payload = transformer.transform(discountedOrderMock, avataxConfigMock, []);
+  it("returns lines with discounted: true when there are discounts", async () => {
+    const payload = await transformer.transform(discountedOrderMock, avataxConfigMock, []);
 
     const linesWithoutShipping = payload.model.lines.slice(0, -1);
     const check = linesWithoutShipping.every((line) => line.discounted === true);
 
     expect(check).toBe(true);
   });
-  it("returns lines with discounted: false when there are no discounts", () => {
-    const payload = transformer.transform(orderMock, avataxConfigMock, []);
+  it("returns lines with discounted: false when there are no discounts", async () => {
+    const transformer = new AvataxOrderCreatedPayloadTransformer();
+    const payload = await transformer.transform(orderMock, avataxConfigMock, []);
 
     const linesWithoutShipping = payload.model.lines.slice(0, -1);
     const check = linesWithoutShipping.every((line) => line.discounted === false);

--- a/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
@@ -27,7 +27,7 @@ export class AvataxOrderCreatedPayloadTransformer {
     const linesTransformer = new AvataxOrderCreatedPayloadLinesTransformer();
     const avataxClient = new AvataxClient(avataxConfig);
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
-    const entityUseCode = await entityTypeMatcher.match(order.privateMetadata);
+    const entityUseCode = await entityTypeMatcher.match(order.metadata);
 
     return {
       model: {

--- a/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
@@ -2,10 +2,11 @@ import { DocumentType } from "avatax/lib/enums/DocumentType";
 import { OrderCreatedSubscriptionFragment } from "../../../../generated/graphql";
 import { discountUtils } from "../../taxes/discount-utils";
 import { avataxAddressFactory } from "../address-factory";
-import { CreateTransactionArgs } from "../avatax-client";
+import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxOrderCreatedPayloadLinesTransformer } from "./avatax-order-created-payload-lines-transformer";
+import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 
 export const SHIPPING_ITEM_CODE = "Shipping";
 
@@ -18,16 +19,20 @@ export class AvataxOrderCreatedPayloadTransformer {
 
     return DocumentType.SalesInvoice;
   }
-  transform(
+  async transform(
     order: OrderCreatedSubscriptionFragment,
     avataxConfig: AvataxConfig,
     matches: AvataxTaxCodeMatches
-  ): CreateTransactionArgs {
+  ): Promise<CreateTransactionArgs> {
     const linesTransformer = new AvataxOrderCreatedPayloadLinesTransformer();
+    const avataxClient = new AvataxClient(avataxConfig);
+    const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
+    const entityUseCode = await entityTypeMatcher.match(order.privateMetadata);
 
     return {
       model: {
         type: this.matchDocumentType(avataxConfig),
+        entityUseCode,
         customerCode:
           order.user?.id ??
           "" /* In Saleor Avatax plugin, the customer code is 0. In Taxes App, we set it to the user id. */,

--- a/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-created/avatax-order-created-payload-transformer.ts
@@ -27,7 +27,7 @@ export class AvataxOrderCreatedPayloadTransformer {
     const linesTransformer = new AvataxOrderCreatedPayloadLinesTransformer();
     const avataxClient = new AvataxClient(avataxConfig);
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
-    const entityUseCode = await entityTypeMatcher.match(order.metadata);
+    const entityUseCode = await entityTypeMatcher.match(order.avataxEntityCode);
 
     return {
       model: {

--- a/apps/taxes/src/modules/channel-configuration/ui/channel-section.tsx
+++ b/apps/taxes/src/modules/channel-configuration/ui/channel-section.tsx
@@ -1,3 +1,4 @@
+import { Text } from "@saleor/macaw-ui/next";
 import { Section } from "../../ui/app-section";
 import { ChannelList } from "./channel-list";
 import { AppDashboardLink } from "../../ui/app-dashboard-link";
@@ -9,15 +10,17 @@ const Intro = () => {
       data-testid="channel-intro"
       description={
         <>
-          This table displays all the channels configured to use the tax app as the tax calculation
-          method.
-          <br />
-          <br />
-          You can change the tax configuration method for each channel in the{" "}
-          <AppDashboardLink data-testid="configuration-taxes-text-link" href="/taxes/channels">
-            Configuration → Taxes
-          </AppDashboardLink>{" "}
-          view.
+          <Text as="p" marginBottom={4}>
+            This table displays all the channels configured to use the tax app as the tax
+            calculation method.
+          </Text>
+          <Text as="p">
+            You can change the tax configuration method for each channel in the{" "}
+            <AppDashboardLink data-testid="configuration-taxes-text-link" href="/taxes/channels">
+              Configuration → Taxes
+            </AppDashboardLink>{" "}
+            view.
+          </Text>
         </>
       }
     />

--- a/apps/taxes/src/modules/provider-connections/ui/providers-section.tsx
+++ b/apps/taxes/src/modules/provider-connections/ui/providers-section.tsx
@@ -1,6 +1,7 @@
 import { TextLink } from "@saleor/apps-ui";
 import { Section } from "../../ui/app-section";
 import { ProvidersList } from "./providers-list";
+import { Text } from "@saleor/macaw-ui/next";
 
 const Intro = () => {
   return (
@@ -9,18 +10,20 @@ const Intro = () => {
       data-testid="providers-intro"
       description={
         <>
-          Saleor offers two ways of calculating taxes: flat or dynamic rates.
-          <br />
-          <br />
-          Taxes App leverages the dynamic rates by delegating the tax calculation to third-party
-          services.
-          <br />
-          <br />
-          You can read more about how Saleor deals with taxes in{" "}
-          <TextLink newTab href="https://docs.saleor.io/docs/3.x/developer/taxes">
-            our documentation
-          </TextLink>
-          .
+          <Text as="p" marginBottom={4}>
+            Saleor offers two ways of calculating taxes: flat or dynamic rates.
+          </Text>
+          <Text as="p" marginBottom={4}>
+            Taxes App leverages the dynamic rates by delegating the tax calculation to third-party
+            services.
+          </Text>
+          <Text as="p">
+            You can read more about how Saleor deals with taxes in{" "}
+            <TextLink newTab href="https://docs.saleor.io/docs/3.x/developer/taxes">
+              our documentation
+            </TextLink>
+            .
+          </Text>
         </>
       }
     />

--- a/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
@@ -95,7 +95,7 @@ const taxIncludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    privateMetadata: [],
+    metadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },
@@ -193,7 +193,7 @@ const taxExcludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    privateMetadata: [],
+    metadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
@@ -95,7 +95,7 @@ const taxIncludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    metadata: [],
+    avataxEntityCode: null,
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },
@@ -193,7 +193,7 @@ const taxExcludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
-    metadata: [],
+    avataxEntityCode: null,
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
@@ -95,6 +95,7 @@ const taxIncludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
+    privateMetadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },
@@ -148,6 +149,7 @@ const taxExcludedTaxBase: TaxBase = {
       sourceLine: {
         __typename: "OrderLine",
         id: "T3JkZXJMaW5lOjUxZDc2ZDY1LTFhYTgtNGEzMi1hNWJhLTJkZDMzNjVhZDhlZQ==",
+
         orderProductVariant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzQ5",
           product: {
@@ -170,6 +172,7 @@ const taxExcludedTaxBase: TaxBase = {
       sourceLine: {
         __typename: "OrderLine",
         id: "T3JkZXJMaW5lOjlhMGJjZDhmLWFiMGQtNDJhOC04NTBhLTEyYjQ2YjJiNGIyZg==",
+
         orderProductVariant: {
           id: "UHJvZHVjdFZhcmlhbnQ6MzQw",
           product: {
@@ -190,6 +193,7 @@ const taxExcludedTaxBase: TaxBase = {
     },
   ],
   sourceObject: {
+    privateMetadata: [],
     user: {
       id: "VXNlcjoyMDg0NTEwNDEw",
     },

--- a/apps/taxes/src/modules/taxjar/ui/taxjar-instructions.tsx
+++ b/apps/taxes/src/modules/taxjar/ui/taxjar-instructions.tsx
@@ -8,11 +8,13 @@ export const TaxJarInstructions = () => {
       title={"TaxJar Configuration"}
       description={
         <>
-          The form consists of two sections: <i>Credentials</i> and <i>Address</i>.
-          <br />
-          <br />
-          <i>Credentials</i> will fail if:
-          <Box as="ol" margin={0}>
+          <Text as="p" marginBottom={4}>
+            The form consists of two sections: <i>Credentials</i> and <i>Address</i>.
+          </Text>
+          <Text as="p">
+            <i>Credentials</i> will fail if:
+          </Text>
+          <Box as="ol" margin={0} marginBottom={4}>
             <li>
               <Text>- The API Key is incorrect.</Text>
             </li>
@@ -20,10 +22,10 @@ export const TaxJarInstructions = () => {
               <Text>- The API Key does not match &quot;sandbox mode&quot; setting.</Text>
             </li>
           </Box>
-          <br />
-          <br />
-          <i>Address</i> will fail if:
-          <Box as="ol" margin={0}>
+          <Text as="p" marginBottom={4}>
+            <i>Address</i> will fail if:
+          </Text>
+          <Box as="ol" margin={0} marginBottom={4}>
             <li>
               <Text>
                 - The address does not match{" "}
@@ -34,13 +36,13 @@ export const TaxJarInstructions = () => {
               </Text>
             </li>
           </Box>
-          <br />
-          <br />
-          If the configuration fails, please visit the{" "}
-          <TextLink href="https://developers.taxjar.com/api/reference/" newTab>
-            TaxJar documentation
-          </TextLink>
-          .
+          <Text as="p" marginBottom={4}>
+            If the configuration fails, please visit the{" "}
+            <TextLink href="https://developers.taxjar.com/api/reference/" newTab>
+              TaxJar documentation
+            </TextLink>
+            .
+          </Text>
         </>
       }
     />


### PR DESCRIPTION
## Scope of the PR

### Context

By providing the value for the Order metadata field of key `avataxEntityCode`, you can attach [`entityUseCode`](https://developer.avalara.com/erp-integration-guide/sales-tax-badge/designing/entity-code/) to transactions that will be created in Avatax. You can use this feature to, f.e., mark the customers that should be tax-exempted.

### Features
- added `metadata` to webhook orders
- added `AvataxEntityTypeMatcher` class that handles the entire logic of retrieving the entity code from metadata and validating it against Avatax API
- removed missed `<br />s` from instructions

## Related issues

https://github.com/saleor/appstore/issues/216

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
