### PR TITLE
fix: cannot resolve customer code in Taxes App

### DIFF
--- a/.changeset/cold-trainers-help.md
+++ b/.changeset/cold-trainers-help.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": minor
+---
+
+Fixed the issue with the app throwing errors when no customer code was resolved. Now, it falls back to "0" which is the recommended dummy value for when it's impossible to identify a customer (e.g. in an anonymous checkout).

--- a/apps/taxes/graphql/fragments/TaxBase.graphql
+++ b/apps/taxes/graphql/fragments/TaxBase.graphql
@@ -63,11 +63,15 @@ fragment TaxBase on TaxableObject {
     __typename
     ... on Checkout {
       avataxEntityCode: metafield(key: "avataxEntityCode")
-      email
+      user {
+        id
+      }
     }
     ... on Order {
       avataxEntityCode: metafield(key: "avataxEntityCode")
-      userEmail
+      user {
+        id
+      }
     }
   }
 }

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.test.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { CalculateTaxesPayload } from "../../pages/api/webhooks/checkout-calculate-taxes";
+import { AvataxCustomerCodeResolver } from "./avatax-customer-code-resolver";
+import {
+  OrderConfirmedEventSubscriptionFragment,
+  OrderConfirmedSubscriptionFragment,
+} from "../../../generated/graphql";
+
+const idOrderPayload = {
+  user: {
+    id: "123",
+  },
+} as unknown as OrderConfirmedSubscriptionFragment;
+
+const noIdOrderPayload = {} as unknown as OrderConfirmedSubscriptionFragment;
+
+const noIdCalculateTaxesCheckoutPayload = {
+  taxBase: {
+    sourceObject: {
+      __typename: "Checkout",
+    },
+  },
+} as unknown as CalculateTaxesPayload;
+
+const idCalculateTaxesCheckoutPayload = {
+  taxBase: {
+    sourceObject: {
+      __typename: "Checkout",
+      user: {
+        id: "123",
+      },
+    },
+  },
+} as unknown as CalculateTaxesPayload;
+
+const noIdCalculateTaxesOrderPayload = {
+  taxBase: {
+    sourceObject: {
+      __typename: "Order",
+    },
+  },
+} as unknown as CalculateTaxesPayload;
+
+const idCalculateTaxesOrderPayload = {
+  taxBase: {
+    sourceObject: {
+      __typename: "Order",
+      user: {
+        id: "123",
+      },
+    },
+  },
+} as unknown as CalculateTaxesPayload;
+
+const resolver = new AvataxCustomerCodeResolver();
+
+describe("AvataxCustomerCodeResolver", () => {
+  describe("resolveOrderCustomerCode", () => {
+    it("returns user id when present in sourceObject", () => {
+      const customerCode = resolver.resolveOrderCustomerCode(idOrderPayload);
+
+      expect(customerCode).toBe("123");
+    });
+    it("returns 0 when no user id", () => {
+      const customerCode = resolver.resolveOrderCustomerCode(noIdOrderPayload);
+
+      expect(customerCode).toBe("0");
+    });
+  });
+  describe("resolveCalculateTaxesCustomerCode", () => {
+    describe("when checkout", () => {
+      it("returns user id when present in sourceObject", () => {
+        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
+          idCalculateTaxesCheckoutPayload,
+        );
+
+        expect(customerCode).toBe("123");
+        it("returns 0 when no user id", () => {
+          const customerCode = resolver.resolveCalculateTaxesCustomerCode(
+            noIdCalculateTaxesCheckoutPayload,
+          );
+
+          expect(customerCode).toBe("0");
+        });
+      });
+    });
+    describe("when order", () => {
+      it("returns user id when present in sourceObject", () => {
+        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
+          idCalculateTaxesOrderPayload,
+        );
+
+        expect(customerCode).toBe("123");
+      });
+      it("returns 0 when no user id", () => {
+        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
+          noIdCalculateTaxesOrderPayload,
+        );
+
+        expect(customerCode).toBe("0");
+      });
+    });
+  });
+});

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -1,0 +1,32 @@
+import { OrderConfirmedSubscriptionFragment } from "../../../generated/graphql";
+import { taxProviderUtils } from "../taxes/tax-provider-utils";
+import { TaxBadPayloadError } from "../taxes/tax-error";
+import { CalculateTaxesPayload } from "../../pages/api/webhooks/checkout-calculate-taxes";
+
+export class AvataxCustomerCodeResolver {
+  resolveOrderCustomerCode(order: OrderConfirmedSubscriptionFragment) {
+    return taxProviderUtils.resolveStringOrThrow(
+      order.user?.id,
+      new TaxBadPayloadError("Cannot resolve user id"),
+    );
+  }
+
+  // During the checkout process, it appears the customer id is not always available. We can use the email address instead.
+  resolveCalculateTaxesCustomerCode(payload: CalculateTaxesPayload): string {
+    if (payload.taxBase.sourceObject.__typename === "Checkout") {
+      return taxProviderUtils.resolveStringOrThrow(
+        payload.taxBase.sourceObject.email,
+        new TaxBadPayloadError("Cannot resolve email from sourceObject"),
+      );
+    }
+
+    if (payload.taxBase.sourceObject.__typename === "Order") {
+      return taxProviderUtils.resolveStringOrThrow(
+        payload.taxBase.sourceObject.userEmail,
+        new TaxBadPayloadError("Cannot resolve userEmail from sourceObject"),
+      );
+    }
+
+    throw new TaxBadPayloadError("Cannot resolve customer code");
+  }
+}

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -1,32 +1,18 @@
 import { OrderConfirmedSubscriptionFragment } from "../../../generated/graphql";
