### PR TITLE
Update timeouts for e2e tests in PactumJS

### DIFF
--- a/apps/avatax/e2e/setup.ts
+++ b/apps/avatax/e2e/setup.ts
@@ -16,7 +16,9 @@ beforeAll(() => {
     throw new Error("Cannot run tests TEST_SALEOR_API_URL is invalid");
   }
 
-  settings.setRequestDefaultRetryCount(3);
+  settings.setRequestDefaultRetryCount(3); // retry up to 3 times by default
+  settings.setRequestDefaultRetryDelay(50); // wait 50ms between retries
+
   /*
    * We have to use baseUrl (without /graphql/ suffix)
    * for Pactum to work properly, it expects a base URL + path for each request
@@ -26,6 +28,6 @@ beforeAll(() => {
    * Use a default 20s timeout for tests
    * This is a timeout for sync webhooks in Saleor
    */
-  request.setDefaultTimeout(60_000);
+  request.setDefaultTimeout(20_000);
   stash.loadData("./e2e/data");
 });

--- a/apps/avatax/e2e/setup.ts
+++ b/apps/avatax/e2e/setup.ts
@@ -28,6 +28,6 @@ beforeAll(() => {
    * Use a default 20s timeout for tests
    * This is a timeout for sync webhooks in Saleor
    */
-  request.setDefaultTimeout(20_000);
+  request.setDefaultTimeout(21_000);
   stash.loadData("./e2e/data");
 });

--- a/apps/avatax/vitest.workspace.ts
+++ b/apps/avatax/vitest.workspace.ts
@@ -16,10 +16,11 @@ export default defineWorkspace([
       name: "integration",
       environment: "node",
       /*
-       * Use a default 60s timeout for tests
-       * Each request has a timeout of 20s, and can be retried up to 3 times
+       * Use a default 63s timeout for tests
+       * Each request has a timeout of 21s, and can be retried up to 3 times
+       * 20s is a timeout of sync webhooks in Saleor, we add additional buffer on top of that
        */
-      testTimeout: 60_000,
+      testTimeout: 63_000,
       /*
        * Request retries are done by PactumJS
        * Making a retry in vitest would cause issues with e2e utility

--- a/apps/avatax/vitest.workspace.ts
+++ b/apps/avatax/vitest.workspace.ts
@@ -16,10 +16,10 @@ export default defineWorkspace([
       name: "integration",
       environment: "node",
       /*
-       * Use a default 20s timeout for tests
-       * This is a timeout for sync webhooks in Saleor
+       * Use a default 60s timeout for tests
+       * Each request has a timeout of 20s, and can be retried up to 3 times
        */
-      testTimeout: 20_000,
+      testTimeout: 60_000,
       /*
        * Request retries are done by PactumJS
        * Making a retry in vitest would cause issues with e2e utility


### PR DESCRIPTION
## Scope of the PR

Update timeouts for PactumJS tests in Avatax, previously timeouts were raised for PactumJS but not vitest, which could have caused tests to be marked as failed due to timeout, even without doing any retries.

This PR also changes retry delay to be 50ms, instead of default 1000ms

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
