### PR TITLE
Product feed - change max function exec time to 5 minutes

### DIFF
--- a/.changeset/tender-seas-hunt.md
+++ b/.changeset/tender-seas-hunt.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": patch
+---
+
+Changed Vercel's maximum execution time to be 5 minutes for feed generation. This should help with the previous limits of 60s, that was not enough for feed to be generated.

--- a/apps/products-feed/src/pages/api/feed/[url]/[channel]/google.xml.ts
+++ b/apps/products-feed/src/pages/api/feed/[url]/[channel]/google.xml.ts
@@ -16,6 +16,10 @@ import { getDownloadUrl, getFileName } from "../../../../../modules/file-storage
 import { RootConfig } from "../../../../../modules/app-configuration/app-config";
 import { z, ZodError } from "zod";
 
+export const config = {
+  maxDuration: 5,
+};
+
 // By default we cache the feed for 5 minutes. This can be changed by setting the FEED_CACHE_MAX_AGE
 const FEED_CACHE_MAX_AGE = process.env.FEED_CACHE_MAX_AGE
   ? parseInt(process.env.FEED_CACHE_MAX_AGE, 10)


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->

https://vercel.com/docs/functions/serverless-functions/runtimes#maxduration

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