-import { taxProviderUtils } from "../taxes/tax-provider-utils";
-import { TaxBadPayloadError } from "../taxes/tax-error";
 import { CalculateTaxesPayload } from "../../pages/api/webhooks/checkout-calculate-taxes";
 
 export class AvataxCustomerCodeResolver {
+  /*
+   * "If you're creating a sales order for a customer that does not yet exist in your system, you can send a dummyCustomerCode as sales orders are not recorded."
+   * https://developer.avalara.com/ecommerce-integration-guide/sales-tax-badge/transactions/simple-transactions/
+   */
+  private fallbackCustomerCode = "0";
+
   resolveOrderCustomerCode(order: OrderConfirmedSubscriptionFragment) {
-    return taxProviderUtils.resolveStringOrThrow(
-      order.user?.id,
-      new TaxBadPayloadError("Cannot resolve user id"),
-    );
+    return order.user?.id ?? this.fallbackCustomerCode;
   }
 
-  // During the checkout process, it appears the customer id is not always available. We can use the email address instead.
   resolveCalculateTaxesCustomerCode(payload: CalculateTaxesPayload): string {
-    if (payload.taxBase.sourceObject.__typename === "Checkout") {
-      return taxProviderUtils.resolveStringOrThrow(
-        payload.taxBase.sourceObject.email,
-        new TaxBadPayloadError("Cannot resolve email from sourceObject"),
-      );
-    }
-
-    if (payload.taxBase.sourceObject.__typename === "Order") {
-      return taxProviderUtils.resolveStringOrThrow(
-        payload.taxBase.sourceObject.userEmail,
-        new TaxBadPayloadError("Cannot resolve userEmail from sourceObject"),
-      );
-    }
-
-    throw new TaxBadPayloadError("Cannot resolve customer code");
+    return payload.taxBase.sourceObject.user?.id ?? this.fallbackCustomerCode;
   }
 }

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -108,7 +108,9 @@ const defaultTaxBase: TaxBase = {
   sourceObject: {
     avataxEntityCode: null,
     __typename: "Checkout",
-    email: "test@saleor.io",
+    user: {
+      id: "123",
+    },
   },
 };
 

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -66,40 +66,4 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
 
     expect(payload.model.discount).toEqual(0);
   });
-  it("when no email in sourceObject, throws an error", async () => {
-    const taxBaseMock = mockGenerator.generateTaxBase({
-      sourceObject: { email: undefined, __typename: "Checkout" },
-    });
-    const matchesMock = mockGenerator.generateTaxCodeMatches();
-
-    const payloadMock = {
-      taxBase: taxBaseMock,
-    } as unknown as CalculateTaxesPayload;
-
-    await expect(
-      new AvataxCalculateTaxesPayloadTransformer().transform(
-        payloadMock,
-        avataxConfigMock,
-        matchesMock,
-      ),
-    ).rejects.toThrow("Cannot resolve email from sourceObject");
-  });
-  it("when no userEmail in sourceObject, throws an error", async () => {
-    const taxBaseMock = mockGenerator.generateTaxBase({
-      sourceObject: { userEmail: undefined, __typename: "Order" },
-    });
-    const matchesMock = mockGenerator.generateTaxCodeMatches();
-
-    const payloadMock = {
-      taxBase: taxBaseMock,
-    } as unknown as CalculateTaxesPayload;
-
-    await expect(
-      new AvataxCalculateTaxesPayloadTransformer().transform(
-        payloadMock,
-        avataxConfigMock,
-        matchesMock,
-      ),
-    ).rejects.toThrow("Cannot resolve userEmail from sourceObject");
-  });
 });

--- a/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
@@ -97,7 +97,9 @@ const taxIncludedTaxBase: TaxBase = {
   sourceObject: {
     avataxEntityCode: null,
     __typename: "Checkout",
-    email: "test@saleor.io",
+    user: {
+      id: "123",
+    },
   },
 };
 
@@ -194,7 +196,9 @@ const taxExcludedTaxBase: TaxBase = {
   sourceObject: {
     avataxEntityCode: null,
     __typename: "Checkout",
-    email: "test@saleor.io",
+    user: {
+      id: "123",
+    },
   },
 };
 

--- a/cspell.json
+++ b/cspell.json
@@ -83,6 +83,7 @@
     "**/*.spec.ts",
     "**/graphql.ts",
     "**/CHANGELOG.md",
-    "**/schema.graphql"
+    "**/schema.graphql",
+    "**/*-generator.ts"
   ]
 }


### PR DESCRIPTION
**Featuring**:
- Extracted the logic of resolving the `customerCode` AvaTax field to a shared class. Now, instead of throwing an error, we return the recommended dummy value. It happens when there is no user id in checkout/order.

**Note**:
I updated the `TaxBase` fragment, but there is no need to perform migrations because we fall back to "0" (which is the default value in the AvaTax plugin anyway). 