### PR TITLE
add metadata cache for webhooks

### DIFF
--- a/.changeset/two-adults-repair.md
+++ b/.changeset/two-adults-repair.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": minor
+---
+
+Added caching to App Metadata. Now, when webhook is called by Saleor, metadata from payload will be cached and consumed in MetadataManager. If cache doesn't exist, MetadataManager will fetch missing metadata. This change removes unnecessary graphql call that was timing out the handler.

--- a/apps/avatax/bruno/package-lock.json
+++ b/apps/avatax/bruno/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "bruno",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bruno",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@faker-js/faker": "^8.4.1"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
+    }
+  }
+}

--- a/apps/avatax/src/lib/app-metadata-cache.ts
+++ b/apps/avatax/src/lib/app-metadata-cache.ts
@@ -1,0 +1,43 @@
+import { AsyncLocalStorage } from "async_hooks";
+import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
+import { SALEOR_API_URL_HEADER, SALEOR_EVENT_HEADER } from "@saleor/app-sdk/const";
+
+/**
+ * Set global context that stores metadata from webhook payload.
+ * Use it as a temporary storage that provides access to metadata in the request scope
+ */
+export class AppMetadataCache {
+  private als = new AsyncLocalStorage<Record<string, unknown>>();
+
+  getRawContext() {
+    const store = this.als.getStore();
+
+    if (!store) {
+      console.debug("You cant use LoggerContext outside of the wrapped scope. Will fallback to {}");
+
+      return {};
+    }
+
+    return store;
+  }
+
+  async wrap(fn: (...args: unknown[]) => unknown, initialState = {}) {
+    return this.als.run(initialState, fn);
+  }
+
+  set(key: string, value: string | number | Record<string, unknown> | null) {
+    const store = this.getRawContext();
+
+    store[key] = value;
+  }
+}
+
+export const wrapWithMetadataCache = (cache: AppMetadataCache) => (handler: NextApiHandler) => {
+  return (req: NextApiRequest, res: NextApiResponse) => {
+    return cache.wrap(() => {
+      return handler(req, res);
+    });
+  };
+};
+
+export const metadataCache = new AppMetadataCache();

--- a/apps/avatax/src/lib/app-metadata-cache.ts
+++ b/apps/avatax/src/lib/app-metadata-cache.ts
@@ -15,7 +15,7 @@ export class AppMetadataCache {
     if (!store) {
       console.debug("You cant use LoggerContext outside of the wrapped scope. Will fallback to {}");
 
-      return [];
+      return null;
     }
 
     return store.metadata;

--- a/apps/avatax/src/modules/app/metadata-manager.test.ts
+++ b/apps/avatax/src/modules/app/metadata-manager.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, Mock } from "vitest";
+import { createSettingsManager } from "./metadata-manager";
+import { Client } from "urql";
+import { AppMetadataCache } from "../../lib/app-metadata-cache";
+import { encrypt } from "@saleor/app-sdk/settings-manager";
+
+const mockGqlClient: Pick<Client, "query" | "mutation"> = {
+  mutation: vi.fn(),
+  query: vi.fn(),
+};
+
+const SECRET_KEY = "SECRET_KEY";
+const METADATA_KEY = "foo";
+const METADATA_VALUE = "bar";
+
+vi.stubEnv("SECRET_KEY", SECRET_KEY);
+
+describe("MetadataManager", () => {
+  it("Consumes cache if exists", async () => {
+    const cache = new AppMetadataCache();
+    const manager = createSettingsManager(mockGqlClient, "test-id", cache);
+
+    function someExecution() {
+      cache.setMetadata([
+        {
+          key: METADATA_KEY,
+          value: encrypt(METADATA_VALUE, SECRET_KEY),
+        },
+      ]);
+
+      return manager.get(METADATA_KEY);
+    }
+
+    return expect(cache.wrap(() => someExecution())).resolves.toBe("bar");
+  });
+
+  it("Still works if cache is empty", () => {
+    const cache = new AppMetadataCache();
+    const manager = createSettingsManager(mockGqlClient, "test-id", cache);
+
+    (mockGqlClient.query as Mock).mockImplementationOnce(() => {
+      return {
+        async toPromise() {
+          return {
+            data: {
+              app: {
+                privateMetadata: [
+                  {
+                    key: METADATA_KEY,
+                    value: encrypt(METADATA_VALUE, SECRET_KEY),
+                  },
+                ],
+              },
+            },
+          };
+        },
+      };
+    });
+
+    function someExecution() {
+      return manager.get(METADATA_KEY);
+    }
+
+    return expect(cache.wrap(() => someExecution())).resolves.toBe(METADATA_VALUE);
+  });
+});

