### PR TITLE
fix: prevent Avalara from applying discounts two times for certain vouchers

### DIFF
--- a/.changeset/afraid-ducks-heal.md
+++ b/.changeset/afraid-ducks-heal.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Avatax app now calculates discount properly if voucher for cheapest product or specific product is used.

--- a/apps/avatax/graphql/fragments/TaxBase.graphql
+++ b/apps/avatax/graphql/fragments/TaxBase.graphql
@@ -76,12 +76,18 @@ fragment TaxBase on TaxableObject {
       user {
         ...User
       }
+      voucher {
+        ...Voucher
+      }
     }
     ... on Order {
       id
       avataxEntityCode: metafield(key: "avataxEntityCode")
       user {
         ...User
+      }
+      voucher {
+        ...Voucher
       }
     }
   }

--- a/apps/avatax/graphql/fragments/TaxBase.graphql
+++ b/apps/avatax/graphql/fragments/TaxBase.graphql
@@ -12,6 +12,9 @@ fragment TaxBaseLine on TaxableObjectLine {
           }
         }
       }
+      undiscountedTotalPrice {
+        amount
+      }
     }
     ... on OrderLine {
       id
@@ -22,6 +25,11 @@ fragment TaxBaseLine on TaxableObjectLine {
             id
             name
           }
+        }
+      }
+      undiscountedTotalPrice {
+        net {
+          amount
         }
       }
     }

--- a/apps/avatax/graphql/fragments/Voucher.graphql
+++ b/apps/avatax/graphql/fragments/Voucher.graphql
@@ -2,4 +2,5 @@ fragment Voucher on Voucher {
   __typename
   id
   type
+  applyOncePerOrder
 }

--- a/apps/avatax/graphql/fragments/Voucher.graphql
+++ b/apps/avatax/graphql/fragments/Voucher.graphql
@@ -1,0 +1,5 @@
+fragment Voucher on Voucher {
+  __typename
+  id
+  type
+}

--- a/apps/avatax/scripts/migrations/1.1-avatax-migration.ts
+++ b/apps/avatax/scripts/migrations/1.1-avatax-migration.ts
@@ -1,0 +1,15 @@
+/* eslint-disable multiline-comment-style */
+import { checkoutCalculateTaxesSyncWebhook } from "../../src/pages/api/webhooks/checkout-calculate-taxes";
+import { orderCalculateTaxesSyncWebhook } from "../../src/pages/api/webhooks/order-calculate-taxes";
+import { AppWebhookMigrator } from "./app-webhook-migrator";
+
+/**
+ * Contains the migration logic for the Taxes App. In the 1st step, it is expected to only write, not delete. The cleanup will be done in the 2nd step.
+ * @param webhookMigrator - The AppWebhookMigrator instance.
+ */
+export async function migrateAvatax(webhookMigrator: AppWebhookMigrator) {
+  // Migration plan:
+  //  1. Update subscriptionQuery of all calculateTaxes webhooks
+  webhookMigrator.updateWebhookQueryByHandler(orderCalculateTaxesSyncWebhook);
+  webhookMigrator.updateWebhookQueryByHandler(checkoutCalculateTaxesSyncWebhook);
+}

--- a/apps/avatax/scripts/migrations/run-migration.ts
+++ b/apps/avatax/scripts/migrations/run-migration.ts
@@ -3,6 +3,7 @@
 import * as dotenv from "dotenv";
 import { createAppWebhookMigrator } from "./app-webhook-migrator";
 import { fetchCloudAplEnvs, verifyRequiredEnvs } from "./migration-utils";
+import { migrateAvatax } from "./1.1-avatax-migration";
 
 dotenv.config();
 
@@ -26,7 +27,7 @@ const runMigration = async () => {
 
       const webhookMigrator = createAppWebhookMigrator(env, { mode: "migrate" });
 
-      throw new Error("No migrations registered");
+      await migrateAvatax(webhookMigrator);
     } catch (error) {
       console.log("⏩ Error while migrating webhook. Continuing with the next app.");
       continue;

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -53,7 +53,7 @@ const defaultTaxBase: TaxBase = {
         },
         undiscountedTotalPrice: {
           net: {
-            amount: 70,
+            amount: 60,
           },
         },
       },

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-mock-generator.ts
@@ -51,6 +51,11 @@ const defaultTaxBase: TaxBase = {
             },
           },
         },
