### PR TITLE
Update checkout workflow to fix build on release PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
         # Tags are fetched for Changeset to distinguish from new ones while running `changeset tag`
       - name: Git fetch tags 
         run: git fetch --tags origin


### PR DESCRIPTION
## Scope of the PR

It makes force-pushes by changesets done by PAT user, instead github-actions token. Thanks to that, force push can trigger workflow (like build)

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
