### PR TITLE
Change heading level of "other official apps" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ In the `apps` folder, you will find the following applications:
 - [slack](./apps/slack) - get notifications on Slack channel from Saleor events.
 - [taxes](https://docs.saleor.io/docs/3.x/developer/app-store/apps/taxes/overview) - calculate order and checkout taxes using external services.
 
-## Another official apps
+#### Other official apps
 
-Some of Saleor apps are available in separate repositories:
+Some of the Saleor apps are available in separate repositories:
 - [Stripe](https://github.com/saleor/saleor-app-payment-stripe)
 
 ## Development


### PR DESCRIPTION
The "Another official apps" heading is bigger than the "apps list" heading. IMO, it should be a sub-heading