### PR TITLE
Add weight attribute to the product feed

### DIFF
--- a/.changeset/young-papayas-sin.md
+++ b/.changeset/young-papayas-sin.md
@@ -1,0 +1,7 @@
+---
+"saleor-app-products-feed": minor
+---
+
+Added "weight" attribute to the Google product feed.
+
+The attribute is added to the item entry when weight is defined and product is marked as requiring a shipping.

--- a/apps/products-feed/graphql/fragments/GoogleFeedProductVariantFragment.graphql
+++ b/apps/products-feed/graphql/fragments/GoogleFeedProductVariantFragment.graphql
@@ -2,6 +2,10 @@ fragment GoogleFeedProductVariant on ProductVariant {
   id
   name
   sku
+  weight {
+    unit
+    value
+  }
   pricing {
     priceUndiscounted{
       gross {
@@ -32,6 +36,9 @@ fragment GoogleFeedProductVariant on ProductVariant {
     slug
     description
     seoDescription
+    productType {
+      isShippingRequired
+    }
     media{
       id
       alt

--- a/apps/products-feed/src/modules/app-configuration/example-variant-data.ts
+++ b/apps/products-feed/src/modules/app-configuration/example-variant-data.ts
@@ -1,7 +1,7 @@
 import { GoogleFeedProductVariantFragment } from "../../../generated/graphql";
 
 export const exampleVariantData: GoogleFeedProductVariantFragment = {
-  id: "UHJvZHVjdFZhcmlhbnQ6MzYx",
+  id: "UHJvZHVjdFZhcmlhbnQ6MzYx", // cspell:disable-line
   name: "M",
   sku: "218223580",
   pricing: {
@@ -16,7 +16,7 @@ export const exampleVariantData: GoogleFeedProductVariantFragment = {
   attributes: [
     {
       attribute: {
-        id: "QXR0cmlidXRlOjM4",
+        id: "QXR0cmlidXRlOjM4", // cspell:disable-line
       },
       values: [
         {
@@ -33,10 +33,13 @@ export const exampleVariantData: GoogleFeedProductVariantFragment = {
     description:
       '{"time": 1653425319677, "blocks": [{"id": "sMEIn2NR8s", "data": {"text": "<b>Ever have those days where you feel a bit geometric?</b> Can\'t quite shape yourself up right? Show your different sides with a Saleor styles."}, "type": "paragraph"}], "version": "2.22.2"}',
     seoDescription: "",
+    productType: {
+      isShippingRequired: true,
+    },
     attributes: [
       {
         attribute: {
-          id: "QXR0cmlidXRlOjM2",
+          id: "QXR0cmlidXRlOjM2", // cspell:disable-line
         },
         values: [
           {
@@ -50,7 +53,7 @@ export const exampleVariantData: GoogleFeedProductVariantFragment = {
       url: "https://example.eu.saleor.cloud/media/thumbnails/products/saleor-blue-polygon-tee-front_thumbnail_256.png",
     },
     category: {
-      id: "Q2F0ZWdvcnk6Mzk=",
+      id: "Q2F0ZWdvcnk6Mzk=", // cspell:disable-line
       name: "T-shirts",
       googleCategoryId: "42",
     },

--- a/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.test.ts
+++ b/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { GoogleFeedProductVariantFragment } from "../../../generated/graphql";
+import { GoogleFeedProductVariantFragment, WeightUnitsEnum } from "../../../generated/graphql";
 import { generateGoogleXmlFeed } from "./generate-google-xml-feed";
 
 const productBase: GoogleFeedProductVariantFragment["product"] = {
@@ -17,6 +17,9 @@ const productBase: GoogleFeedProductVariantFragment["product"] = {
   slug: "product-slug",
   thumbnail: { __typename: "Image", url: "" },
   attributes: [],
+  productType: {
+    isShippingRequired: true,
+  },
 };
 
 const priceBase: GoogleFeedProductVariantFragment["pricing"] = {
@@ -57,6 +60,10 @@ describe("generateGoogleXmlFeed", () => {
           name: "Product variant",
           product: productBase,
           attributes: [],
+          weight: {
+            unit: WeightUnitsEnum.Kg,
+            value: 1,
+          },
         },
         {
           id: "id2",
@@ -85,6 +92,7 @@ describe("generateGoogleXmlFeed", () => {
             <g:condition>new</g:condition>
             <g:availability>in_stock</g:availability>
             <g:product_type>Category Name</g:product_type>
+            <g:shipping_weight>1 kg</g:shipping_weight>
             <g:google_product_category>1</g:google_product_category>
             <link>https://example.com/p/product-slug</link>
             <g:price>2.00 USD</g:price>

--- a/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.ts
+++ b/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.ts
@@ -9,6 +9,7 @@ import { renderHandlebarsTemplate } from "../handlebarsTemplates/render-handleba
 import { transformTemplateFormat } from "../handlebarsTemplates/transform-template-format";
 import { EditorJsPlaintextRenderer } from "@saleor/apps-shared";
 import { getRelatedMedia, getVariantMediaMap } from "./get-related-media";
+import { getWeightAttributeValue } from "./get-weight-attribute-value";
 
 interface GenerateGoogleXmlFeedArgs {
   productVariants: GoogleFeedProductVariantFragment[];
@@ -67,6 +68,11 @@ export const generateGoogleXmlFeed = ({
       });
     } catch {}
 
+    let weight = getWeightAttributeValue({
+      isShippingRequired: variant.product.productType.isShippingRequired,
+      weight: variant.weight || undefined,
+    });
+
     return productToProxy({
       link,
       title: title || "",
@@ -86,6 +92,7 @@ export const generateGoogleXmlFeed = ({
       brand: attributes?.brand,
       pattern: attributes?.pattern,
       size: attributes?.size,
+      weight,
       ...pricing,
     });
   });

--- a/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.ts
+++ b/apps/products-feed/src/modules/google-feed/generate-google-xml-feed.ts
@@ -68,7 +68,7 @@ export const generateGoogleXmlFeed = ({
       });
     } catch {}
 
-    let weight = getWeightAttributeValue({
+    const weight = getWeightAttributeValue({
       isShippingRequired: variant.product.productType.isShippingRequired,
       weight: variant.weight || undefined,
     });

--- a/apps/products-feed/src/modules/google-feed/get-weight-attribute-value.test.ts
+++ b/apps/products-feed/src/modules/google-feed/get-weight-attribute-value.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getWeightAttributeValue } from "./get-weight-attribute-value";
+import { WeightUnitsEnum } from "../../../generated/graphql";
+
+describe("getWeightAttributeValueTest", () => {
+  it("Returns undefined, when weight is not provided", () => {
+    expect(getWeightAttributeValue({ isShippingRequired: true })).toBe(undefined);
+    expect(getWeightAttributeValue({ isShippingRequired: false })).toBe(undefined);
+  });
+
+  it("Returns undefined, when shipping is not required", () => {
+    expect(getWeightAttributeValue({ isShippingRequired: false })).toBe(undefined);
+    expect(
+      getWeightAttributeValue({
+        isShippingRequired: false,
+        weight: { unit: WeightUnitsEnum.G, value: 10 },
+      }),
+    ).toBe(undefined);
+  });
+
+  it("Returns units in lowercase, when shipping and weight is provided", () => {
+    expect(
+      getWeightAttributeValue({
+        isShippingRequired: true,
+        weight: { unit: WeightUnitsEnum.Kg, value: 10 },
+      }),
+    ).toBe("10 kg");
+
+    expect(
+      getWeightAttributeValue({
+        isShippingRequired: true,
+        weight: { unit: WeightUnitsEnum.Lb, value: 5 },
+      }),
+    ).toBe("5 lb");
+  });
+
+  it("Returns weight with dot as decimal deliminiter, when float value is used", () => {
+    expect(
+      getWeightAttributeValue({
+        isShippingRequired: true,
+        weight: { unit: WeightUnitsEnum.Kg, value: 10.5 },
+      }),
+    ).toBe("10.5 kg");
+
+    expect(
+      getWeightAttributeValue({
+        isShippingRequired: true,
+        weight: { unit: WeightUnitsEnum.Oz, value: 0.01 },
+      }),
+    ).toBe("0.01 oz");
+  });
+});

--- a/apps/products-feed/src/modules/google-feed/get-weight-attribute-value.ts
+++ b/apps/products-feed/src/modules/google-feed/get-weight-attribute-value.ts
@@ -1,0 +1,23 @@
+import { Weight } from "../../../generated/graphql";
+
+interface getWeightAttributeValueArgs {
+  weight?: Weight;
+  isShippingRequired: boolean;
+}
+
+/*
+ * Returns value for the "g:shipping_weight" attribute.
+ * When shipping is not required or weight is not provided, returns undefined.
+ *
+ * Google Docs specification: https://support.google.com/merchants/answer/6324503?hl=en
+ */
+export const getWeightAttributeValue = ({
+  weight,
+  isShippingRequired,
+}: getWeightAttributeValueArgs) => {
+  if (!isShippingRequired || !weight) {
+    return undefined;
+  }
+
+  return `${weight.value} ${weight.unit.toLowerCase() || "kg"}`;
+};

--- a/apps/products-feed/src/modules/google-feed/product-to-proxy.ts
+++ b/apps/products-feed/src/modules/google-feed/product-to-proxy.ts
@@ -57,6 +57,16 @@ export const productToProxy = (p: ProductEntry) => {
     });
   }
 
+  if (p.weight) {
+    item.push({
+      "g:shipping_weight": [
+        {
+          "#text": p.weight,
+        },
+      ],
+    });
+  }
+
   /**
    * This field is optional and Google automatically match category if not has been provided
    *

--- a/apps/products-feed/src/modules/google-feed/types.ts
+++ b/apps/products-feed/src/modules/google-feed/types.ts
@@ -19,6 +19,7 @@ export type ProductEntry = {
   size?: string;
   brand?: string;
   pattern?: string;
+  weight?: string;
 };
 
 export type ShopDetailsEntry = {


### PR DESCRIPTION
## Scope of the PR

Added weight attribute to Google Feed.

The field is formatted according to the specyfication: https://support.google.com/merchants/answer/6324503?hl=en

Preview of the loaded data including the weight field:
<img width="450" alt="image" src="https://github.com/saleor/apps/assets/5188636/5543a245-979b-4964-ba95-d9e23b533750">


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
