### PR TITLE
Fix vercel deploys of apps

### DIFF
--- a/apps/cms-v2/package.json
+++ b/apps/cms-v2/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-cms-v2",
+  "name": "cms-v2",
   "version": "2.6.2",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/cms-v2/sentry.client.config.ts
+++ b/apps/cms-v2/sentry.client.config.ts
@@ -18,5 +18,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/cms-v2/sentry.edge.config.ts
+++ b/apps/cms-v2/sentry.edge.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/cms-v2/sentry.server.config.ts
+++ b/apps/cms-v2/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-crm",
+  "name": "crm",
   "version": "1.8.3",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/crm/sentry.client.config.ts
+++ b/apps/crm/sentry.client.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/crm/sentry.edge.config.ts
+++ b/apps/crm/sentry.edge.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/crm/sentry.server.config.ts
+++ b/apps/crm/sentry.server.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/data-importer/package.json
+++ b/apps/data-importer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-data-importer",
+  "name": "data-importer",
   "version": "1.10.3",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/data-importer/sentry.client.config.ts
+++ b/apps/data-importer/sentry.client.config.ts
@@ -18,5 +18,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/data-importer/sentry.edge.config.ts
+++ b/apps/data-importer/sentry.edge.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/data-importer/sentry.server.config.ts
+++ b/apps/data-importer/sentry.server.config.ts
@@ -13,5 +13,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/emails-and-messages/package.json
+++ b/apps/emails-and-messages/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-emails-and-messages",
+  "name": "emails-and-messages",
   "version": "1.10.4",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/emails-and-messages/sentry.client.config.ts
+++ b/apps/emails-and-messages/sentry.client.config.ts
@@ -17,5 +17,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/emails-and-messages/sentry.edge.config.ts
+++ b/apps/emails-and-messages/sentry.edge.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/emails-and-messages/sentry.server.config.ts
+++ b/apps/emails-and-messages/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/invoices/package.json
+++ b/apps/invoices/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-invoices",
+  "name": "invoices",
   "version": "1.17.3",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/invoices/sentry.client.config.ts
+++ b/apps/invoices/sentry.client.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
 
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/invoices/sentry.edge.config.ts
+++ b/apps/invoices/sentry.edge.config.ts
@@ -12,5 +12,5 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/invoices/sentry.server.config.ts
+++ b/apps/invoices/sentry.server.config.ts
@@ -12,5 +12,5 @@ Sentry.init({
   enableTracing: false,
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/klaviyo/package.json
+++ b/apps/klaviyo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-klaviyo",
+  "name": "klaviyo",
   "version": "1.10.3",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/klaviyo/sentry.client.config.ts
+++ b/apps/klaviyo/sentry.client.config.ts
@@ -18,5 +18,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/klaviyo/sentry.edge.config.ts
+++ b/apps/klaviyo/sentry.edge.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/klaviyo/sentry.server.config.ts
+++ b/apps/klaviyo/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/products-feed/package.json
+++ b/apps/products-feed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-products-feed",
+  "name": "products-feed",
   "version": "1.14.2",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/products-feed/sentry.client.config.ts
+++ b/apps/products-feed/sentry.client.config.ts
@@ -17,5 +17,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/products-feed/sentry.edge.config.ts
+++ b/apps/products-feed/sentry.edge.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/products-feed/sentry.server.config.ts
+++ b/apps/products-feed/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/search/next.config.js
+++ b/apps/search/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
     "@saleor/webhook-utils",
     "@saleor/react-hook-form-macaw",
   ],
+  distDir: "build",
 };
 
 const configWithSentry = withSentryConfig(

--- a/apps/search/next.config.js
+++ b/apps/search/next.config.js
@@ -14,7 +14,6 @@ const nextConfig = {
     "@saleor/webhook-utils",
     "@saleor/react-hook-form-macaw",
   ],
-  distDir: "build",
 };
 
 const configWithSentry = withSentryConfig(

--- a/apps/search/package.json
+++ b/apps/search/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-search",
+  "name": "search",
   "version": "1.20.1",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/search/sentry.client.config.ts
+++ b/apps/search/sentry.client.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/search/sentry.edge.config.ts
+++ b/apps/search/sentry.edge.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/search/sentry.server.config.ts
+++ b/apps/search/sentry.server.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/segment/package.json
+++ b/apps/segment/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-segment",
+  "name": "segment",
   "version": "1.1.3",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/segment/sentry.client.config.ts
+++ b/apps/segment/sentry.client.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/segment/sentry.edge.config.ts
+++ b/apps/segment/sentry.edge.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/segment/sentry.server.config.ts
+++ b/apps/segment/sentry.server.config.ts
@@ -14,5 +14,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/slack/package.json
+++ b/apps/slack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-slack",
+  "name": "slack",
   "version": "1.10.0",
   "scripts": {
     "build": "pnpm generate && next build",

--- a/apps/slack/sentry.client.config.ts
+++ b/apps/slack/sentry.client.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [],
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/slack/sentry.edge.config.ts
+++ b/apps/slack/sentry.edge.config.ts
@@ -16,5 +16,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/slack/sentry.server.config.ts
+++ b/apps/slack/sentry.server.config.ts
@@ -15,5 +15,5 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
   environment: process.env.SENTRY_ENVIRONMENT,
-  release: `${pkg.name}@${pkg.version}`,
+  release: `saleor-app-${pkg.name}@${pkg.version}`,
 });

--- a/apps/taxes/package.json
+++ b/apps/taxes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor-app-taxes",
+  "name": "taxes",
   "version": "1.21.2",
   "scripts": {
     "build": "pnpm generate && next build",


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
We discovered that the names of the packages in package.json must match the names of the folders. In the past, we had `apps/search` and `name: saleor-app-search`, which caused an error during the build process with Turbo. I made the necessary changes in this pull request. Changes in sentry config are for backward compatibility. The other apps are not affected because we don't override the Vercel "Build command" for them.

Stack discussion: [link](https://stackoverflow.com/questions/70758736/nextjs-vercel-deployment-error-routes-manifest-json-couldnt-be-found)

## Related issues

<!-- If any, mention issues that are connected with this PR -->

Fixes: SHOPX-107

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
