### PR TITLE
Map customer code to a metadata field in the Taxes App

### DIFF
--- a/.changeset/silly-trainers-carry.md
+++ b/.changeset/silly-trainers-carry.md
@@ -1,0 +1,5 @@
+---
+"taxes": minor
+---
+
+The app can now read the value of AvaTax's transaction `customerCode` from the `user.avataxCustomerCode` metadata field. If not provided, the app will use `user.id` for a logged-in user or the recommended fallback value.

--- a/apps/taxes/graphql/fragments/TaxBase.graphql
+++ b/apps/taxes/graphql/fragments/TaxBase.graphql
@@ -34,6 +34,7 @@ fragment TaxBaseLine on TaxableObjectLine {
     amount
   }
 }
+
 fragment TaxDiscount on TaxableObjectDiscount {
   name
   amount {
@@ -64,13 +65,13 @@ fragment TaxBase on TaxableObject {
     ... on Checkout {
       avataxEntityCode: metafield(key: "avataxEntityCode")
       user {
-        id
+        ...User
       }
     }
     ... on Order {
       avataxEntityCode: metafield(key: "avataxEntityCode")
       user {
-        id
+        ...User
       }
     }
   }

--- a/apps/taxes/graphql/fragments/User.graphql
+++ b/apps/taxes/graphql/fragments/User.graphql
@@ -1,0 +1,5 @@
+fragment User on User {
+  id
+  email
+  avataxCustomerCode: metafield(key: "avataxCustomerCode")
+}

--- a/apps/taxes/graphql/subscriptions/OrderConfirmed.graphql
+++ b/apps/taxes/graphql/subscriptions/OrderConfirmed.graphql
@@ -25,8 +25,7 @@ fragment OrderConfirmedSubscription on Order {
   number
   userEmail
   user {
-    id
-    email
+    ...User
   }
   created
   status

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.test.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.test.ts
@@ -1,104 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { CalculateTaxesPayload } from "../../pages/api/webhooks/checkout-calculate-taxes";
-import { AvataxCustomerCodeResolver } from "./avatax-customer-code-resolver";
-import {
-  OrderConfirmedEventSubscriptionFragment,
-  OrderConfirmedSubscriptionFragment,
-} from "../../../generated/graphql";
+import { UserFragment } from "../../../generated/graphql";
+import { avataxCustomerCode } from "./avatax-customer-code-resolver";
 
-const idOrderPayload = {
-  user: {
-    id: "123",
-  },
-} as unknown as OrderConfirmedSubscriptionFragment;
-
-const noIdOrderPayload = {} as unknown as OrderConfirmedSubscriptionFragment;
-
-const noIdCalculateTaxesCheckoutPayload = {
-  taxBase: {
-    sourceObject: {
-      __typename: "Checkout",
-    },
-  },
-} as unknown as CalculateTaxesPayload;
-
-const idCalculateTaxesCheckoutPayload = {
-  taxBase: {
-    sourceObject: {
-      __typename: "Checkout",
-      user: {
-        id: "123",
-      },
-    },
-  },
-} as unknown as CalculateTaxesPayload;
-
-const noIdCalculateTaxesOrderPayload = {
-  taxBase: {
-    sourceObject: {
-      __typename: "Order",
-    },
-  },
-} as unknown as CalculateTaxesPayload;
-
-const idCalculateTaxesOrderPayload = {
-  taxBase: {
-    sourceObject: {
-      __typename: "Order",
-      user: {
-        id: "123",
-      },
-    },
-  },
-} as unknown as CalculateTaxesPayload;
-
-const resolver = new AvataxCustomerCodeResolver();
-
-describe("AvataxCustomerCodeResolver", () => {
-  describe("resolveOrderCustomerCode", () => {
+describe("avataxCustomerCode", () => {
+  describe("resolve", () => {
     it("returns user id when present in sourceObject", () => {
-      const customerCode = resolver.resolveOrderCustomerCode(idOrderPayload);
+      const customerCode = avataxCustomerCode.resolve({
+        email: "demo@saleor.io",
+        id: "123",
+      });
 
       expect(customerCode).toBe("123");
     });
+    it("returns avataxCustomerCode when present in sourceObject", () => {
+      const customerCode = avataxCustomerCode.resolve({
+        email: "demo@saleor.io",
+        id: "123",
+        avataxCustomerCode: "456",
+      });
+
+      expect(customerCode).toBe("456");
+    });
     it("returns 0 when no user id", () => {
-      const customerCode = resolver.resolveOrderCustomerCode(noIdOrderPayload);
+      const customerCode = avataxCustomerCode.resolve({
+        email: "demo@saleor.io",
+      } as UserFragment);
 
       expect(customerCode).toBe("0");
-    });
-  });
-  describe("resolveCalculateTaxesCustomerCode", () => {
-    describe("when checkout", () => {
-      it("returns user id when present in sourceObject", () => {
-        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
-          idCalculateTaxesCheckoutPayload,
-        );
-
-        expect(customerCode).toBe("123");
-        it("returns 0 when no user id", () => {
-          const customerCode = resolver.resolveCalculateTaxesCustomerCode(
-            noIdCalculateTaxesCheckoutPayload,
-          );
-
-          expect(customerCode).toBe("0");
-        });
-      });
-    });
-    describe("when order", () => {
-      it("returns user id when present in sourceObject", () => {
-        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
-          idCalculateTaxesOrderPayload,
-        );
-
-        expect(customerCode).toBe("123");
-      });
-      it("returns 0 when no user id", () => {
-        const customerCode = resolver.resolveCalculateTaxesCustomerCode(
-          noIdCalculateTaxesOrderPayload,
-        );
-
-        expect(customerCode).toBe("0");
-      });
     });
   });
 });

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -1,18 +1,31 @@
-import { OrderConfirmedSubscriptionFragment } from "../../../generated/graphql";
-import { CalculateTaxesPayload } from "../../pages/api/webhooks/checkout-calculate-taxes";
+import { createLogger } from "@saleor/apps-logger";
+import { UserFragment } from "../../../generated/graphql";
 
-export class AvataxCustomerCodeResolver {
-  /*
-   * "If you're creating a sales order for a customer that does not yet exist in your system, you can send a dummyCustomerCode as sales orders are not recorded."
-   * https://developer.avalara.com/ecommerce-integration-guide/sales-tax-badge/transactions/simple-transactions/
-   */
-  private fallbackCustomerCode = "0";
+const logger = createLogger("avataxCustomerCode");
 
-  resolveOrderCustomerCode(order: OrderConfirmedSubscriptionFragment) {
-    return order.user?.id ?? this.fallbackCustomerCode;
-  }
+/*
+ * "If you're creating a sales order for a customer that does not yet exist in your system, you can send a dummyCustomerCode as sales orders are not recorded."
+ * https://developer.avalara.com/ecommerce-integration-guide/sales-tax-badge/transactions/simple-transactions/
+ */
+const FALLBACK_CUSTOMER_CODE = "0";
 
-  resolveCalculateTaxesCustomerCode(payload: CalculateTaxesPayload): string {
-    return payload.taxBase.sourceObject.user?.id ?? this.fallbackCustomerCode;
-  }
-}
+export const avataxCustomerCode = {
+  resolve(user: UserFragment | null | undefined): string {
+    const avataxCustomerCode = user?.avataxCustomerCode;
+
+    if (avataxCustomerCode) {
+      logger.trace(`Returning customer code found in the user metadata.`);
+      return avataxCustomerCode;
+    }
+
+    const userId = user?.id;
+
+    if (userId) {
+      logger.trace(`Returning user id as a customer code.`);
+      return userId;
+    }
+
+    logger.trace(`Returning fallback customer code.`);
+    return FALLBACK_CUSTOMER_CODE;
+  },
+};

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -11,6 +11,7 @@ const FALLBACK_CUSTOMER_CODE = "0";
 
 export const avataxCustomerCode = {
   resolve(user: UserFragment | null | undefined): string {
+    // see: docs.saleor.io/docs/3.x/developer/app-store/apps/taxes/avatax/overview#customer-code
     const avataxCustomerCode = user?.avataxCustomerCode;
 
     if (avataxCustomerCode) {

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -22,7 +22,7 @@ export const avataxCustomerCode = {
     const userId = user?.id;
 
     if (userId) {
-      logger.trace(`Returning user id as a customer code.`);
+      logger.trace({ userId }, `Returning user id as a customer code.`);
       return userId;
     }
 

--- a/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
+++ b/apps/taxes/src/modules/avatax/avatax-customer-code-resolver.ts
@@ -15,7 +15,7 @@ export const avataxCustomerCode = {
     const avataxCustomerCode = user?.avataxCustomerCode;
 
     if (avataxCustomerCode) {
-      logger.trace(`Returning customer code found in the user metadata.`);
+      logger.trace({ avataxCustomerCode }, `Returning customer code found in the user metadata.`);
       return avataxCustomerCode;
     }
 

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -27,7 +27,7 @@ export class AvataxEntityTypeMatcher {
     return result.value?.[0].code || this.returnFallback();
   }
 
-  // Now that we get the customer code from user metadata, maybe we should get the entity code from the same place?
+  // TODO: Now that we get the customer code from user metadata, maybe we should get the entity code from the same place?
   async match(entityCode: string | null | undefined) {
     if (!entityCode) {
       return this.returnFallback();

--- a/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/taxes/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -27,6 +27,7 @@ export class AvataxEntityTypeMatcher {
     return result.value?.[0].code || this.returnFallback();
   }
 
+  // Now that we get the customer code from user metadata, maybe we should get the entity code from the same place?
   async match(entityCode: string | null | undefined) {
     if (!entityCode) {
       return this.returnFallback();

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -110,6 +110,7 @@ const defaultTaxBase: TaxBase = {
     __typename: "Checkout",
     user: {
       id: "123",
+      email: "demo@saleor.io",
     },
   },
 };

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -4,7 +4,7 @@ import { discountUtils } from "../../taxes/discount-utils";
 import { avataxAddressFactory } from "../address-factory";
 import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
-import { AvataxCustomerCodeResolver } from "../avatax-customer-code-resolver";
+import { avataxCustomerCode } from "../avatax-customer-code-resolver";
 import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";
@@ -28,13 +28,12 @@ export class AvataxCalculateTaxesPayloadTransformer {
     const payloadLinesTransformer = new AvataxCalculateTaxesPayloadLinesTransformer();
     const avataxClient = new AvataxClient(avataxConfig);
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
-    const customerCodeResolver = new AvataxCustomerCodeResolver();
 
     const entityUseCode = await entityTypeMatcher.match(
       payload.taxBase.sourceObject.avataxEntityCode,
     );
 
-    const customerCode = customerCodeResolver.resolveCalculateTaxesCustomerCode(payload);
+    const customerCode = avataxCustomerCode.resolve(payload.taxBase.sourceObject.user);
 
     return {
       model: {

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -5,7 +5,7 @@ import { avataxAddressFactory } from "../address-factory";
 import { AvataxCalculationDateResolver } from "../avatax-calculation-date-resolver";
 import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
-import { AvataxCustomerCodeResolver } from "../avatax-customer-code-resolver";
+import { avataxCustomerCode } from "../avatax-customer-code-resolver";
 import { AvataxDocumentCodeResolver } from "../avatax-document-code-resolver";
 import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
@@ -33,7 +33,6 @@ export class AvataxOrderConfirmedPayloadTransformer {
     const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
     const dateResolver = new AvataxCalculationDateResolver();
     const documentCodeResolver = new AvataxDocumentCodeResolver();
-    const customerCodeResolver = new AvataxCustomerCodeResolver();
 
     const entityUseCode = await entityTypeMatcher.match(order.avataxEntityCode);
     const date = dateResolver.resolve(order.avataxTaxCalculationDate, order.created);
@@ -41,7 +40,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
       avataxDocumentCode: order.avataxDocumentCode,
       orderId: order.id,
     });
-    const customerCode = customerCodeResolver.resolveOrderCustomerCode(order);
+    const customerCode = avataxCustomerCode.resolve(order.user);
 
     return {
       model: {

--- a/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
+++ b/apps/taxes/src/modules/taxjar/calculate-taxes/taxjar-calculate-taxes-mock-generator.ts
@@ -99,6 +99,7 @@ const taxIncludedTaxBase: TaxBase = {
     __typename: "Checkout",
     user: {
       id: "123",
+      email: "demo@saleor.io",
     },
   },
 };
@@ -198,6 +199,7 @@ const taxExcludedTaxBase: TaxBase = {
     __typename: "Checkout",
     user: {
       id: "123",
+      email: "demo@saleor.io",
     },
   },
 };


### PR DESCRIPTION
## Context

Taxes App synchronizes a group of fields from Saleor to an AvaTax transaction. Some of these fields are used to determine the tax value (e.g. the customer code).

The general approach is to use the Saleor field that matches the purpose of the AvaTax field the most. However, users sometimes want to override that value with their own. This usually comes into play when multiple other systems (where e.g. one system manages the customers) collaborate on the tax calculation. 

## Scope of the PR

- Refactored the app to use `UserFragment` everywhere
- Added new logic to resolving AvaTax customer code. The app now tries to read it from metadata. If not found, it falls back to the user id. When no user id is found, it falls back to the dummy value (as AvaTax docs suggest).

## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
- [x] [I documented it](https://github.com/saleor/saleor-docs/pull/1078)

## Note
This PR isn't breaking. If the metadata field is not found, the app will fall back as usual. We will add the migrations next week.