### PR TITLE
Add fail-fast strategy to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,14 +1,17 @@
 name: E2E staging
 on:
   push:
-    branches:
-      - changeset-release/*
+    # TODO: remove after testing
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   e2e:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         saleor: [318, 319]
     env:
@@ -28,7 +31,7 @@ jobs:
             - args: [--frozen-lockfile, --filter=app-avatax]
       - name: Get Saleor snapshot
         run: |
-          BACKUP=$(pnpm dlx saleor backup list --name="snapshot-avatax-$SALEOR_VERSION" --latest --json)
+          BACKUP=$(pnpm dlx saleor backup list --name="snapshot-avat-$SALEOR_VERSION" --latest --json)
           BACKUP_ID=$(echo "$BACKUP" | jq -r '.[0].key')
           echo "BACKUP_ID=$BACKUP_ID" >> "$GITHUB_ENV"
       - name: Restore Saleor snapshot

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,8 @@
 name: E2E staging
 on:
   push:
-    # TODO: remove after testing
+    branches:
+      - changeset-release/*
   workflow_dispatch:
 
 concurrency:
@@ -31,7 +32,7 @@ jobs:
             - args: [--frozen-lockfile, --filter=app-avatax]
       - name: Get Saleor snapshot
         run: |
-          BACKUP=$(pnpm dlx saleor backup list --name="snapshot-avat-$SALEOR_VERSION" --latest --json)
+          BACKUP=$(pnpm dlx saleor backup list --name="snapshot-avatax-$SALEOR_VERSION" --latest --json)
           BACKUP_ID=$(echo "$BACKUP" | jq -r '.[0].key')
           echo "BACKUP_ID=$BACKUP_ID" >> "$GITHUB_ENV"
       - name: Restore Saleor snapshot

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,9 +5,6 @@ on:
       - changeset-release/*
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-
 jobs:
   e2e:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->

I added fail-fast strategy to e2e workflow. Currently if tests on 3.19 fails 3.18 job is canceled.

![CleanShot 2024-03-06 at 11 25 27@2x](https://github.com/saleor/apps/assets/9116238/5108622e-65cd-4ef8-92fc-772ac53dcd25)


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
