### PR TITLE
Disable changeset check for release pr

### DIFF
--- a/.github/workflows/changeset-checker.yml
+++ b/.github/workflows/changeset-checker.yml
@@ -7,13 +7,11 @@ on:
       - labeled
       - edited
       - synchronize
-    branches-ignore:    
-      - 'changeset-release/**'
 jobs:
   changeset_check:
     name: Changeset added to the PR
     # Adding 'skip changesets' label to the PR will skip this job
-    if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip changeset') }}
+    if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip changeset') || !startsWith(github.head_ref, 'changeset-release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
