### PR TITLE
Update .env.example for taxes

### DIFF
--- a/apps/taxes/.env.example
+++ b/apps/taxes/.env.example
@@ -13,10 +13,10 @@ ALLOWED_DOMAIN=
 # Local development variables. When developed locally with Saleor inside docker, these can be set to:
 # APP_IFRAME_BASE_URL = http://localhost:3000, so Dashboard on host can access iframe
 # APP_API_BASE_URL=http://host.docker.internal:3000 - so Saleor can reach App running on host, from the container.
-# If developed with tunnels, set this empty, it will fallback to default Next's localhost:3000
+# If developed with tunnels, comment them and app will fallback to default Next's localhost:3000
 # https://docs.saleor.io/docs/3.x/developer/extending/apps/local-app-development
-APP_IFRAME_BASE_URL=
-APP_API_BASE_URL=
+# APP_IFRAME_BASE_URL=
+# APP_API_BASE_URL=
 
 OTEL_ENABLED=true
 OTEL_SERVICE_NAME=saleor-app-taxes


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
This PR fixes `.env.example` for taxes app when it is developed with tunnel. Leaving those two env variables with empty values causes app to throw errors with `Invalid URL`. If you comment them out app works fine.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
