### PR TITLE
Apply override for vulnerable crypto-js versions

### DIFF
--- a/.changeset/dirty-crabs-count.md
+++ b/.changeset/dirty-crabs-count.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-invoices": patch
+---
+
+Updated `crypto-js` package used as a nested dependency of `microinvoice`. This update resolves `CVE-2023-46233` vulnerability.

--- a/apps/invoices/package.json
+++ b/apps/invoices/package.json
@@ -62,6 +62,11 @@
     "vite": "4.4.8",
     "vitest": "0.34.1"
   },
+  "pnpm": {
+    "overrides": {
+      "crypto-js@<4.2.0": ">=4.2.0"
+    }
+  },
   "private": true,
   "saleor": {
     "schemaVersion": "3.10"

--- a/apps/invoices/package.json
+++ b/apps/invoices/package.json
@@ -62,11 +62,6 @@
     "vite": "4.4.8",
     "vitest": "0.34.1"
   },
-  "pnpm": {
-    "overrides": {
-      "crypto-js@<4.2.0": ">=4.2.0"
-    }
-  },
   "private": true,
   "saleor": {
     "schemaVersion": "3.10"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "packageManager": "pnpm@8.7.4",
   "pnpm": {
     "overrides": {
-      "@saleor/app-sdk": "0.43.1"
+      "@saleor/app-sdk": "0.43.1",
+      "crypto-js@<4.2.0": ">=4.2.0"
     }
   },
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,12 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@saleor/app-sdk': 0.43.1
+  crypto-js@<4.2.0: '>=4.2.0'
 
 importers:
 
@@ -13480,8 +13485,8 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  /crypto-js@4.1.1:
-    resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
+  /crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
     dev: false
 
   /crypto-random-string@2.0.0:
@@ -19059,7 +19064,7 @@ packages:
   /pdfkit@0.12.3:
     resolution: {integrity: sha512-+qDLgm2yq6WOKcxTb43lDeo3EtMIDQs0CK1RNqhHC9iT6u0KOmgwAClkYh9xFw2ATbmUZzt4f7KMwDCOfPDluA==}
     dependencies:
-      crypto-js: 4.1.1
+      crypto-js: 4.2.0
       fontkit: 1.9.0
       linebreak: 1.1.0
       png-js: 1.0.0
@@ -22826,7 +22831,3 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Scope of the PR

This PR resolves Dependabot security alert due to `crypto-js` critical vulrability: https://github.com/saleor/apps/security/dependabot/44

## Related issues

CVE-2023-46233