+        undiscountedTotalPrice: {
+          net: {
+            amount: 70,
+          },
+        },
       },
       quantity: 3,
       unitPrice: {
@@ -73,6 +78,11 @@ const defaultTaxBase: TaxBase = {
             },
           },
         },
+        undiscountedTotalPrice: {
+          net: {
+            amount: 20,
+          },
+        },
       },
       quantity: 1,
       unitPrice: {
@@ -93,6 +103,11 @@ const defaultTaxBase: TaxBase = {
               id: "VGF4Q2xhc3M6TWjI=",
               name: "Sweets",
             },
+          },
+        },
+        undiscountedTotalPrice: {
+          net: {
+            amount: 100,
           },
         },
       },

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -8,8 +8,8 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
   describe("transform", () => {
     it("maps lines, adds shipping as line and maps the tax code of one product", () => {
       const mockGenerator = new AvataxCalculateTaxesMockGenerator();
-      const avataxConfigMock = mockGenerator.generateAvataxConfig();
       const taxBaseMock = mockGenerator.generateTaxBase();
+      const avataxConfigMock = mockGenerator.generateAvataxConfig();
       const matchesMock = mockGenerator.generateTaxCodeMatches();
 
       const lines = transformer.transform(taxBaseMock, avataxConfigMock, matchesMock);
@@ -78,7 +78,7 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         },
       ]);
     });
-    it("when discounts, sets discounted to true", () => {
+    it("when discounts, sets discounted to true [entire checkout voucher]", () => {
       const mockGenerator = new AvataxCalculateTaxesMockGenerator();
       const avataxConfigMock = mockGenerator.generateAvataxConfig();
       const matchesMock = mockGenerator.generateTaxCodeMatches();
@@ -101,72 +101,24 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
           quantity: 1,
           taxCode: "",
           taxIncluded: true,
-          discounted: false,
+          discounted: true,
         },
         {
           amount: 100,
           quantity: 2,
           taxCode: "",
           taxIncluded: true,
-          discounted: false,
+          discounted: true,
         },
         {
           amount: 48.33,
-          discounted: false,
+          discounted: true,
           itemCode: "Shipping",
           quantity: 1,
           taxCode: "FR000000",
           taxIncluded: true,
         },
       ]);
-    });
-    it("discounts propery", () => {
-      const mockGenerator = new AvataxCalculateTaxesMockGenerator();
-      const avataxConfigMock = mockGenerator.generateAvataxConfig();
-      const taxBaseMock = mockGenerator.generateTaxBase();
-      const matchesMock = mockGenerator.generateTaxCodeMatches();
-
-      const lines = transformer.transform(taxBaseMock, avataxConfigMock, matchesMock);
-
-      expect(lines).toEqual([
-        {
-          amount: 60,
-          quantity: 3,
-          taxCode: "P0000000",
-          taxIncluded: true,
-          discounted: false,
-        },
-        {
-          amount: 20,
-          quantity: 1,
-          taxCode: "",
-          taxIncluded: true,
-          discounted: false,
-        },
-        {
-          amount: 100,
-          quantity: 2,
-          taxCode: "",
-          taxIncluded: true,
-          discounted: false,
-        },
-        {
-          amount: 48.33,
-          itemCode: "Shipping",
-          quantity: 1,
-          taxCode: "FR000000",
-          taxIncluded: true,
-          discounted: false,
-        },
-      ]);
-      /*
-       * 1. get 3 products priced at 3.66, get 3 products priced at 5
-       * 2. get a 5% voucher for ONE item
-       * 3. Create a checkout
-       * 4. Add voucher
-       * 5. Set shipping method
-       * 6. check if the voucher is not distributed across 3 highest priced items
-       */
     });
   });
 });

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AvataxCalculateTaxesMockGenerator } from "./avatax-calculate-taxes-mock-generator";
-import {
-  AvataxCalculateTaxesPayloadLinesTransformer,
-  checkDiscounts,
-  checkIfIsDiscountedLine,
-} from "./avatax-calculate-taxes-payload-lines-transformer";
-import { TaxBaseFragment } from "../../../../generated/graphql";
+import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";
+import { TaxBaseFragment, VoucherTypeEnum } from "../../../../generated/graphql";
 
 const transformer = new AvataxCalculateTaxesPayloadLinesTransformer();
 
@@ -21,6 +17,23 @@ const mockTaxBaseWithDiscountedLine = (taxBaseMock: TaxBaseFragment) => {
       },
       ...taxBaseMock.lines.slice(1),
     ],
