### PR TITLE
refactor: unify shipping line logic

### DIFF
--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
@@ -10,8 +10,6 @@ import { AvataxCalculateTaxesPayloadService } from "./avatax-calculate-taxes-pay
 import { AvataxCalculateTaxesResponseTransformer } from "./avatax-calculate-taxes-response-transformer";
 import { createLogger } from "../../../logger";
 
-export const SHIPPING_ITEM_CODE = "Shipping";
-
 export type AvataxCalculateTaxesTarget = CreateTransactionArgs;
 export type AvataxCalculateTaxesResponse = CalculateTaxesResponse;
 

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -3,13 +3,13 @@ import { TaxBaseFragment } from "../../../../generated/graphql";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxCalculateTaxesTaxCodeMatcher } from "./avatax-calculate-taxes-tax-code-matcher";
-import { SHIPPING_ITEM_CODE } from "./avatax-calculate-taxes-adapter";
+import { avataxShippingLine } from "./avatax-shipping-line";
 
 export class AvataxCalculateTaxesPayloadLinesTransformer {
   transform(
     taxBase: TaxBaseFragment,
     config: AvataxConfig,
-    matches: AvataxTaxCodeMatches
+    matches: AvataxTaxCodeMatches,
   ): LineItemModel[] {
     const isDiscounted = taxBase.discounts.length > 0;
     const productLines: LineItemModel[] = taxBase.lines.map((line) => {
@@ -26,15 +26,11 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
     });
 
     if (taxBase.shippingPrice.amount !== 0) {
-      // * In AvaTax, shipping is a regular line
-      const shippingLine: LineItemModel = {
+      const shippingLine = avataxShippingLine.create({
         amount: taxBase.shippingPrice.amount,
-        itemCode: SHIPPING_ITEM_CODE,
         taxCode: config.shippingTaxCode,
-        quantity: 1,
         taxIncluded: taxBase.pricesEnteredWithTax,
-        discounted: isDiscounted,
-      };
+      });
 
       return [...productLines, shippingLine];
     }

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
@@ -3,7 +3,7 @@ import { numbers } from "../../taxes/numbers";
 import { TaxBadPayloadError } from "../../taxes/tax-error";
 import { taxProviderUtils } from "../../taxes/tax-provider-utils";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
-import { SHIPPING_ITEM_CODE } from "./avatax-calculate-taxes-adapter";
+import { SHIPPING_ITEM_CODE } from "./avatax-shipping-line";
 
 export class AvataxCalculateTaxesResponseLinesTransformer {
   transform(transaction: TransactionModel): CalculateTaxesResponse["lines"] {

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.test.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { avataxMockFactory } from "../avatax-mock-factory";
-import { AvataxCalculateTaxesResponseShippingTransformer } from "./avatax-calculate-taxes-response-shipping-transformer";
-
-const transformer = new AvataxCalculateTaxesResponseShippingTransformer();
+import { transformAvataxTransactionModelIntoShipping } from "./avatax-calculate-taxes-response-shipping-transformer";
 
 const TAX_EXCLUDED_NO_SHIPPING_TRANSACTION_MOCK =
   avataxMockFactory.createMockTransaction("taxExcludedNoShipping");
@@ -12,9 +10,11 @@ const TAX_INCLUDED_SHIPPING_TRANSACTION_MOCK =
 const TAX_EXCLUDED_SHIPPING_TRANSACTION_MOCK =
   avataxMockFactory.createMockTransaction("taxExcludedShipping");
 
-describe("AvataxCalculateTaxesResponseShippingTransformer", () => {
+describe("transformAvataxTransactionModelIntoShipping", () => {
   it("when shipping line is not present, returns 0s", () => {
-    const shippingLine = transformer.transform(TAX_EXCLUDED_NO_SHIPPING_TRANSACTION_MOCK);
+    const shippingLine = transformAvataxTransactionModelIntoShipping(
+      TAX_EXCLUDED_NO_SHIPPING_TRANSACTION_MOCK,
+    );
 
     expect(shippingLine).toEqual({
       shipping_price_gross_amount: 0,
@@ -23,7 +23,9 @@ describe("AvataxCalculateTaxesResponseShippingTransformer", () => {
     });
   });
   it("when shipping line is not taxable, returns line amount", () => {
-    const nonTaxableShippingLine = transformer.transform(NON_TAXABLE_TRANSACTION_MOCK);
+    const nonTaxableShippingLine = transformAvataxTransactionModelIntoShipping(
+      NON_TAXABLE_TRANSACTION_MOCK,
+    );
 
     expect(nonTaxableShippingLine).toEqual({
       shipping_price_gross_amount: 77.51,
@@ -33,7 +35,9 @@ describe("AvataxCalculateTaxesResponseShippingTransformer", () => {
   });
 
   it("when shipping line is taxable and tax is included, returns calculated gross & net amounts", () => {
-    const taxableShippingLine = transformer.transform(TAX_INCLUDED_SHIPPING_TRANSACTION_MOCK);
+    const taxableShippingLine = transformAvataxTransactionModelIntoShipping(
+      TAX_INCLUDED_SHIPPING_TRANSACTION_MOCK,
+    );
 
     expect(taxableShippingLine).toEqual({
       shipping_price_gross_amount: 77.51,
@@ -43,7 +47,9 @@ describe("AvataxCalculateTaxesResponseShippingTransformer", () => {
   });
 
   it("when shipping line is taxable and tax is not included, returns calculated gross & net amounts", () => {
-    const taxableShippingLine = transformer.transform(TAX_EXCLUDED_SHIPPING_TRANSACTION_MOCK);
+    const taxableShippingLine = transformAvataxTransactionModelIntoShipping(
+      TAX_EXCLUDED_SHIPPING_TRANSACTION_MOCK,
+    );
 
     expect(taxableShippingLine).toEqual({
       shipping_price_gross_amount: 84.87,

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
@@ -4,7 +4,11 @@ import { TaxBadProviderResponseError } from "../../taxes/tax-error";
 import { taxProviderUtils } from "../../taxes/tax-provider-utils";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
 import { avataxShippingLine } from "./avatax-shipping-line";
+import { createLogger } from "@saleor/apps-logger";
 
+const logger = createLogger("transformAvataxTransactionModelIntoShipping");
+
+// why is tax rate 0?
 export function transformAvataxTransactionModelIntoShipping(
   transaction: TransactionModel,
 ): Pick<
@@ -14,6 +18,10 @@ export function transformAvataxTransactionModelIntoShipping(
   const shippingLine = avataxShippingLine.getFromTransactionModel(transaction);
 
   if (!shippingLine) {
+    logger.warn(
+      "Shipping line was not found in the response from AvaTax. The app will return 0s for shipping fields.",
+    );
+
     return {
       shipping_price_gross_amount: 0,
       shipping_price_net_amount: 0,

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
@@ -5,57 +5,55 @@ import { taxProviderUtils } from "../../taxes/tax-provider-utils";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
 import { avataxShippingLine } from "./avatax-shipping-line";
 
-export class AvataxCalculateTaxesResponseShippingTransformer {
-  transform(
-    transaction: TransactionModel,
-  ): Pick<
-    CalculateTaxesResponse,
-    "shipping_price_gross_amount" | "shipping_price_net_amount" | "shipping_tax_rate"
-  > {
-    const shippingLine = avataxShippingLine.getFromTransactionModel(transaction);
+export function transformAvataxTransactionModelIntoShipping(
+  transaction: TransactionModel,
+): Pick<
+  CalculateTaxesResponse,
+  "shipping_price_gross_amount" | "shipping_price_net_amount" | "shipping_tax_rate"
+> {
+  const shippingLine = avataxShippingLine.getFromTransactionModel(transaction);
 
-    if (!shippingLine) {
-      return {
-        shipping_price_gross_amount: 0,
-        shipping_price_net_amount: 0,
-        shipping_tax_rate: 0,
-      };
-    }
-
-    if (!shippingLine.isItemTaxable) {
-      return {
-        shipping_price_gross_amount: taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
-          shippingLine.lineAmount,
-          new TaxBadProviderResponseError("shippingLine.lineAmount is undefined"),
-        ),
-        shipping_price_net_amount: taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
-          shippingLine.lineAmount,
-          new TaxBadProviderResponseError("shippingLine.lineAmount is undefined"),
-        ),
-        /*
-         * avatax doesn't return combined tax rate
-         * // todo: calculate percentage tax rate
-         */
-        shipping_tax_rate: 0,
-      };
-    }
-
-    const shippingTaxCalculated = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
-      shippingLine.taxCalculated,
-      new TaxBadProviderResponseError("shippingLine.taxCalculated is undefined"),
-    );
-    const shippingTaxableAmount = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
-      shippingLine.taxableAmount,
-      new TaxBadProviderResponseError("shippingLine.taxableAmount is undefined"),
-    );
-    const shippingGrossAmount = numbers.roundFloatToTwoDecimals(
-      shippingTaxableAmount + shippingTaxCalculated,
-    );
-
+  if (!shippingLine) {
     return {
-      shipping_price_gross_amount: shippingGrossAmount,
-      shipping_price_net_amount: shippingTaxableAmount,
+      shipping_price_gross_amount: 0,
+      shipping_price_net_amount: 0,
       shipping_tax_rate: 0,
     };
   }
+
+  if (!shippingLine.isItemTaxable) {
+    return {
+      shipping_price_gross_amount: taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
+        shippingLine.lineAmount,
+        new TaxBadProviderResponseError("shippingLine.lineAmount is undefined"),
+      ),
+      shipping_price_net_amount: taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
+        shippingLine.lineAmount,
+        new TaxBadProviderResponseError("shippingLine.lineAmount is undefined"),
+      ),
+      /*
+       * avatax doesn't return combined tax rate
+       * // todo: calculate percentage tax rate
+       */
+      shipping_tax_rate: 0,
+    };
+  }
+
+  const shippingTaxCalculated = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
+    shippingLine.taxCalculated,
+    new TaxBadProviderResponseError("shippingLine.taxCalculated is undefined"),
+  );
+  const shippingTaxableAmount = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
+    shippingLine.taxableAmount,
+    new TaxBadProviderResponseError("shippingLine.taxableAmount is undefined"),
+  );
+  const shippingGrossAmount = numbers.roundFloatToTwoDecimals(
+    shippingTaxableAmount + shippingTaxCalculated,
+  );
+
+  return {
+    shipping_price_gross_amount: shippingGrossAmount,
+    shipping_price_net_amount: shippingTaxableAmount,
+    shipping_tax_rate: 0,
+  };
 }

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
@@ -1,9 +1,9 @@
 import { TransactionModel } from "avatax/lib/models/TransactionModel";
 import { numbers } from "../../taxes/numbers";
+import { TaxBadProviderResponseError } from "../../taxes/tax-error";
 import { taxProviderUtils } from "../../taxes/tax-provider-utils";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
-import { SHIPPING_ITEM_CODE } from "./avatax-calculate-taxes-adapter";
-import { TaxBadProviderResponseError } from "../../taxes/tax-error";
+import { avataxShippingLine } from "./avatax-shipping-line";
 
 export class AvataxCalculateTaxesResponseShippingTransformer {
   transform(
@@ -12,7 +12,7 @@ export class AvataxCalculateTaxesResponseShippingTransformer {
     CalculateTaxesResponse,
     "shipping_price_gross_amount" | "shipping_price_net_amount" | "shipping_tax_rate"
   > {
-    const shippingLine = transaction.lines?.find((line) => line.itemCode === SHIPPING_ITEM_CODE);
+    const shippingLine = avataxShippingLine.getFromTransactionModel(transaction);
 
     if (!shippingLine) {
       return {

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-transformer.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-transformer.ts
@@ -1,12 +1,11 @@
 import { TransactionModel } from "avatax/lib/models/TransactionModel";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
 import { AvataxCalculateTaxesResponseLinesTransformer } from "./avatax-calculate-taxes-response-lines-transformer";
-import { AvataxCalculateTaxesResponseShippingTransformer } from "./avatax-calculate-taxes-response-shipping-transformer";
+import { transformAvataxTransactionModelIntoShipping } from "./avatax-calculate-taxes-response-shipping-transformer";
 
 export class AvataxCalculateTaxesResponseTransformer {
   transform(response: TransactionModel): CalculateTaxesResponse {
-    const shippingTransformer = new AvataxCalculateTaxesResponseShippingTransformer();
-    const shipping = shippingTransformer.transform(response);
+    const shipping = transformAvataxTransactionModelIntoShipping(response);
 
     const linesTransformer = new AvataxCalculateTaxesResponseLinesTransformer();
     const lines = linesTransformer.transform(response);

--- a/apps/taxes/src/modules/avatax/calculate-taxes/avatax-shipping-line.ts
+++ b/apps/taxes/src/modules/avatax/calculate-taxes/avatax-shipping-line.ts
@@ -1,0 +1,39 @@
+import { createLogger } from "@saleor/apps-logger";
+import { LineItemModel } from "avatax/lib/models/LineItemModel";
+import { TransactionModel } from "avatax/lib/models/TransactionModel";
+
+export const SHIPPING_ITEM_CODE = "Shipping";
+
+const logger = createLogger("avataxShippingLine");
+
+export const avataxShippingLine = {
+  // * In AvaTax, shipping is a regular line
+  create({
+    amount,
+    taxCode,
+    taxIncluded,
+  }: {
+    amount: number;
+    taxCode: string | undefined;
+    taxIncluded: boolean;
+  }): LineItemModel {
+    return {
+      amount,
+      taxIncluded,
+      taxCode,
+      itemCode: SHIPPING_ITEM_CODE,
+      quantity: 1,
+    };
+  },
+  getFromTransactionModel(transactionModel: TransactionModel) {
+    const shippingLine = transactionModel.lines?.find(
+      (line) => line.itemCode === SHIPPING_ITEM_CODE,
+    );
+
+    if (!shippingLine) {
+      logger.warn("Shipping line not found in the transaction model");
+    }
+
+    return shippingLine;
+  },
+};

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-lines-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-lines-transformer.ts
@@ -2,9 +2,9 @@ import { LineItemModel } from "avatax/lib/models/LineItemModel";
 import { OrderConfirmedSubscriptionFragment } from "../../../../generated/graphql";
 import { numbers } from "../../taxes/numbers";
 import { AvataxConfig } from "../avatax-connection-schema";
+import { avataxShippingLine } from "../calculate-taxes/avatax-shipping-line";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxOrderConfirmedTaxCodeMatcher } from "./avatax-order-confirmed-tax-code-matcher";
-import { SHIPPING_ITEM_CODE } from "../calculate-taxes/avatax-calculate-taxes-adapter";
 
 export class AvataxOrderConfirmedPayloadLinesTransformer {
   transform(
@@ -31,18 +31,11 @@ export class AvataxOrderConfirmedPayloadLinesTransformer {
     });
 
     if (order.shippingPrice.net.amount !== 0) {
-      // * In AvaTax, shipping is a regular line
-      const shippingLine: LineItemModel = {
+      const shippingLine = avataxShippingLine.create({
         amount: order.shippingPrice.gross.amount,
-        taxIncluded: true,
-        itemCode: SHIPPING_ITEM_CODE,
-        /**
-         * * Different shipping methods can have different tax codes.
-         * https://developer.avalara.com/ecommerce-integration-guide/sales-tax-badge/designing/non-standard-items/\
-         */
         taxCode: config.shippingTaxCode,
-        quantity: 1,
-      };
+        taxIncluded: true,
+      });
 
       return [...productLines, shippingLine];
     }

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-lines-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-lines-transformer.ts
@@ -3,14 +3,14 @@ import { OrderConfirmedSubscriptionFragment } from "../../../../generated/graphq
 import { numbers } from "../../taxes/numbers";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
-import { SHIPPING_ITEM_CODE } from "./avatax-order-confirmed-payload-transformer";
 import { AvataxOrderConfirmedTaxCodeMatcher } from "./avatax-order-confirmed-tax-code-matcher";
+import { SHIPPING_ITEM_CODE } from "../calculate-taxes/avatax-calculate-taxes-adapter";
 
 export class AvataxOrderConfirmedPayloadLinesTransformer {
   transform(
     order: OrderConfirmedSubscriptionFragment,
     config: AvataxConfig,
-    matches: AvataxTaxCodeMatches
+    matches: AvataxTaxCodeMatches,
   ): LineItemModel[] {
     const productLines: LineItemModel[] = order.lines.map((line) => {
       const matcher = new AvataxOrderConfirmedTaxCodeMatcher();
@@ -20,7 +20,7 @@ export class AvataxOrderConfirmedPayloadLinesTransformer {
         // taxes are included because we treat what is passed in payload as the source of truth
         taxIncluded: true,
         amount: numbers.roundFloatToTwoDecimals(
-          line.totalPrice.net.amount + line.totalPrice.tax.amount
+          line.totalPrice.net.amount + line.totalPrice.tax.amount,
         ),
         taxCode,
         quantity: line.quantity,

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -42,6 +42,11 @@ export class AvataxOrderConfirmedPayloadTransformer {
       orderId: order.id,
     });
     const customerCode = customerCodeResolver.resolveOrderCustomerCode(order);
+    const billingAddress = order.billingAddress;
+
+    if (!billingAddress) {
+      throw new Error("Billing address not found in OrderConfirmed subscription.");
+    }
 
     return {
       model: {
@@ -55,7 +60,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
         addresses: {
           shipFrom: avataxAddressFactory.fromChannelAddress(avataxConfig.address),
           // billing or shipping address?
-          shipTo: avataxAddressFactory.fromSaleorAddress(order.billingAddress!),
+          shipTo: avataxAddressFactory.fromSaleorAddress(billingAddress),
         },
         currencyCode: order.total.currency,
         // we can fall back to empty string because email is not a required field

--- a/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/taxes/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -11,8 +11,6 @@ import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxOrderConfirmedPayloadLinesTransformer } from "./avatax-order-confirmed-payload-lines-transformer";
 
-export const SHIPPING_ITEM_CODE = "Shipping";
-
 export class AvataxOrderConfirmedPayloadTransformer {
   private matchDocumentType(config: AvataxConfig): DocumentType {
     if (!config.isDocumentRecordingEnabled) {


### PR DESCRIPTION
## Context
A shipping app calculates taxes. It returns positive values. But when querying the shipping values, they are all 0s (not just the tax rate). We narrowed down the cause - it's the Taxes App.

We need to revisit the shipping calculations in the Taxes App and try to figure out why it returns 0s. 

## Scope of the PR
- Unified the shipping line taxes/values calculation logic so it's all in the same place.

No cause was yet found, so it's WIP.

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
