### PR TITLE
Use shipping address in `order-confirmed`

### DIFF
--- a/.changeset/violet-keys-help.md
+++ b/.changeset/violet-keys-help.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Avatax app now uses shipping address for order tax calculations

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -51,7 +51,9 @@ export class AvataxOrderConfirmedPayloadTransformer {
         commit: avataxConfig.isAutocommit,
         addresses: {
           shipFrom: avataxAddressFactory.fromChannelAddress(avataxConfig.address),
-          shipTo: avataxAddressFactory.fromSaleorAddress(order.shippingAddress!),
+          shipTo: avataxAddressFactory.fromSaleorAddress(
+            order.shippingAddress ?? order.billingAddress!,
+          ),
         },
         currencyCode: order.total.currency,
         // we can fall back to empty string because email is not a required field

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -10,6 +10,9 @@ import { AvataxDocumentCodeResolver } from "../avatax-document-code-resolver";
 import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxOrderConfirmedPayloadLinesTransformer } from "./avatax-order-confirmed-payload-lines-transformer";
+import { err, ok } from "neverthrow";
+import * as Sentry from "@sentry/nextjs";
+import { TaxBadPayloadError } from "../../taxes/tax-error";
 
 export class AvataxOrderConfirmedPayloadTransformer {
   private matchDocumentType(config: AvataxConfig): DocumentType {
@@ -19,6 +22,21 @@ export class AvataxOrderConfirmedPayloadTransformer {
     }
 
     return DocumentType.SalesInvoice;
+  }
+  private getSaleorAddress(order: OrderConfirmedSubscriptionFragment) {
+    if (order.shippingAddress) {
+      return ok(order.shippingAddress);
+    }
+
+    if (order.billingAddress) {
+      Sentry.captureMessage(
+        "OrderConfirmedPayload has no shipping address, falling back to billing address",
+      );
+
+      return ok(order.billingAddress);
+    }
+
+    return err(new TaxBadPayloadError("OrderConfirmedPayload has no shipping or billing address"));
   }
   async transform(
     order: OrderConfirmedSubscriptionFragment,
@@ -39,6 +57,13 @@ export class AvataxOrderConfirmedPayloadTransformer {
       orderId: order.id,
     });
     const customerCode = avataxCustomerCode.resolve(order.user);
+    const addressPayload = this.getSaleorAddress(order);
+
+    if (addressPayload.isErr()) {
+      Sentry.captureException(addressPayload.error);
+
+      throw addressPayload.error;
+    }
 
     return {
       model: {
@@ -51,9 +76,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
         commit: avataxConfig.isAutocommit,
         addresses: {
           shipFrom: avataxAddressFactory.fromChannelAddress(avataxConfig.address),
-          shipTo: avataxAddressFactory.fromSaleorAddress(
-            order.shippingAddress ?? order.billingAddress!,
-          ),
+          shipTo: avataxAddressFactory.fromSaleorAddress(addressPayload.value),
         },
         currencyCode: order.total.currency,
         // we can fall back to empty string because email is not a required field

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -32,11 +32,9 @@ export class AvataxOrderConfirmedPayloadTransformer {
     }
 
     if (order.billingAddress) {
-      const message =
-        "OrderConfirmedPayload has no shipping address, falling back to billing address";
-
-      this.logger.warn(message);
-      Sentry.captureMessage(message);
+      this.logger.warn(
+        "OrderConfirmedPayload has no shipping address, falling back to billing address",
+      );
 
       return ok(order.billingAddress);
     }

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -51,8 +51,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
         commit: avataxConfig.isAutocommit,
         addresses: {
           shipFrom: avataxAddressFactory.fromChannelAddress(avataxConfig.address),
-          // billing or shipping address?
-          shipTo: avataxAddressFactory.fromSaleorAddress(order.billingAddress!),
+          shipTo: avataxAddressFactory.fromSaleorAddress(order.shippingAddress!),
         },
         currencyCode: order.total.currency,
         // we can fall back to empty string because email is not a required field

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -64,7 +64,9 @@ export class AvataxOrderConfirmedPayloadTransformer {
 
     if (addressPayload.isErr()) {
       Sentry.captureException(addressPayload.error);
-      this.logger.error("Error while transforming OrderConfirmedPayload", addressPayload.error);
+      this.logger.error("Error while transforming OrderConfirmedPayload", {
+        error: addressPayload.error,
+      });
 
       throw addressPayload.error;
     }

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -86,6 +86,7 @@ export default wrapWithLoggerContext(
 
             switch (true) {
               case error instanceof TaxBadPayloadError: {
+                // @ts-ignore - Vercel uses old version of Typescript
                 return res.status(400).send(error.message);
               }
             }

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -66,7 +66,7 @@ export default wrapWithLoggerContext(
           try {
             const confirmedOrder = await taxProviderResult.value.confirmOrder(payload.order);
 
-            logger.info("Order confirmed", { confirmedOrder });
+            logger.info("Order confirmed", { orderId: confirmedOrder.id });
             const client = createInstrumentedGraphqlClient({
               saleorApiUrl,
               token,

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -13,6 +13,7 @@ import {
   getActiveConnectionService,
 } from "../../../modules/taxes/get-active-connection-service";
 import { orderConfirmedAsyncWebhook } from "../../../modules/webhooks/definitions/order-confirmed";
+import { TaxBadPayloadError } from "../../../modules/taxes/tax-error";
 
 export const config = {
   api: {

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -86,7 +86,6 @@ export default wrapWithLoggerContext(
 
             switch (true) {
               case error instanceof TaxBadPayloadError: {
-                // @ts-ignore - Vercel uses old version of Typescript
                 return res.status(400).send("Order data is not valid.");
               }
             }

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -87,7 +87,7 @@ export default wrapWithLoggerContext(
             switch (true) {
               case error instanceof TaxBadPayloadError: {
                 // @ts-ignore - Vercel uses old version of Typescript
-                return res.status(400).send(error.message);
+                return res.status(400).send("Order data is not valid.");
               }
             }
 


### PR DESCRIPTION
## Scope of the PR

* Changes billing address to shipping address in `order-confirmed`
* Adds payload verification in `order-confirmed`

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).

## Known problems

- If deployment of `saleor-app-search` fails - rerun vercel deployment. We work with Vercel of fixing that but for now we suggest this as workaround.
