### PR TITLE
Improve logging on tRPC routes

### DIFF
--- a/.changeset/thick-chairs-learn.md
+++ b/.changeset/thick-chairs-learn.md
@@ -1,0 +1,10 @@
+---
+"saleor-app-emails-and-messages": patch
+"saleor-app-products-feed": patch
+"saleor-app-invoices": patch
+"saleor-app-cms-v2": patch
+"saleor-app-taxes": patch
+"saleor-app-crm": patch
+---
+
+Added error logging for exceptions thrown at tRPC routes.

--- a/apps/cms-v2/src/pages/api/trpc/[trpc].ts
+++ b/apps/cms-v2/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });

--- a/apps/crm/src/pages/api/trpc/[trpc].ts
+++ b/apps/crm/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });

--- a/apps/emails-and-messages/src/pages/api/trpc/[trpc].ts
+++ b/apps/emails-and-messages/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });

--- a/apps/invoices/src/pages/api/trpc/[trpc].ts
+++ b/apps/invoices/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });

--- a/apps/products-feed/src/pages/api/trpc/[trpc].ts
+++ b/apps/products-feed/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });

--- a/apps/taxes/src/pages/api/trpc/[trpc].ts
+++ b/apps/taxes/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,18 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
+import { createLogger } from "@saleor/apps-shared";
+
+const logger = createLogger({ name: "tRPC error" });
 
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      logger.error(error, `${path} returned error:`);
+      return;
+    }
+    logger.debug(error, `${path} returned error:`);
+  },
 });


### PR DESCRIPTION
## Scope of the PR

By default tRPC does not log unexpected errors on tRPC routes.

Proposed change:
- logs INTERNAL SERVER ERROR as `error` log level, so even the production env will log it
- rest of the errors have asigned `debug` level, so validation errors, unauthorized, etc will be visible on development envs

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [x] `.github/dependabot.yaml` is up-to date.
- [x] I added changesets and [read good practices](/.changeset/README.md).
