### PR TITLE
Fix Sentry error logging for Avatax

### DIFF
--- a/.changeset/little-ears-talk.md
+++ b/.changeset/little-ears-talk.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Cleanup `WebhookResponse.error` function - now it won't capture exception to Sentry. Instead you should use `Sentry.captureException` explicitly when there is unhandled exception.

--- a/apps/avatax/src/modules/app/webhook-response.ts
+++ b/apps/avatax/src/modules/app/webhook-response.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/nextjs";
 import { NextApiResponse } from "next";
 
 import { CriticalError, ExpectedError } from "../../error";
@@ -16,11 +15,10 @@ export class WebhookResponse {
   }
 
   /**
-   * @deprecated
+   * @deprecated use `NextApiResponse.res.status(500)` instead
    */
   error(error: unknown) {
     if (error instanceof CriticalError) {
-      Sentry.captureException(error);
       this.logger.error("CriticalError occurred", { error });
       return this.respondWithError(error.message);
     }
@@ -30,8 +28,6 @@ export class WebhookResponse {
       return this.respondWithError(error.message);
     }
 
-    Sentry.captureMessage("Unhandled error occurred");
-    Sentry.captureException(error);
     this.logger.error("Unhandled error occurred", { error });
     return this.respondWithError("Unhandled error occurred");
   }

--- a/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
@@ -33,7 +33,8 @@ export default wrapWithLoggerContext(
       if (!payload.order) {
         const error = new Error("Insufficient order data");
 
-        Sentry.captureException(error);
+        logger.error("Insufficient order data", { error });
+
         return webhookResponse.error(error);
       }
 

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -12,8 +12,8 @@ import {
   ActiveConnectionServiceErrors,
   getActiveConnectionService,
 } from "../../../modules/taxes/get-active-connection-service";
-import { orderConfirmedAsyncWebhook } from "../../../modules/webhooks/definitions/order-confirmed";
 import { TaxBadPayloadError } from "../../../modules/taxes/tax-error";
+import { orderConfirmedAsyncWebhook } from "../../../modules/webhooks/definitions/order-confirmed";
 
 export const config = {
   api: {
@@ -51,7 +51,6 @@ export default wrapWithLoggerContext(
         if (!payload.order) {
           const error = new Error("Insufficient order data");
 
-          Sentry.captureException(error);
           return webhookResponse.error(error);
         }
 
@@ -90,7 +89,7 @@ export default wrapWithLoggerContext(
                 return res.status(400).send("Order data is not valid.");
               }
             }
-
+            Sentry.captureException(error);
             logger.error("Unhandled error executing webhook", { error });
             return webhookResponse.error(error);
           }


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Cleanup `WebhookResponse.error` function - now it won't capture exception to Sentry. Instead you should use `Sentry.captureException` explicitly when there is unhandled exception. I also removed not needed `captureMessage` from `WebhookResponse.error`

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