--- a/apps/avatax/src/modules/app/metadata-manager.ts
+++ b/apps/avatax/src/modules/app/metadata-manager.ts
@@ -72,7 +72,10 @@ export const createSettingsManager = (client: Client, appId: string) => {
   return new EncryptedMetadataManager({
     // Secret key should be randomly created for production and set as environment variable
     encryptionKey: process.env.SECRET_KEY!,
-    fetchMetadata: () => fetchAllMetadata(client),
+    fetchMetadata: () => {
+      console.warn("Calling FETCH ALL METADATA");
+      return fetchAllMetadata(client);
+    },
     mutateMetadata: (metadata) => mutateMetadata(client, metadata, appId),
   });
 };

--- a/apps/avatax/src/modules/avatax/configuration/avatax-connection-repository.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-connection-repository.ts
@@ -19,10 +19,7 @@ export class AvataxConnectionRepository {
   private logger = createLogger("AvataxConnectionRepository", {
     metadataKey: TAX_PROVIDER_KEY,
   });
-  constructor(
-    private settingsManager: EncryptedMetadataManager,
-    private saleorApiUrl: string,
-  ) {
+  constructor(settingsManager: EncryptedMetadataManager, saleorApiUrl: string) {
     this.crudSettingsManager = new CrudSettingsManager(
       settingsManager,
       saleorApiUrl,

--- a/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -6,6 +6,7 @@ import { AvataxConnectionRepository } from "./avatax-connection-repository";
 import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
 import { AvataxClient } from "../avatax-client";
 import { createLogger } from "../../../logger";
+import { metadataCache } from "../../../lib/app-metadata-cache";
 
 export class AvataxConnectionService {
   private logger = createLogger("AvataxConnectionService");
@@ -20,7 +21,7 @@ export class AvataxConnectionService {
     appId: string;
     saleorApiUrl: string;
   }) {
-    const settingsManager = createSettingsManager(client, appId);
+    const settingsManager = createSettingsManager(client, appId, metadataCache);
 
     this.avataxConnectionRepository = new AvataxConnectionRepository(settingsManager, saleorApiUrl);
   }

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
@@ -7,6 +7,7 @@ import {
 } from "./avatax-tax-code-match-repository";
 import { createLogger } from "../../../logger";
 import { createInstrumentedGraphqlClient } from "../../../lib/create-instrumented-graphql-client";
+import { metadataCache } from "../../../lib/app-metadata-cache";
 
 export class AvataxTaxCodeMatchesService {
   private logger = createLogger("AvataxTaxCodeMatchesService");
@@ -18,7 +19,7 @@ export class AvataxTaxCodeMatchesService {
       token: authData.token,
     });
     const { appId, saleorApiUrl } = authData;
-    const settingsManager = createSettingsManager(client, appId);
+    const settingsManager = createSettingsManager(client, appId, metadataCache);
 
     this.taxCodeMatchRepository = new AvataxTaxCodeMatchRepository(settingsManager, saleorApiUrl);
   }

--- a/apps/avatax/src/modules/channel-configuration/channel-configuration.service.ts
+++ b/apps/avatax/src/modules/channel-configuration/channel-configuration.service.ts
@@ -6,6 +6,7 @@ import { ChannelConfigurationMerger } from "./channel-configuration-merger";
 import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
 import { createSettingsManager } from "../app/metadata-manager";
 import { createLogger } from "../../logger";
+import { metadataCache } from "../../lib/app-metadata-cache";
 
 export class ChannelConfigurationService {
   private configurationRepository: ChannelConfigurationRepository;
@@ -16,7 +17,7 @@ export class ChannelConfigurationService {
     private appId: string,
     private saleorApiUrl: string,
   ) {
-    const settingsManager = createSettingsManager(client, appId);
+    const settingsManager = createSettingsManager(client, appId, metadataCache);
 
     this.settingsManager = settingsManager;
 

--- a/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
@@ -53,6 +53,9 @@ export default wrapWithLoggerContext(
           }
 
           const appMetadata = payload.recipient?.privateMetadata ?? [];
+
+          metadataCache.setMetadata(appMetadata);
+
           const channelSlug = payload.taxBase.channel.slug;
           const activeConnectionServiceResult = getActiveConnectionService(
             channelSlug,

--- a/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
@@ -10,6 +10,7 @@ import { ObservabilityAttributes } from "@saleor/apps-otel/src/lib/observability
 import { loggerContext } from "../../../logger-context";
 import { checkoutCalculateTaxesSyncWebhook } from "../../../modules/webhooks/definitions/checkout-calculate-taxes";
 import { verifyCalculateTaxesPayload } from "../../../modules/webhooks/validate-webhook-payload";
+import { metadataCache, wrapWithMetadataCache } from "../../../lib/app-metadata-cache";
 
 export const config = {
   api: {
@@ -17,79 +18,84 @@ export const config = {
   },
 };
 
+const withMetadataCache = wrapWithMetadataCache(metadataCache);
+
 /**
  * TODO: Add tests to handler
  */
 export default wrapWithLoggerContext(
   withOtel(
-    checkoutCalculateTaxesSyncWebhook.createHandler(async (req, res, ctx) => {
-      const webhookResponse = new WebhookResponse(res);
+    withMetadataCache(
+      checkoutCalculateTaxesSyncWebhook.createHandler(async (req, res, ctx) => {
+        const webhookResponse = new WebhookResponse(res);
 
-      try {
-        const logger = createLogger("checkoutCalculateTaxesSyncWebhook");
-        const { payload } = ctx;
+        try {
+          const logger = createLogger("checkoutCalculateTaxesSyncWebhook");
+          const { payload } = ctx;
 
-        loggerContext.set("channelSlug", ctx.payload.taxBase.channel.slug);
-        loggerContext.set("checkoutId", ctx.payload.taxBase.sourceObject.id);
-        if (payload.version) {
-          Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-          loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-        }
+          loggerContext.set("channelSlug", ctx.payload.taxBase.channel.slug);
+          loggerContext.set("checkoutId", ctx.payload.taxBase.sourceObject.id);
+          if (payload.version) {
+            Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+            loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+          }
 
-        logger.info("Handler for CHECKOUT_CALCULATE_TAXES webhook called");
+          logger.info("Handler for CHECKOUT_CALCULATE_TAXES webhook called");
 
-        const payloadVerificationResult = verifyCalculateTaxesPayload(payload);
+          const payloadVerificationResult = verifyCalculateTaxesPayload(payload);
 
-        if (payloadVerificationResult.isErr()) {
-          logger.warn("Failed to calculate taxes, due to incomplete payload", {
-            error: payloadVerificationResult.error,
-          });
+          if (payloadVerificationResult.isErr()) {
+            logger.warn("Failed to calculate taxes, due to incomplete payload", {
+              error: payloadVerificationResult.error,
+            });
 
-          return res.status(400).send(payloadVerificationResult.error.message);
-        }
+            return res.status(400).send(payloadVerificationResult.error.message);
+          }
 
-        const appMetadata = payload.recipient?.privateMetadata ?? [];
-        const channelSlug = payload.taxBase.channel.slug;
-        const activeConnectionServiceResult = getActiveConnectionService(
-          channelSlug,
-          appMetadata,
-          ctx.authData,
-        );
+          const appMetadata = payload.recipient?.privateMetadata ?? [];
+          const channelSlug = payload.taxBase.channel.slug;
+          const activeConnectionServiceResult = getActiveConnectionService(
+            channelSlug,
+            appMetadata,
+            ctx.authData,
+          );
 
-        if (activeConnectionServiceResult.isErr()) {
-          const err = activeConnectionServiceResult.error;
+          if (activeConnectionServiceResult.isErr()) {
+            const err = activeConnectionServiceResult.error;
 
-          logger.warn(`Error in taxes calculation occurred: ${err.name} ${err.message}`, {
-            error: err,
-          });
-
-          const executeErrorStrategy = calculateTaxesErrorsStrategy(req, res).get(err.name);
-
-          if (executeErrorStrategy) {
-            return executeErrorStrategy();
-          } else {
-            Sentry.captureException(err);
-
-            logger.fatal(`UNHANDLED: ${err.name}`, {
+            logger.warn(`Error in taxes calculation occurred: ${err.name} ${err.message}`, {
               error: err,
             });
 
-            return res.status(500).send("Error calculating taxes");
+            const executeErrorStrategy = calculateTaxesErrorsStrategy(req, res).get(err.name);
+
+            if (executeErrorStrategy) {
+              return executeErrorStrategy();
+            } else {
+              Sentry.captureException(err);
+
+              logger.fatal(`UNHANDLED: ${err.name}`, {
+                error: err,
+              });
+
+              return res.status(500).send("Error calculating taxes");
+            }
+          } else {
+            logger.info("Found active connection service. Calculating taxes...");
+            // TODO: Improve errors handling like above
+            const calculatedTaxes =
+              await activeConnectionServiceResult.value.calculateTaxes(payload);
+
+            logger.info("Taxes calculated", { calculatedTaxes });
+            return webhookResponse.success(ctx.buildResponse(calculatedTaxes));
           }
-        } else {
-          logger.info("Found active connection service. Calculating taxes...");
-          // TODO: Improve errors handling like above
-          const calculatedTaxes = await activeConnectionServiceResult.value.calculateTaxes(payload);
+        } catch (error) {
+          Sentry.captureException(error);
 
-          logger.info("Taxes calculated", { calculatedTaxes });
-          return webhookResponse.success(ctx.buildResponse(calculatedTaxes));
+          return webhookResponse.error(error);
         }
-      } catch (error) {
-        Sentry.captureException(error);
-
-        return webhookResponse.error(error);
-      }
-    }),
+      }),
+    ),
     "/api/webhooks/checkout-calculate-taxes",
   ),
   loggerContext,

--- a/apps/avatax/src/pages/api/webhooks/order-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-calculate-taxes.ts
@@ -9,6 +9,7 @@ import { getActiveConnectionService } from "../../../modules/taxes/get-active-co
 import { calculateTaxesErrorsStrategy } from "../../../modules/webhooks/calculate-taxes-errors-strategy";
 import { orderCalculateTaxesSyncWebhook } from "../../../modules/webhooks/definitions/order-calculate-taxes";
 import { verifyCalculateTaxesPayload } from "../../../modules/webhooks/validate-webhook-payload";
+import { metadataCache, wrapWithMetadataCache } from "../../../lib/app-metadata-cache";
 
 export const config = {
   api: {
@@ -16,74 +17,79 @@ export const config = {
   },
 };
 
+const withMetadataCache = wrapWithMetadataCache(metadataCache);
+
 export default wrapWithLoggerContext(
   withOtel(
-    orderCalculateTaxesSyncWebhook.createHandler(async (req, res, ctx) => {
-      const webhookResponse = new WebhookResponse(res);
+    withMetadataCache(
+      orderCalculateTaxesSyncWebhook.createHandler(async (req, res, ctx) => {
+        const webhookResponse = new WebhookResponse(res);
 
-      try {
-        const logger = createLogger("orderCalculateTaxesSyncWebhook");
-        const { payload } = ctx;
+        try {
+          const logger = createLogger("orderCalculateTaxesSyncWebhook");
+          const { payload } = ctx;
 
-        loggerContext.set("channelSlug", ctx.payload.taxBase.channel.slug);
-        loggerContext.set("orderId", ctx.payload.taxBase.sourceObject.id);
-        if (payload.version) {
-          Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-          loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-        }
+          loggerContext.set("channelSlug", ctx.payload.taxBase.channel.slug);
+          loggerContext.set("orderId", ctx.payload.taxBase.sourceObject.id);
+          if (payload.version) {
+            Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+            loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+          }
 
-        logger.info("Handler for ORDER_CALCULATE_TAXES webhook called");
+          logger.info("Handler for ORDER_CALCULATE_TAXES webhook called");
 
-        const payloadVerificationResult = verifyCalculateTaxesPayload(payload);
+          const payloadVerificationResult = verifyCalculateTaxesPayload(payload);
 
-        if (payloadVerificationResult.isErr()) {
-          logger.warn("Failed to calculate taxes, due to incomplete payload", {
-            error: payloadVerificationResult.error,
-          });
+          if (payloadVerificationResult.isErr()) {
+            logger.warn("Failed to calculate taxes, due to incomplete payload", {
+              error: payloadVerificationResult.error,
+            });
 
-          return res.status(400).send(payloadVerificationResult.error.message);
-        }
+            return res.status(400).send(payloadVerificationResult.error.message);
+          }
 
-        const appMetadata = payload.recipient?.privateMetadata ?? [];
-        const channelSlug = payload.taxBase.channel.slug;
-        const activeConnectionServiceResult = getActiveConnectionService(
-          channelSlug,
-          appMetadata,
-          ctx.authData,
-        );
+          const appMetadata = payload.recipient?.privateMetadata ?? [];
+          const channelSlug = payload.taxBase.channel.slug;
+          const activeConnectionServiceResult = getActiveConnectionService(
+            channelSlug,
+            appMetadata,
+            ctx.authData,
+          );
 
-        if (activeConnectionServiceResult.isOk()) {
-          const calculatedTaxes = await activeConnectionServiceResult.value.calculateTaxes(payload);
+          if (activeConnectionServiceResult.isOk()) {
+            const calculatedTaxes =
+              await activeConnectionServiceResult.value.calculateTaxes(payload);
 
-          logger.info("Taxes calculated", { calculatedTaxes });
+            logger.info("Taxes calculated", { calculatedTaxes });
 
-          return webhookResponse.success(ctx.buildResponse(calculatedTaxes));
-        } else if (activeConnectionServiceResult.isErr()) {
-          const err = activeConnectionServiceResult.error;
+            return webhookResponse.success(ctx.buildResponse(calculatedTaxes));
+          } else if (activeConnectionServiceResult.isErr()) {
+            const err = activeConnectionServiceResult.error;
 
-          logger.warn(`Error in taxes calculation occurred: ${err.name} ${err.message}`, {
-            error: err,
-          });
-
-          const executeErrorStrategy = calculateTaxesErrorsStrategy(req, res).get(err.name);
-
-          if (executeErrorStrategy) {
-            return executeErrorStrategy();
-          } else {
-            Sentry.captureException(err);
-            logger.fatal(`UNHANDLED: ${err.name}`, {
+            logger.warn(`Error in taxes calculation occurred: ${err.name} ${err.message}`, {
               error: err,
             });
 
-            return res.status(500).send("Error calculating taxes");
-          }
-        }
-      } catch (error) {
-        Sentry.captureException(error);
+            const executeErrorStrategy = calculateTaxesErrorsStrategy(req, res).get(err.name);
 
-        return webhookResponse.error(error);
-      }
-    }),
+            if (executeErrorStrategy) {
+              return executeErrorStrategy();
+            } else {
+              Sentry.captureException(err);
+              logger.fatal(`UNHANDLED: ${err.name}`, {
+                error: err,
+              });
+
+              return res.status(500).send("Error calculating taxes");
+            }
+          }
+        } catch (error) {
+          Sentry.captureException(error);
+
+          return webhookResponse.error(error);
+        }
+      }),
+    ),
     "/api/order-calculate-taxes",
   ),
   loggerContext,

--- a/apps/avatax/src/pages/api/webhooks/order-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-calculate-taxes.ts
@@ -49,6 +49,9 @@ export default wrapWithLoggerContext(
           }
 
           const appMetadata = payload.recipient?.privateMetadata ?? [];
+
+          metadataCache.setMetadata(appMetadata);
+
           const channelSlug = payload.taxBase.channel.slug;
           const activeConnectionServiceResult = getActiveConnectionService(
             channelSlug,

--- a/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
@@ -7,6 +7,7 @@ import { loggerContext } from "../../../logger-context";
 import { WebhookResponse } from "../../../modules/app/webhook-response";
 import { getActiveConnectionService } from "../../../modules/taxes/get-active-connection-service";
 import { orderCancelledAsyncWebhook } from "../../../modules/webhooks/definitions/order-cancelled";
+import { metadataCache, wrapWithMetadataCache } from "../../../lib/app-metadata-cache";
 
 export const config = {
   api: {
@@ -14,59 +15,63 @@ export const config = {
   },
 };
 
+const withMetadataCache = wrapWithMetadataCache(metadataCache);
+
 export default wrapWithLoggerContext(
   withOtel(
-    orderCancelledAsyncWebhook.createHandler(async (req, res, ctx) => {
-      const logger = createLogger("orderCancelledAsyncWebhook", {
-        saleorApiUrl: ctx.authData.saleorApiUrl,
-      });
-      const { payload } = ctx;
-      const webhookResponse = new WebhookResponse(res);
+    withMetadataCache(
+      orderCancelledAsyncWebhook.createHandler(async (req, res, ctx) => {
+        const logger = createLogger("orderCancelledAsyncWebhook", {
+          saleorApiUrl: ctx.authData.saleorApiUrl,
+        });
+        const { payload } = ctx;
+        const webhookResponse = new WebhookResponse(res);
 
-      if (payload.version) {
-        Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-        loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-      }
-
-      logger.info("Handler called with payload");
-
-      if (!payload.order) {
-        const error = new Error("Insufficient order data");
-
-        logger.error("Insufficient order data", { error });
-
-        return webhookResponse.error(error);
-      }
-
-      try {
-        const appMetadata = payload.recipient?.privateMetadata ?? [];
-        const channelSlug = payload.order.channel.slug;
-        const taxProviderResult = getActiveConnectionService(
-          channelSlug,
-          appMetadata,
-          ctx.authData,
-        );
-
-        logger.info("Cancelling order...");
-
-        if (taxProviderResult.isOk()) {
-          await taxProviderResult.value.cancelOrder(payload);
-
-          logger.info("Order cancelled");
-
-          return webhookResponse.success();
+        if (payload.version) {
+          Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+          loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
         }
 
-        if (taxProviderResult.isErr()) {
-          Sentry.captureException(taxProviderResult.error);
-          // TODO: Map errors
-          return webhookResponse.error(taxProviderResult.error);
+        logger.info("Handler called with payload");
+
+        if (!payload.order) {
+          const error = new Error("Insufficient order data");
+
+          logger.error("Insufficient order data", { error });
+
+          return webhookResponse.error(error);
         }
-      } catch (error) {
-        Sentry.captureException(error);
-        return webhookResponse.error(error);
-      }
-    }),
+
+        try {
+          const appMetadata = payload.recipient?.privateMetadata ?? [];
+          const channelSlug = payload.order.channel.slug;
+          const taxProviderResult = getActiveConnectionService(
+            channelSlug,
+            appMetadata,
+            ctx.authData,
+          );
+
+          logger.info("Cancelling order...");
+
+          if (taxProviderResult.isOk()) {
+            await taxProviderResult.value.cancelOrder(payload);
+
+            logger.info("Order cancelled");
+
+            return webhookResponse.success();
+          }
+
+          if (taxProviderResult.isErr()) {
+            Sentry.captureException(taxProviderResult.error);
+            // TODO: Map errors
+            return webhookResponse.error(taxProviderResult.error);
+          }
+        } catch (error) {
+          Sentry.captureException(error);
+          return webhookResponse.error(error);
+        }
+      }),
+    ),
     "/api/webhooks/order-cancelled",
   ),
   loggerContext,

--- a/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-cancelled.ts
@@ -44,6 +44,9 @@ export default wrapWithLoggerContext(
 
         try {
           const appMetadata = payload.recipient?.privateMetadata ?? [];
+
+          metadataCache.setMetadata(appMetadata);
+
           const channelSlug = payload.order.channel.slug;
           const taxProviderResult = getActiveConnectionService(
             channelSlug,

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../modules/taxes/get-active-connection-service";
 import { TaxBadPayloadError } from "../../../modules/taxes/tax-error";
 import { orderConfirmedAsyncWebhook } from "../../../modules/webhooks/definitions/order-confirmed";
+import { metadataCache, wrapWithMetadataCache } from "../../../lib/app-metadata-cache";
 
 export const config = {
   api: {
@@ -21,119 +22,123 @@ export const config = {
   },
 };
 
+const withMetadataCache = wrapWithMetadataCache(metadataCache);
+
 export default wrapWithLoggerContext(
   withOtel(
-    orderConfirmedAsyncWebhook.createHandler(async (req, res, ctx) => {
-      const logger = createLogger("orderConfirmedAsyncWebhook", {
-        saleorApiUrl: ctx.authData.saleorApiUrl,
-      });
-      const { payload, authData } = ctx;
-      const { saleorApiUrl, token } = authData;
-      const webhookResponse = new WebhookResponse(res);
+    withMetadataCache(
+      orderConfirmedAsyncWebhook.createHandler(async (req, res, ctx) => {
+        const logger = createLogger("orderConfirmedAsyncWebhook", {
+          saleorApiUrl: ctx.authData.saleorApiUrl,
+        });
+        const { payload, authData } = ctx;
+        const { saleorApiUrl, token } = authData;
+        const webhookResponse = new WebhookResponse(res);
 
-      if (payload.version) {
-        Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-        loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
-      }
-
-      logger.info("Handler called with payload");
-
-      try {
-        const appMetadata = payload.recipient?.privateMetadata ?? [];
-        const channelSlug = payload.order?.channel.slug;
-        const taxProviderResult = getActiveConnectionService(
-          channelSlug,
-          appMetadata,
-          ctx.authData,
-        );
-
-        // todo: figure out what fields are needed and add validation
-        if (!payload.order) {
-          const error = new Error("Insufficient order data");
-
-          return webhookResponse.error(error);
+        if (payload.version) {
+          Sentry.setTag(ObservabilityAttributes.SALEOR_VERSION, payload.version);
+          loggerContext.set(ObservabilityAttributes.SALEOR_VERSION, payload.version);
         }
 
-        if (payload.order.status === OrderStatus.Fulfilled) {
-          return webhookResponse.error(
-            new Error("Skipping fulfilled order to prevent duplication"),
+        logger.info("Handler called with payload");
+
+        try {
+          const appMetadata = payload.recipient?.privateMetadata ?? [];
+          const channelSlug = payload.order?.channel.slug;
+          const taxProviderResult = getActiveConnectionService(
+            channelSlug,
+            appMetadata,
+            ctx.authData,
           );
-        }
 
-        logger.debug("Confirming order...");
+          // todo: figure out what fields are needed and add validation
+          if (!payload.order) {
+            const error = new Error("Insufficient order data");
 
-        if (taxProviderResult.isOk()) {
-          try {
-            const confirmedOrder = await taxProviderResult.value.confirmOrder(payload.order);
+            return webhookResponse.error(error);
+          }
 
-            logger.info("Order confirmed", { orderId: confirmedOrder.id });
-            const client = createInstrumentedGraphqlClient({
-              saleorApiUrl,
-              token,
-            });
-
-            const orderMetadataManager = new OrderMetadataManager(client);
-
-            await orderMetadataManager.updateOrderMetadataWithExternalId(
-              payload.order.id,
-              confirmedOrder.id,
+          if (payload.order.status === OrderStatus.Fulfilled) {
+            return webhookResponse.error(
+              new Error("Skipping fulfilled order to prevent duplication"),
             );
-            logger.info("Updated order metadata with externalId");
+          }
 
-            return webhookResponse.success();
-          } catch (error) {
+          logger.debug("Confirming order...");
+
+          if (taxProviderResult.isOk()) {
+            try {
+              const confirmedOrder = await taxProviderResult.value.confirmOrder(payload.order);
+
+              logger.info("Order confirmed", { orderId: confirmedOrder.id });
+              const client = createInstrumentedGraphqlClient({
+                saleorApiUrl,
+                token,
+              });
+
+              const orderMetadataManager = new OrderMetadataManager(client);
+
+              await orderMetadataManager.updateOrderMetadataWithExternalId(
+                payload.order.id,
+                confirmedOrder.id,
+              );
+              logger.info("Updated order metadata with externalId");
+
+              return webhookResponse.success();
+            } catch (error) {
+              logger.debug("Error confirming order", { error });
+
+              switch (true) {
+                case error instanceof TaxBadPayloadError: {
+                  return res.status(400).send("Order data is not valid.");
+                }
+              }
+              Sentry.captureException(error);
+              logger.error("Unhandled error executing webhook", { error });
+              return webhookResponse.error(error);
+            }
+          }
+
+          if (taxProviderResult.isErr()) {
+            const error = taxProviderResult.error;
+
             logger.debug("Error confirming order", { error });
 
             switch (true) {
-              case error instanceof TaxBadPayloadError: {
-                return res.status(400).send("Order data is not valid.");
+              case error instanceof ActiveConnectionServiceErrors.WrongChannelError: {
+                /**
+                 * Subscription can listen on every channel or no channels.
+                 * However, app works only for some of them (which are configured to be used with taxes routing).
+                 * If this happens, webhook will be received, but this is no-op.
+                 */
+                return res.status(202).send("Channel not configured with the app.");
+              }
+
+              case error instanceof ActiveConnectionServiceErrors.MissingMetadataError:
+              case error instanceof ActiveConnectionServiceErrors.ProviderNotAssignedToChannelError:
+              case error instanceof ActiveConnectionServiceErrors.BrokenConfigurationError: {
+                return res.status(400).send("App is not configured properly.");
+              }
+              case error instanceof ActiveConnectionServiceErrors.MissingChannelSlugError: {
+                return res
+                  .status(500)
+                  .send("Webhook didn't contain channel slug. This should not happen.");
+              }
+              default: {
+                Sentry.captureException(taxProviderResult.error);
+                logger.fatal("Unhandled error", { error });
+
+                return res.status(500).send("Unhandled error");
               }
             }
-            Sentry.captureException(error);
-            logger.error("Unhandled error executing webhook", { error });
-            return webhookResponse.error(error);
           }
+        } catch (error) {
+          Sentry.captureException(error);
+          logger.error("Unhandled error executing webhook", { error });
+          return webhookResponse.error(error);
         }
-
-        if (taxProviderResult.isErr()) {
-          const error = taxProviderResult.error;
-
-          logger.debug("Error confirming order", { error });
-
-          switch (true) {
-            case error instanceof ActiveConnectionServiceErrors.WrongChannelError: {
-              /**
-               * Subscription can listen on every channel or no channels.
-               * However, app works only for some of them (which are configured to be used with taxes routing).
-               * If this happens, webhook will be received, but this is no-op.
-               */
-              return res.status(202).send("Channel not configured with the app.");
-            }
-
-            case error instanceof ActiveConnectionServiceErrors.MissingMetadataError:
-            case error instanceof ActiveConnectionServiceErrors.ProviderNotAssignedToChannelError:
-            case error instanceof ActiveConnectionServiceErrors.BrokenConfigurationError: {
-              return res.status(400).send("App is not configured properly.");
-            }
-            case error instanceof ActiveConnectionServiceErrors.MissingChannelSlugError: {
-              return res
-                .status(500)
-                .send("Webhook didn't contain channel slug. This should not happen.");
-            }
-            default: {
-              Sentry.captureException(taxProviderResult.error);
-              logger.fatal("Unhandled error", { error });
-
-              return res.status(500).send("Unhandled error");
-            }
-          }
-        }
-      } catch (error) {
-        Sentry.captureException(error);
-        logger.error("Unhandled error executing webhook", { error });
-        return webhookResponse.error(error);
-      }
-    }),
+      }),
+    ),
     "/api/webhooks/order-confirmed",
   ),
   loggerContext,

--- a/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/avatax/src/pages/api/webhooks/order-confirmed.ts
@@ -44,6 +44,9 @@ export default wrapWithLoggerContext(
 
         try {
           const appMetadata = payload.recipient?.privateMetadata ?? [];
+
+          metadataCache.setMetadata(appMetadata);
+
           const channelSlug = payload.order?.channel.slug;
           const taxProviderResult = getActiveConnectionService(
             channelSlug,


### PR DESCRIPTION
## Scope of the PR

Added caching to App Metadata. Now, when webhook is called by Saleor, metadata from payload will be cached and consumed in MetadataManager. If cache doesn't exist, MetadataManager will fetch missing metadata. This change removes unnecessary graphql call that was timing out the handler.

Tested ORDER_CALCULATE_TAXES with this change and I couldn't get time longer than 2s

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
