### PR TITLE
Add `CheckoutError` fragment to CheckoutAddVoucher mutation

### DIFF
--- a/apps/avatax/e2e/graphql/mutations/CheckoutAddVoucher.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CheckoutAddVoucher.graphql
@@ -8,5 +8,8 @@ mutation CheckoutAddVoucher($checkoutId: ID!, $promoCode: String!) {
       }
       discountName
     }
+    errors {
+      ...CheckoutError
+    }
   }
 }


### PR DESCRIPTION
## Scope of the PR

Add error fragment for voucher creation mutation in Avatax E2E tests

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