+  };
+};
+
+const addVoucher = (
+  taxBaseMock: TaxBaseFragment,
+  voucherType: VoucherTypeEnum,
+): TaxBaseFragment => {
+  return {
+    ...taxBaseMock,
+    sourceObject: {
+      ...taxBaseMock.sourceObject,
+      voucher: {
+        type: voucherType,
+        id: "1",
+        __typename: "Voucher",
+      },
+    },
   };
 };
 
@@ -106,7 +119,11 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         discounts: [{ amount: { amount: 10 } }],
       });
 
-      const lines = transformer.transform(taxBaseMock, avataxConfigMock, matchesMock);
+      const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(
+        addVoucher(taxBaseMock, VoucherTypeEnum.EntireOrder),
+      );
+
+      const lines = transformer.transform(modifiedTaxBaseMock, avataxConfigMock, matchesMock);
 
       expect(lines).toEqual([
         {
@@ -132,7 +149,7 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         },
         {
           amount: 48.33,
-          discounted: true,
+          discounted: false,
           itemCode: "Shipping",
           quantity: 1,
           taxCode: "FR000000",
@@ -148,7 +165,9 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         discounts: [{ amount: { amount: 10 } }],
       });
 
-      const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
+      const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(
+        addVoucher(taxBaseMock, VoucherTypeEnum.SpecificProduct),
+      );
 
       const lines = transformer.transform(modifiedTaxBaseMock, avataxConfigMock, matchesMock);
 
@@ -184,51 +203,50 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         },
       ]);
     });
-  });
-});
 
-describe("AvataxCalculateTaxesPayloadLinesTransformer discount utils", () => {
-  it("Checks if line is discounted", () => {
-    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+    it("when shipping discounts, sets shipping line discount to true [specific item voucher]", () => {
+      const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+      const avataxConfigMock = mockGenerator.generateAvataxConfig();
+      const matchesMock = mockGenerator.generateTaxCodeMatches();
+      const taxBaseMock = mockGenerator.generateTaxBase({
+        discounts: [{ amount: { amount: 10 } }],
+      });
 
-    const taxBaseMock = mockGenerator.generateTaxBase({
-      discounts: [{ amount: { amount: 10 } }],
+      const modifiedTaxBaseMock = addVoucher(taxBaseMock, VoucherTypeEnum.Shipping);
+
+      const lines = transformer.transform(modifiedTaxBaseMock, avataxConfigMock, matchesMock);
+
+      expect(lines).toEqual([
+        {
+          amount: 60,
+          quantity: 3,
+          taxCode: "P0000000",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 20,
+          quantity: 1,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 100,
+          quantity: 2,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 48.33,
+          discounted: true,
+          itemCode: "Shipping",
+          quantity: 1,
+          taxCode: "FR000000",
+          taxIncluded: true,
+        },
+      ]);
     });
-
-    const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
-
-    expect(modifiedTaxBaseMock.lines[0].totalPrice.amount).toBe(50);
-    expect(checkIfIsDiscountedLine(true, modifiedTaxBaseMock.lines[0])).toBe(true);
-  });
-
-  it("Correctly determines specific product voucher discount type", () => {
-    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
-
-    const taxBaseMock = mockGenerator.generateTaxBase({
-      discounts: [{ amount: { amount: 10 } }],
-    });
-
-    const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
-
-    const { hasEntireCheckoutDiscount, hasOncePerOrderVoucher } = checkDiscounts(
-      modifiedTaxBaseMock,
-      true,
-    );
-
-    expect(hasEntireCheckoutDiscount).toBe(false);
-    expect(hasOncePerOrderVoucher).toBe(true);
-  });
-
-  it("Correctly determines entire checkout voucher discount type", () => {
-    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
-
-    const taxBaseMock = mockGenerator.generateTaxBase({
-      discounts: [{ amount: { amount: 10 } }],
-    });
-
-    const { hasEntireCheckoutDiscount, hasOncePerOrderVoucher } = checkDiscounts(taxBaseMock, true);
-
-    expect(hasEntireCheckoutDiscount).toBe(true);
-    expect(hasOncePerOrderVoucher).toBe(false);
   });
 });

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -112,7 +112,7 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         },
         {
           amount: 48.33,
-          discounted: true,
+          discounted: false,
           itemCode: "Shipping",
           quantity: 1,
           taxCode: "FR000000",

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -101,14 +101,14 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
           quantity: 1,
           taxCode: "",
           taxIncluded: true,
-          discounted: true,
+          discounted: false,
         },
         {
           amount: 100,
           quantity: 2,
           taxCode: "",
           taxIncluded: true,
-          discounted: true,
+          discounted: false,
         },
         {
           amount: 48.33,
@@ -119,6 +119,54 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
           taxIncluded: true,
         },
       ]);
