### PR TITLE
feat: Avatax metadata document code

### DIFF
--- a/.changeset/forty-shirts-battle.md
+++ b/.changeset/forty-shirts-battle.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": minor
+---
+
+Added support for reading document code from metadata field `avataxDocumentCode`. The default value is the order id from Saleor.

--- a/apps/taxes/graphql/subscriptions/OrderConfirmed.graphql
+++ b/apps/taxes/graphql/subscriptions/OrderConfirmed.graphql
@@ -66,6 +66,7 @@ fragment OrderConfirmedSubscription on Order {
   }
   avataxEntityCode: metafield(key: "avataxEntityCode")
   avataxTaxCalculationDate: metafield(key: "avataxTaxCalculationDate")
+  avataxDocumentCode: metafield(key: "avataxDocumentCode")
 }
 fragment OrderConfirmedEventSubscription on Event {
   __typename

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-document-code-resolver.test.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-document-code-resolver.test.ts
@@ -1,0 +1,23 @@
+import { OrderConfirmedSubscriptionFragment } from "../../../../generated/graphql";
+import { AvataxOrderConfirmedDocumentCodeResolver } from "./avatax-order-confirmed-document-code-resolver";
+import { expect, describe, it } from "vitest";
+
+const resolver = new AvataxOrderConfirmedDocumentCodeResolver();
+
+describe("AvataxOrderConfirmedDocumentCodeResolver", () => {
+  it("returns document code when provided in metadata", () => {
+    expect(
+      resolver.resolve({
+        id: "id",
+        avataxDocumentCode: "123",
+      } as unknown as OrderConfirmedSubscriptionFragment)
+    ).toBe("123");
+  });
+  it("returns order id when document code is not provided in metadata", () => {
+    expect(
+      resolver.resolve({
+        id: "id",
+      } as unknown as OrderConfirmedSubscriptionFragment)
+    ).toBe("id");
+  });
+});

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-document-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-document-code-resolver.ts
@@ -1,0 +1,11 @@
+import { OrderConfirmedSubscriptionFragment } from "../../../../generated/graphql";
+
+export class AvataxOrderConfirmedDocumentCodeResolver {
+  resolve(order: OrderConfirmedSubscriptionFragment): string {
+    /*
+     * The value for "code" can be provided in the metadata.
+     * Read more: https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/
+     */
+    return order.avataxDocumentCode ?? order.id;
+  }
+}

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -8,6 +8,7 @@ import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-reposito
 import { AvataxOrderConfirmedPayloadLinesTransformer } from "./avatax-order-confirmed-payload-lines-transformer";
 import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 import { AvataxOrderConfirmedCalculationDateResolver } from "./avatax-order-confirmed-calculation-date-resolver";
+import { AvataxOrderConfirmedDocumentCodeResolver } from "./avatax-order-confirmed-document-code-resolver";
 
 export const SHIPPING_ITEM_CODE = "Shipping";
 
@@ -31,12 +32,15 @@ export class AvataxOrderConfirmedPayloadTransformer {
     const linesTransformer = new AvataxOrderConfirmedPayloadLinesTransformer();
     const dateResolver = new AvataxOrderConfirmedCalculationDateResolver();
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
+    const documentCodeResolver = new AvataxOrderConfirmedDocumentCodeResolver();
 
     const entityUseCode = await entityTypeMatcher.match(order.avataxEntityCode);
     const date = dateResolver.resolve(order);
+    const code = documentCodeResolver.resolve(order);
 
     return {
       model: {
+        code,
         type: this.matchDocumentType(avataxConfig),
         entityUseCode,
         customerCode:


### PR DESCRIPTION
## Scope of the PR

- Added support for reading document code from metadata field `avataxDocumentCode`. The default value is the order id from Saleor.

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
