### PR TITLE
EAM: Add AWS credentials validation

### DIFF
--- a/.changeset/mean-ghosts-beam.md
+++ b/.changeset/mean-ghosts-beam.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": patch
+---
+
+Added validation for AWS credentials. If provided configuration for S3 Bucket is invalid, it won't be saved.

--- a/apps/products-feed/src/modules/file-storage/s3/check-bucket-access.ts
+++ b/apps/products-feed/src/modules/file-storage/s3/check-bucket-access.ts
@@ -1,0 +1,15 @@
+import { HeadBucketCommand, S3Client } from "@aws-sdk/client-s3";
+
+interface checkBucketAccessArgs {
+  s3Client: S3Client;
+  bucketName: string;
+}
+
+// Check if client can access the bucket. Throws an error otherwise
+export const checkBucketAccess = async ({ s3Client, bucketName }: checkBucketAccessArgs) => {
+  await s3Client.send(
+    new HeadBucketCommand({
+      Bucket: bucketName,
+    })
+  );
+};


### PR DESCRIPTION
## Scope of the PR

- validate AWS credentials on save and prevent users from saving invalid configuration
- add button to test existing configurtion

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