+    });
+    it("discounts propery", () => {
+      const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+      const avataxConfigMock = mockGenerator.generateAvataxConfig();
+      const taxBaseMock = mockGenerator.generateTaxBase();
+      const matchesMock = mockGenerator.generateTaxCodeMatches();
+
+      const lines = transformer.transform(taxBaseMock, avataxConfigMock, matchesMock);
+
+      expect(lines).toEqual([
+        {
+          amount: 60,
+          quantity: 3,
+          taxCode: "P0000000",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 20,
+          quantity: 1,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 100,
+          quantity: 2,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 48.33,
+          itemCode: "Shipping",
+          quantity: 1,
+          taxCode: "FR000000",
+          taxIncluded: true,
+          discounted: false,
+        },
+      ]);
+      /*
+       * 1. get 3 products priced at 3.66, get 3 products priced at 5
+       * 2. get a 5% voucher for ONE item
+       * 3. Create a checkout
+       * 4. Add voucher
+       * 5. Set shipping method
+       * 6. check if the voucher is not distributed across 3 highest priced items
+       */
     });
   });
 });

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { AvataxCalculateTaxesMockGenerator } from "./avatax-calculate-taxes-mock-generator";
-import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";
+import {
+  AvataxCalculateTaxesPayloadLinesTransformer,
+  checkDiscounts,
+  checkIfIsDiscountedLine,
+} from "./avatax-calculate-taxes-payload-lines-transformer";
+import { TaxBaseFragment } from "../../../../generated/graphql";
 
 const transformer = new AvataxCalculateTaxesPayloadLinesTransformer();
+
+const mockTaxBaseWithDiscountedLine = (taxBaseMock: TaxBaseFragment) => {
+  return {
+    ...taxBaseMock,
+    lines: [
+      {
+        ...taxBaseMock.lines[0],
+        totalPrice: {
+          amount: 50,
+        },
+      },
+      ...taxBaseMock.lines.slice(1),
+    ],
+  };
+};
 
 describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
   describe("transform", () => {
@@ -120,5 +140,95 @@ describe("AvataxCalculateTaxesPayloadLinesTransformer", () => {
         },
       ]);
     });
+    it("when specific discounts, sets one discounted item to true [specific item voucher]", () => {
+      const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+      const avataxConfigMock = mockGenerator.generateAvataxConfig();
+      const matchesMock = mockGenerator.generateTaxCodeMatches();
+      const taxBaseMock = mockGenerator.generateTaxBase({
+        discounts: [{ amount: { amount: 10 } }],
+      });
+
+      const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
+
+      const lines = transformer.transform(modifiedTaxBaseMock, avataxConfigMock, matchesMock);
+
+      expect(lines).toEqual([
+        {
+          amount: 60,
+          quantity: 3,
+          taxCode: "P0000000",
+          taxIncluded: true,
+          discounted: true,
+        },
+        {
+          amount: 20,
+          quantity: 1,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 100,
+          quantity: 2,
+          taxCode: "",
+          taxIncluded: true,
+          discounted: false,
+        },
+        {
+          amount: 48.33,
+          discounted: false,
+          itemCode: "Shipping",
+          quantity: 1,
+          taxCode: "FR000000",
+          taxIncluded: true,
+        },
+      ]);
+    });
+  });
+});
+
+describe("AvataxCalculateTaxesPayloadLinesTransformer discount utils", () => {
+  it("Checks if line is discounted", () => {
+    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+
+    const taxBaseMock = mockGenerator.generateTaxBase({
+      discounts: [{ amount: { amount: 10 } }],
+    });
+
+    const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
+
+    expect(modifiedTaxBaseMock.lines[0].totalPrice.amount).toBe(50);
+    expect(checkIfIsDiscountedLine(true, modifiedTaxBaseMock.lines[0])).toBe(true);
+  });
+
+  it("Correctly determines specific product voucher discount type", () => {
+    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+
+    const taxBaseMock = mockGenerator.generateTaxBase({
+      discounts: [{ amount: { amount: 10 } }],
+    });
+
+    const modifiedTaxBaseMock = mockTaxBaseWithDiscountedLine(taxBaseMock);
+
+    const { hasEntireCheckoutDiscount, hasOncePerOrderVoucher } = checkDiscounts(
+      modifiedTaxBaseMock,
+      true,
+    );
+
+    expect(hasEntireCheckoutDiscount).toBe(false);
+    expect(hasOncePerOrderVoucher).toBe(true);
+  });
+
+  it("Correctly determines entire checkout voucher discount type", () => {
+    const mockGenerator = new AvataxCalculateTaxesMockGenerator();
+
+    const taxBaseMock = mockGenerator.generateTaxBase({
+      discounts: [{ amount: { amount: 10 } }],
+    });
+
+    const { hasEntireCheckoutDiscount, hasOncePerOrderVoucher } = checkDiscounts(taxBaseMock, true);
+
+    expect(hasEntireCheckoutDiscount).toBe(true);
+    expect(hasOncePerOrderVoucher).toBe(false);
   });
 });

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -26,6 +26,56 @@ const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
   return false;
 };
 
