### PR TITLE
Update turbo.json deployment configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@
 ## Checklist
 
 - [ ] I added changesets and [read good practices](/.changeset/README.md).
+
+## Known problems
+
+- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.

--- a/apps/search/src/views/configuration/configuration.view.tsx
+++ b/apps/search/src/views/configuration/configuration.view.tsx
@@ -1,12 +1,13 @@
-import { Layout, TextLink } from "@saleor/apps-ui";
 import { Box, Text } from "@saleor/macaw-ui";
+import { Layout } from "@saleor/apps-ui";
 import { AlgoliaConfigurationForm } from "../../components/AlgoliaConfigurationForm";
-import { AlgoliaFieldsSelectionForm } from "../../components/AlgoliaFieldsSelectionForm";
 import { ImportProductsToAlgolia } from "../../components/ImportProductsToAlgolia";
-import { IndicesSettings } from "../../components/IndicesSettings";
-import { MainInstructions } from "../../components/MainInstructions";
 import { WebhooksStatus } from "../../components/WebhooksStatus";
+import { MainInstructions } from "../../components/MainInstructions";
 import { WebhooksStatusInstructions } from "../../components/WebhooksStatusInstructions";
+import { TextLink } from "@saleor/apps-ui";
+import { IndicesSettings } from "../../components/IndicesSettings";
+import { AlgoliaFieldsSelectionForm } from "../../components/AlgoliaFieldsSelectionForm";
 
 const ALGOLIA_DASHBOARD_TOKENS_URL = "https://www.algolia.com/account/api-keys/all";
 
@@ -14,7 +15,7 @@ export const ConfigurationView = () => {
   return (
     <Box display="flex" flexDirection="column" gap={10}>
       <Box>
-        <Text variant="hero" size="medium" as="h1">
+        <Text variant={"hero"} size={"medium"} as={"h1"}>
           Configuration
         </Text>
         <MainInstructions marginTop={1.5} />


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
This PR copies turbo configuration from `build` step into `deploy` step as 1st deployment step is build application.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
