### PR TITLE
feat: :sparkles: add autocomplete and tax codes filtering

### DIFF
--- a/.changeset/five-cherries-juggle.md
+++ b/.changeset/five-cherries-juggle.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-taxes": minor
+---
+
+Added autocomplete component to the tax code matcher. It now allows for filtering the tax codes. This fixes the issue with some tax codes never appearing in the options list. This component will be later replaced with macaw-ui Autocomplete.

--- a/apps/taxes/src/modules/avatax/avatax-client-tax-code.service.ts
+++ b/apps/taxes/src/modules/avatax/avatax-client-tax-code.service.ts
@@ -21,9 +21,11 @@ export class AvataxClientTaxCodeService {
     });
   }
 
-  async getTaxCodes() {
-    // * If we want to do filtering on the front-end, we can use the `filter` parameter.
-    const result = await this.client.listTaxCodes({});
+  async getFilteredTaxCodes({ filter }: { filter: string | null }) {
+    const result = await this.client.listTaxCodes({
+      ...(filter ? { filter: `taxCode contains "${filter}"` } : {}),
+      top: 50,
+    });
 
     return this.filterOutInvalid(result);
   }

--- a/apps/taxes/src/modules/avatax/avatax-client.ts
+++ b/apps/taxes/src/modules/avatax/avatax-client.ts
@@ -96,10 +96,10 @@ export class AvataxClient {
     return this.client.resolveAddress(address);
   }
 
-  async getTaxCodes() {
+  async getFilteredTaxCodes({ filter }: { filter: string | null }) {
     const taxCodeService = new AvataxClientTaxCodeService(this.client);
 
-    return taxCodeService.getTaxCodes();
+    return taxCodeService.getFilteredTaxCodes({ filter });
   }
 
   async ping() {

--- a/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
+++ b/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
@@ -6,7 +6,11 @@ import { protectedClientProcedure } from "../../trpc/protected-client-procedure"
 import { AvataxConnectionService } from "../configuration/avatax-connection.service";
 import { AvataxTaxCodesService } from "./avatax-tax-codes.service";
 
-const getAllForIdSchema = z.object({ connectionId: z.string() });
+const getAllForIdSchema = z.object({
+  connectionId: z.string(),
+  filter: z.string().nullable(),
+  uniqueKey: z.string(),
+});
 
 export const avataxTaxCodesRouter = router({
   getAllForId: protectedClientProcedure.input(getAllForIdSchema).query(async ({ ctx, input }) => {
@@ -25,6 +29,6 @@ export const avataxTaxCodesRouter = router({
 
     logger.debug("Returning tax codes");
 
-    return taxCodesService.getAll();
+    return taxCodesService.getAllFiltered({ filter: input.filter });
   }),
 });

--- a/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.service.ts
+++ b/apps/taxes/src/modules/avatax/tax-code/avatax-tax-codes.service.ts
@@ -22,8 +22,8 @@ export class AvataxTaxCodesService {
     }));
   }
 
-  async getAll() {
-    const response = await this.client.getTaxCodes();
+  async getAllFiltered({ filter }: { filter: string | null }): Promise<TaxCode[]> {
+    const response = await this.client.getFilteredTaxCodes({ filter });
 
     return this.adapt(response);
   }

--- a/apps/taxes/src/modules/avatax/ui/avatax-tax-code-matcher-table.tsx
+++ b/apps/taxes/src/modules/avatax/ui/avatax-tax-code-matcher-table.tsx
@@ -1,100 +1,8 @@
-import { useDashboardNotification } from "@saleor/apps-shared";
-import React from "react";
-import { trpcClient } from "../../trpc/trpc-client";
-import { Table } from "../../ui/table";
-import { Select } from "../../ui/_select";
 import { Box, Text } from "@saleor/macaw-ui";
+import { trpcClient } from "../../trpc/trpc-client";
 import { AppCard } from "../../ui/app-card";
-import { useRouter } from "next/router";
-
-const useGetTaxCodes = () => {
-  const { data: providers } = trpcClient.providersConfiguration.getAll.useQuery();
-  const { notifyError } = useDashboardNotification();
-  const router = useRouter();
-
-  /*
-   * Tax Code Matcher is only available when there is at least one connection.
-   * The reason for it is that we need any working credentials to fetch the provider tax codes.
-   */
-  const firstConnectionId = providers?.[0].id;
-
-  const result = trpcClient.avataxTaxCodes.getAllForId.useQuery(
-    {
-      connectionId: firstConnectionId!,
-    },
-    {
-      enabled: firstConnectionId !== undefined,
-      // Retry once, because it's possible we may get a timeout for such a big request.
-      retry: 1,
-    }
-  );
-
-  React.useEffect(() => {
-    if (result.error) {
-      notifyError("Error", "Unable to fetch AvaTax tax codes.");
-      setTimeout(() => {
-        router.push("/configuration");
-      }, 1000);
-    }
-  }, [notifyError, result.error, router]);
-
-  return result;
-};
-
-const SelectTaxCode = ({ taxClassId }: { taxClassId: string }) => {
-  const [value, setValue] = React.useState("");
-  const { notifySuccess, notifyError } = useDashboardNotification();
-  const { data: taxCodes = [], isLoading: isCodesLoading } = useGetTaxCodes();
-
-  const { data: avataxMatches, isLoading: isMatchesLoading } =
-    trpcClient.avataxMatches.getAll.useQuery();
-
-  React.useEffect(() => {
-    if (avataxMatches) {
-      const match = avataxMatches?.find((item) => item.data.saleorTaxClassId === taxClassId);
-
-      if (match) {
-        setValue(match.data.avataxTaxCode);
-      }
-    }
-  }, [avataxMatches, taxClassId]);
-
-  const { mutate: updateMutation } = trpcClient.avataxMatches.upsert.useMutation({
-    onSuccess() {
-      notifySuccess("Success", "Updated AvaTax tax code matches");
-    },
-    onError(error) {
-      notifyError("Error", error.message);
-    },
-  });
-
-  const changeValue = (avataxTaxCode: string) => {
-    setValue(avataxTaxCode);
-    updateMutation({
-      saleorTaxClassId: taxClassId,
-      avataxTaxCode,
-    });
-  };
-
-  const isLoading = isMatchesLoading || isCodesLoading;
-
-  return (
-    <Select
-      value={value ?? null}
-      disabled={isLoading}
-      onChange={(value) => changeValue(String(value))}
-      options={[
-        ...(isLoading
-          ? [{ value: "", label: "Loading..." }]
-          : [{ value: "", label: "Not assigned" }]),
-        ...taxCodes.map((item) => ({
-          value: item.code,
-          label: `${item.code} | ${item.description}`,
-        })),
-      ]}
-    />
-  );
-};
+import { Table } from "../../ui/table";
+import { TaxCodeSelect } from "./tax-code-select";
 
 export const AvataxTaxCodeMatcherTable = () => {
   const { data: taxClasses = [], isLoading } = trpcClient.taxClasses.getAll.useQuery();
@@ -122,7 +30,7 @@ export const AvataxTaxCodeMatcherTable = () => {
               <Table.TR key={taxClass.id}>
                 <Table.TD>{taxClass.name}</Table.TD>
                 <Table.TD>
-                  <SelectTaxCode taxClassId={taxClass.id} />
+                  <TaxCodeSelect taxClassId={taxClass.id} />
                 </Table.TD>
               </Table.TR>
             );

--- a/apps/taxes/src/modules/avatax/ui/tax-code-select.tsx
+++ b/apps/taxes/src/modules/avatax/ui/tax-code-select.tsx
@@ -107,6 +107,7 @@ const useTaxCodeAutocomplete = ({ taxClassId }: { taxClassId: string }) => {
   };
 };
 
+// todo: replace with macaw-ui Autocomplete component when it's ready
 export const TaxCodeSelect = ({ taxClassId }: { taxClassId: string }) => {
   const { isInputLoading, isInputDisabled, inputText, onInputTextChange, options } =
     useTaxCodeAutocomplete({

--- a/apps/taxes/src/modules/avatax/ui/tax-code-select.tsx
+++ b/apps/taxes/src/modules/avatax/ui/tax-code-select.tsx
@@ -1,0 +1,137 @@
+import { useDashboardNotification } from "@saleor/apps-shared";
+import { Box, Input, Spinner } from "@saleor/macaw-ui";
+import { useRouter } from "next/router";
+import React from "react";
+import { useDebounce } from "usehooks-ts";
+import { trpcClient } from "../../trpc/trpc-client";
+
+const useGetTaxCodes = ({ filter, uniqueKey }: { filter: string | null; uniqueKey: string }) => {
+  const { data: providers, isFetched } = trpcClient.providersConfiguration.getAll.useQuery();
+  const { notifyError } = useDashboardNotification();
+  const router = useRouter();
+
+  /*
+   * Tax Code Matcher is only available when there is at least one connection.
+   * The reason for it is that we need any working credentials to fetch the provider tax codes.
+   */
+  const firstConnectionId = providers?.[0].id;
+
+  if (isFetched && !firstConnectionId) {
+    notifyError("Error", "No AvaTax connection found.");
+    setTimeout(() => {
+      router.push("/configuration");
+    }, 1000);
+  }
+
+  /*
+   * uniqueKey is needed so we can cache the results per each select, not for all the selects
+   * unfortunately, it's impossible to add a custom queryKey to useQuery options https://github.com/trpc/trpc/issues/4989
+   */
+  const result = trpcClient.avataxTaxCodes.getAllForId.useQuery(
+    {
+      connectionId: firstConnectionId!,
+      filter,
+      uniqueKey,
+    },
+    {
+      enabled: firstConnectionId !== undefined,
+    },
+  );
+
+  React.useEffect(() => {
+    if (result.error) {
+      notifyError("Error", "Unable to fetch AvaTax tax codes.");
+      setTimeout(() => {
+        router.push("/configuration");
+      }, 1000);
+    }
+  }, [notifyError, result.error, router]);
+
+  return result;
+};
+
+const useTaxCodeAutocomplete = ({ taxClassId }: { taxClassId: string }) => {
+  const [isTouched, setIsTouched] = React.useState(false);
+  const [value, setValue] = React.useState("");
+  const prevValueRef = React.useRef("");
+  const { notifySuccess, notifyError } = useDashboardNotification();
+
+  const debouncedValue = useDebounce(value, 1000);
+  const {
+    data: taxCodes = [],
+    isLoading: isCodesLoading,
+    isInitialLoading: isCodesInitialLoading,
+  } = useGetTaxCodes({ filter: debouncedValue, uniqueKey: taxClassId });
+
+  const changeValue = (newValue: string) => {
+    setIsTouched(true);
+    setValue(newValue);
+  };
+
+  const { data: avataxMatches = [], isInitialLoading: isMatchesInitialLoading } =
+    trpcClient.avataxMatches.getAll.useQuery();
+
+  const { mutate: updateMutation, isLoading: isMutationLoading } =
+    trpcClient.avataxMatches.upsert.useMutation({
+      onSuccess: () => notifySuccess("Success", "Updated AvaTax tax code matches"),
+      onError: (error) => notifyError("Error", error.message),
+    });
+
+  const updateTaxCode = React.useCallback(() => {
+    const isValidCode =
+      taxCodes.some((item) => item.code === debouncedValue) || debouncedValue === "";
+
+    if (debouncedValue !== prevValueRef.current && isTouched && isValidCode) {
+      prevValueRef.current = debouncedValue;
+      updateMutation({ saleorTaxClassId: taxClassId, avataxTaxCode: debouncedValue });
+    }
+  }, [debouncedValue, isTouched, taxCodes, taxClassId, updateMutation]);
+
+  React.useEffect(() => {
+    const match = avataxMatches.find((item) => item.data.saleorTaxClassId === taxClassId);
+
+    if (match && !isTouched) {
+      setValue(match.data.avataxTaxCode);
+      prevValueRef.current = match.data.avataxTaxCode;
+    }
+
+    updateTaxCode();
+  }, [avataxMatches, isTouched, taxClassId, updateTaxCode]);
+
+  return {
+    inputText: value,
+    onInputTextChange: changeValue,
+    options: taxCodes,
+    isInputDisabled: isCodesInitialLoading || isMatchesInitialLoading,
+    isInputLoading: isMutationLoading || isCodesLoading,
+  };
+};
+
+export const TaxCodeSelect = ({ taxClassId }: { taxClassId: string }) => {
+  const { isInputLoading, isInputDisabled, inputText, onInputTextChange, options } =
+    useTaxCodeAutocomplete({
+      taxClassId,
+    });
+
+  return (
+    <label>
+      <Box display={"flex"} gap={1} alignItems={"center"}>
+        <Input
+          name="taxCode"
+          disabled={isInputDisabled}
+          list="taxCodes"
+          value={inputText}
+          onChange={(e) => onInputTextChange(e.target.value)}
+        />
+        {isInputLoading && <Spinner />}
+      </Box>
+      <datalist id="taxCodes">
+        {options.map((taxCode) => (
+          <option key={taxCode.code} value={taxCode.code}>
+            {taxCode.description}
+          </option>
+        ))}
+      </datalist>
+    </label>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   '@saleor/app-sdk': 0.43.1
   crypto-js@<4.2.0: '>=4.2.0'
@@ -22856,3 +22852,7 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION


https://github.com/saleor/apps/assets/44495184/12cd18e2-3306-4a82-b6f8-b8c8bd6fca28



## Scope of the PR

- Added the tax codes filtering in AvaTax
- Added a basic autocomplete component to be later replaced with [macaw-ui autocomplete](https://github.com/saleor/macaw-ui/issues/452)

## Related issues

- https://github.com/saleor/apps/issues/1130

## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