+/**
+ * If entire checkout discount then lines in webhook subscription are not discounted
+ * If one item is discounted then the line has discounted totalPrice
+ */
+const checkDiscounts = (taxBase: TaxBaseFragment, isDiscounted: boolean) => {
+  let hasEntireCheckoutDiscount = true;
+  let hasOncePerOrderVoucher = false;
+  let discountedLinesCount = 0;
+
+  for (const line of taxBase.lines) {
+    const isLineDiscounted = checkIfIsDiscountedLine(isDiscounted, line);
+
+    if (isLineDiscounted) {
+      discountedLinesCount++;
+    } else {
+      hasEntireCheckoutDiscount = false;
+    }
+
+    if (discountedLinesCount > 1) {
+      hasEntireCheckoutDiscount = false;
+    }
+  }
+
+  // If none of the lines are discounted, but isDiscounted is true then it's entire checkout discount
+  if (discountedLinesCount === 0 && isDiscounted) {
+    hasEntireCheckoutDiscount = true;
+  }
+
+  if (discountedLinesCount === 1) {
+    hasOncePerOrderVoucher = true;
+  }
+
+  return { hasEntireCheckoutDiscount, hasOncePerOrderVoucher };
+};
+
+const isProductLineDiscounted = (
+  line: TaxBaseLine,
+  isDiscounted: boolean,
+  hasOncePerOrderVoucher: boolean,
+  hasEntireCheckoutDiscount: boolean,
+) => {
+  if (!isDiscounted) return false;
+
+  if (hasOncePerOrderVoucher) {
+    return checkIfIsDiscountedLine(isDiscounted, line);
+  }
+
+  return hasEntireCheckoutDiscount;
+};
+
 export class AvataxCalculateTaxesPayloadLinesTransformer {
   transform(
     taxBase: TaxBaseFragment,
@@ -37,18 +87,26 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
      * https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/discounts-and-overrides/discounting-a-transaction/
      */
     const isDiscounted = taxBase.discounts.length > 0;
+    const { hasEntireCheckoutDiscount, hasOncePerOrderVoucher } = checkDiscounts(
+      taxBase,
+      isDiscounted,
+    );
+
     const productLines: LineItemModel[] = taxBase.lines.map((line) => {
       const matcher = new AvataxCalculateTaxesTaxCodeMatcher();
       const taxCode = matcher.match(line, matches);
 
       return {
-        amount: taxBase.pricesEnteredWithTax
-          ? line.totalPrice.amount
-          : getUndiscountedTotalPrice(line),
+        amount: getUndiscountedTotalPrice(line),
         taxIncluded: taxBase.pricesEnteredWithTax,
         taxCode,
         quantity: line.quantity,
-        discounted: checkIfIsDiscountedLine(isDiscounted, line),
+        discounted: isProductLineDiscounted(
+          line,
+          isDiscounted,
+          hasOncePerOrderVoucher,
+          hasEntireCheckoutDiscount,
+        ),
       };
     });
 
@@ -57,7 +115,7 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
         amount: taxBase.shippingPrice.amount,
         taxCode: config.shippingTaxCode,
         taxIncluded: taxBase.pricesEnteredWithTax,
-        discounted: isDiscounted,
+        discounted: hasEntireCheckoutDiscount,
       });
 
       return [...productLines, shippingLine];

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -1,5 +1,5 @@
 import { LineItemModel } from "avatax/lib/models/LineItemModel";
