### PR TITLE
fix: adding country area

### DIFF
--- a/.changeset/three-dryers-kneel.md
+++ b/.changeset/three-dryers-kneel.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-emails-and-messages": patch
+---
+
+Adding countryArea in the address fields to be populated in email templates

--- a/apps/emails-and-messages/graphql/fragments/OrderDetails.graphql
+++ b/apps/emails-and-messages/graphql/fragments/OrderDetails.graphql
@@ -32,6 +32,7 @@ fragment OrderDetails on Order {
     city
     cityArea
     postalCode
+    countryArea
     country {
       country
     }
@@ -46,6 +47,7 @@ fragment OrderDetails on Order {
     city
     cityArea
     postalCode
+    countryArea
     country {
       country
     }

--- a/apps/emails-and-messages/src/modules/event-handlers/default-payloads.ts
+++ b/apps/emails-and-messages/src/modules/event-handlers/default-payloads.ts
@@ -59,6 +59,7 @@ const exampleOrderPayload: OrderDetailsFragment = {
     cityArea: "",
     city: "METROPOLIS",
     postalCode: "71653",
+    countryArea: "PL",
     country: {
       country: "United States of America",
     },
@@ -72,6 +73,7 @@ const exampleOrderPayload: OrderDetailsFragment = {
     cityArea: "",
     city: "METROPOLIS",
     postalCode: "71653",
+    countryArea: "PL",
     country: {
       country: "United States of America",
     },


### PR DESCRIPTION
## Scope of the PR

I don't know, if this is sufficient, but the country area is missing currently - this PR is meant to add it. 

## Related issues

Open issue in the Saleor support slack

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
