### PR TITLE
Add mandatory check for the changeset

### DIFF
--- a/.github/workflows/changeset-checker.yml
+++ b/.github/workflows/changeset-checker.yml
@@ -1,12 +1,18 @@
-name: Changeset checker
+name: Changesets
 
 on:
   pull_request:
+    types:
+      - opened
+      - labeled
+      - edited
     branches-ignore:    
       - 'changeset-release/**'
 jobs:
-  changeset_checker:
-    name: Changeset checker
+  changeset_check:
+    name: Changeset added to the PR
+    # Adding 'skip changesets' label to the PR will skip this job
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip changesets') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/changeset-checker.yml
+++ b/.github/workflows/changeset-checker.yml
@@ -1,0 +1,24 @@
+name: Changeset checker
+
+on:
+  pull_request:
+    branches-ignore:    
+      - 'changeset-release/**'
+jobs:
+  changeset_checker:
+    name: Changeset checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # check out full history
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v2.2.4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Changeset added
+        run: npx changeset status --since origin/main

--- a/.github/workflows/changeset-checker.yml
+++ b/.github/workflows/changeset-checker.yml
@@ -6,13 +6,14 @@ on:
       - opened
       - labeled
       - edited
+      - synchronize
     branches-ignore:    
       - 'changeset-release/**'
 jobs:
   changeset_check:
     name: Changeset added to the PR
     # Adding 'skip changesets' label to the PR will skip this job
-    if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip changesets') }}
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip changeset') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Scope of the PR

The action checks if PR has added a changeset. Check is skipped for the release branch.

PR without added changeset fails:
![image](https://github.com/saleor/apps/assets/5188636/dd831b10-1513-4280-89a9-407538932016)
![image](https://github.com/saleor/apps/assets/5188636/962126b9-5631-4480-8b66-e837469b58a4)

After adding the changeset:
![image](https://github.com/saleor/apps/assets/5188636/62c30ef8-9445-4876-8287-5367ba4418f2)


Adding `skip changesets` label will turn the check off.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