-import { OrderLine, TaxBaseFragment } from "../../../../generated/graphql";
+import { TaxBaseFragment } from "../../../../generated/graphql";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxCalculateTaxesTaxCodeMatcher } from "./avatax-calculate-taxes-tax-code-matcher";
@@ -42,7 +42,7 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
       const taxCode = matcher.match(line, matches);
 
       return {
-        amount: line.totalPrice.amount,
+        amount: getUndiscountedTotalPrice(line),
         taxIncluded: taxBase.pricesEnteredWithTax,
         taxCode,
         quantity: line.quantity,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -28,10 +28,11 @@ const isProductLineDiscounted = (line: TaxBaseLine, taxBase: TaxBaseFragment) =>
   if (!isDiscounted) return false;
 
   const voucherType = taxBase.sourceObject.voucher?.type;
+  const isOncePerOrder = taxBase.sourceObject.voucher?.applyOncePerOrder;
 
   switch (voucherType) {
     case VoucherTypeEnum.EntireOrder:
-      return true;
+      return isOncePerOrder ? checkIfIsDiscountedLine(line) : true;
     case VoucherTypeEnum.SpecificProduct:
       return checkIfIsDiscountedLine(line);
     default:

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -15,7 +15,7 @@ const getUndiscountedTotalPrice = (line: TaxBaseLine) => {
   return line.sourceLine.undiscountedTotalPrice.net.amount;
 };
 
-const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
+export const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
   if (isDiscounted) {
     const undiscountedTotalPrice = getUndiscountedTotalPrice(line);
     const totalPrice = line.totalPrice.amount;
@@ -30,7 +30,7 @@ const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
  * If entire checkout discount then lines in webhook subscription are not discounted
  * If one item is discounted then the line has discounted totalPrice
  */
-const checkDiscounts = (taxBase: TaxBaseFragment, isEntireSourceDiscounted: boolean) => {
+export const checkDiscounts = (taxBase: TaxBaseFragment, isEntireSourceDiscounted: boolean) => {
   let hasEntireCheckoutDiscount = false;
   let hasOncePerOrderVoucher = false;
   let discountedLinesCount = 0;
@@ -43,10 +43,11 @@ const checkDiscounts = (taxBase: TaxBaseFragment, isEntireSourceDiscounted: bool
         discountedLinesCount++;
       }
     }
+
+    // If none of the lines are discounted, but isEntireSourceDiscounted is true then it's entire checkout discount
+    hasEntireCheckoutDiscount = discountedLinesCount === 0;
   }
 
-  // If none of the lines are discounted, but isEntireSourceDiscounted is true then it's entire checkout discount
-  hasEntireCheckoutDiscount = discountedLinesCount === 0;
   hasOncePerOrderVoucher = discountedLinesCount === 1;
 
   return { hasEntireCheckoutDiscount, hasOncePerOrderVoucher };

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -42,7 +42,9 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
       const taxCode = matcher.match(line, matches);
 
       return {
-        amount: getUndiscountedTotalPrice(line),
+        amount: taxBase.pricesEnteredWithTax
+          ? line.totalPrice.amount
+          : getUndiscountedTotalPrice(line),
         taxIncluded: taxBase.pricesEnteredWithTax,
         taxCode,
         quantity: line.quantity,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -22,7 +22,7 @@ const checkIfIsDiscountedLine = (line: TaxBaseLine) => {
   return totalPrice !== undiscountedTotalPrice;
 };
 
-const isLineDiscounted = (line: TaxBaseLine, taxBase: TaxBaseFragment) => {
+const isProductLineDiscounted = (line: TaxBaseLine, taxBase: TaxBaseFragment) => {
   const isDiscounted = taxBase.discounts.length > 0;
 
   if (!isDiscounted) return false;
@@ -68,7 +68,7 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
         taxIncluded: taxBase.pricesEnteredWithTax,
         taxCode,
         quantity: line.quantity,
-        discounted: isLineDiscounted(line, taxBase),
+        discounted: isProductLineDiscounted(line, taxBase),
       };
     });
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -31,7 +31,7 @@ const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
  * If one item is discounted then the line has discounted totalPrice
  */
 const checkDiscounts = (taxBase: TaxBaseFragment, isDiscounted: boolean) => {
-  let hasEntireCheckoutDiscount = true;
+  let hasEntireCheckoutDiscount = false;
   let hasOncePerOrderVoucher = false;
   let discountedLinesCount = 0;
 
@@ -40,12 +40,6 @@ const checkDiscounts = (taxBase: TaxBaseFragment, isDiscounted: boolean) => {
 
     if (isLineDiscounted) {
       discountedLinesCount++;
-    } else {
-      hasEntireCheckoutDiscount = false;
-    }
-
-    if (discountedLinesCount > 1) {
-      hasEntireCheckoutDiscount = false;
     }
   }
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -30,37 +30,39 @@ const checkIfIsDiscountedLine = (isDiscounted: boolean, line: TaxBaseLine) => {
  * If entire checkout discount then lines in webhook subscription are not discounted
  * If one item is discounted then the line has discounted totalPrice
  */
-const checkDiscounts = (taxBase: TaxBaseFragment, isDiscounted: boolean) => {
+const checkDiscounts = (taxBase: TaxBaseFragment, isEntireSourceDiscounted: boolean) => {
   let hasEntireCheckoutDiscount = false;
   let hasOncePerOrderVoucher = false;
   let discountedLinesCount = 0;
 
-  for (const line of taxBase.lines) {
-    const isLineDiscounted = checkIfIsDiscountedLine(isDiscounted, line);
+  if (isEntireSourceDiscounted) {
+    for (const line of taxBase.lines) {
+      const isLineDiscounted = checkIfIsDiscountedLine(isEntireSourceDiscounted, line);
 
-    if (isLineDiscounted) {
-      discountedLinesCount++;
+      if (isLineDiscounted) {
+        discountedLinesCount++;
+      }
     }
   }
 
-  // If none of the lines are discounted, but isDiscounted is true then it's entire checkout discount
-  if (discountedLinesCount === 0 && isDiscounted) {
-    hasEntireCheckoutDiscount = true;
-  }
-
-  if (discountedLinesCount === 1) {
-    hasOncePerOrderVoucher = true;
-  }
+  // If none of the lines are discounted, but isEntireSourceDiscounted is true then it's entire checkout discount
+  hasEntireCheckoutDiscount = discountedLinesCount === 0;
+  hasOncePerOrderVoucher = discountedLinesCount === 1;
 
   return { hasEntireCheckoutDiscount, hasOncePerOrderVoucher };
 };
 
-const isProductLineDiscounted = (
-  line: TaxBaseLine,
-  isDiscounted: boolean,
-  hasOncePerOrderVoucher: boolean,
-  hasEntireCheckoutDiscount: boolean,
-) => {
+const isProductLineDiscounted = ({
+  line,
+  isDiscounted,
+  hasOncePerOrderVoucher,
+  hasEntireCheckoutDiscount,
+}: {
+  line: TaxBaseLine;
+  isDiscounted: boolean;
+  hasOncePerOrderVoucher: boolean;
+  hasEntireCheckoutDiscount: boolean;
+}) => {
   if (!isDiscounted) return false;
 
   if (hasOncePerOrderVoucher) {
@@ -95,12 +97,12 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
         taxIncluded: taxBase.pricesEnteredWithTax,
         taxCode,
         quantity: line.quantity,
-        discounted: isProductLineDiscounted(
+        discounted: isProductLineDiscounted({
           line,
           isDiscounted,
           hasOncePerOrderVoucher,
           hasEntireCheckoutDiscount,
-        ),
+        }),
       };
     });
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher.test.ts
@@ -22,6 +22,11 @@ describe("AvataxCalculateTaxesTaxCodeMatcher", () => {
           id: "1",
           product: {},
         },
+        undiscountedTotalPrice: {
+          net: {
+            amount: 100,
+          },
+        },
       },
     };
     const matches: AvataxTaxCodeMatches = [
@@ -55,6 +60,11 @@ describe("AvataxCalculateTaxesTaxCodeMatcher", () => {
               name: "Clothing",
               id: "1",
             },
+          },
+        },
+        undiscountedTotalPrice: {
+          net: {
+            amount: 100,
           },
         },
       },

--- a/apps/avatax/src/modules/webhooks/validate-webhook-payload.test.ts
+++ b/apps/avatax/src/modules/webhooks/validate-webhook-payload.test.ts
@@ -46,6 +46,11 @@ const getBasePayload = (): CalculateTaxesPayload => {
                 },
               },
             },
+            undiscountedTotalPrice: {
+              net: {
+                amount: 100,
+              },
+            },
             id: "1",
           },
         },

--- a/apps/avatax/src/pages/api/manifest.ts
+++ b/apps/avatax/src/pages/api/manifest.ts
@@ -32,7 +32,7 @@ export default wrapWithLoggerContext(
           homepageUrl: "https://github.com/saleor/apps",
           id: "saleor.app.avatax",
           name: "Avatax",
-          permissions: ["HANDLE_TAXES", "MANAGE_ORDERS"],
+          permissions: ["HANDLE_TAXES", "MANAGE_ORDERS", "MANAGE_DISCOUNTS"],
           requiredSaleorVersion: REQUIRED_SALEOR_VERSION,
           supportUrl: "https://github.com/saleor/apps/discussions",
           tokenTargetUrl: `${apiBaseURL}/api/register`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 13.2.3
       next:
         specifier: 13.4.8
-        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       prettier:
         specifier: 3.0.3
         version: 3.0.3
@@ -2559,7 +2559,7 @@ importers:
         version: 7.33.2(eslint@8.46.0)
       next:
         specifier: 13.4.8
-        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -2758,7 +2758,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2825,7 +2825,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -2856,7 +2856,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -21133,6 +21133,49 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
+
+  /next@13.4.8(@babel/core@7.23.9)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==}
+    engines: {node: '>=16.8.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      fibers: '>= 3.1.0'
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      fibers:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 13.4.8
+      '@opentelemetry/api': link:node_modules/@opentelemetry/api
+      '@swc/helpers': 0.5.1
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001561
+      postcss: 8.4.14
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
+      watchpack: 2.4.0
+      zod: 3.21.4
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 13.4.8
+      '@next/swc-darwin-x64': 13.4.8
+      '@next/swc-linux-arm64-gnu': 13.4.8
+      '@next/swc-linux-arm64-musl': 13.4.8
+      '@next/swc-linux-x64-gnu': 13.4.8
+      '@next/swc-linux-x64-musl': 13.4.8
+      '@next/swc-win32-arm64-msvc': 13.4.8
+      '@next/swc-win32-ia32-msvc': 13.4.8
+      '@next/swc-win32-x64-msvc': 13.4.8
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
 
   /next@13.4.8(@babel/core@7.23.9)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 13.2.3
       next:
         specifier: 13.4.8
-        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       prettier:
         specifier: 3.0.3
         version: 3.0.3
@@ -2559,7 +2559,7 @@ importers:
         version: 7.33.2(eslint@8.46.0)
       next:
         specifier: 13.4.8
-        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -2758,7 +2758,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2825,7 +2825,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -2856,7 +2856,7 @@ importers:
         version: link:../eslint-config-saleor
       next:
         specifier: 13.4.8
-        version: 13.4.8(@babel/core@7.23.9)(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.8(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -21133,49 +21133,6 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
-
-  /next@13.4.8(@babel/core@7.23.9)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==}
-    engines: {node: '>=16.8.0'}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      fibers: '>= 3.1.0'
-      react: ^18.2.0
-      react-dom: ^18.2.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      fibers:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 13.4.8
-      '@opentelemetry/api': link:node_modules/@opentelemetry/api
-      '@swc/helpers': 0.5.1
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001561
-      postcss: 8.4.14
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.9)(react@18.2.0)
-      watchpack: 2.4.0
-      zod: 3.21.4
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 13.4.8
-      '@next/swc-darwin-x64': 13.4.8
-      '@next/swc-linux-arm64-gnu': 13.4.8
-      '@next/swc-linux-arm64-musl': 13.4.8
-      '@next/swc-linux-x64-gnu': 13.4.8
-      '@next/swc-linux-x64-musl': 13.4.8
-      '@next/swc-win32-arm64-msvc': 13.4.8
-      '@next/swc-win32-ia32-msvc': 13.4.8
-      '@next/swc-win32-x64-msvc': 13.4.8
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   /next@13.4.8(@babel/core@7.23.9)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-lxUjndYKjZHGK3CWeN2RI+/6ni6EUvjiqGWXAYPxUfGIdFGQ5XoisrqAJ/dF74aP27buAfs8MKIbIMMdxjqSBg==}


### PR DESCRIPTION
## Scope of the PR

* Determines which discount is applied
* Checks which line is actually discounted
* Prevents Avalara from receiving multiple discounted lines when only one line is discounted

## Breaking change

Avatax needs additional permission - `MANAGE_DISCOUNTS`

<!-- Describe briefly changed made in this PR -->

## Related issues

https://github.com/saleor/apps/pull/1234 - E2E tests for this case

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
