### PR TITLE
handle ActiveConnectionServiceErrors.WrongChannelError and other errors in order-confirmed webhook

### DIFF
--- a/.changeset/spotty-pandas-cross.md
+++ b/.changeset/spotty-pandas-cross.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Add handling of WrongChannelError for OrderConfirmed event. Now false-positive error will not be thrown

--- a/apps/avatax/src/modules/taxes/get-active-connection-service.ts
+++ b/apps/avatax/src/modules/taxes/get-active-connection-service.ts
@@ -44,7 +44,7 @@ export const ActiveConnectionServiceErrors = {
   ),
 
   /**
-   * Will happen when `order-created` webhook is triggered by creating an order in a channel that doesn't use the tax app
+   * Will happen when `order-confirmed` webhook is triggered by creating an order in a channel that doesn't use the tax app
    */
   WrongChannelError: ActiveConnectionServiceError.subclass("WrongChannelError"),
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
