### PR TITLE
Split e2e workflow into two: one for label second for dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,9 @@ name: Run e2e tests
 on:
   workflow_call:
     secrets:
-      token:
-        description: "Saleor token"
+      saleor_token:
+        required: true
+      op_service_account_token:
         required: true
 
 concurrency:
@@ -17,7 +18,7 @@ jobs:
       matrix:
         saleor: [318, 319]
     env:
-      ACCESS_TOKEN: ${{ secrets.token }}
+      ACCESS_TOKEN: ${{ secrets.saleor_token }}
       SALEOR_VERSION: ${{ matrix.saleor }}
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
         with:
           export-env: true
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op_service_account_token }}
           TEST_SALEOR_API_URL: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/TEST_SALEOR_API_URL"
           REST_APL_TOKEN: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/REST_APL_TOKEN"
           REST_APL_ENDPOINT: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/REST_APL_ENDPOINT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,16 +1,11 @@
-name: E2E staging
-on:
-  pull_request:
-    types: [labeled]
-  workflow_dispatch:
+name: Run e2e tests
+on: workflow_call
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   e2e:
-    # Only run when the label is added or when the workflow is manually triggered
-    if: ${{ github.event.label.name == 'run e2e' || github.event.action == 'requested' }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: Run e2e tests
 on:
   workflow_call:
     secrets:
-      saleor_token:
+      saleor-token:
         required: true
-      op_service_account_token:
+      op-service-account-token:
         required: true
 
 concurrency:
@@ -18,7 +18,7 @@ jobs:
       matrix:
         saleor: [318, 319]
     env:
-      ACCESS_TOKEN: ${{ secrets.saleor_token }}
+      ACCESS_TOKEN: ${{ secrets.saleor-token }}
       SALEOR_VERSION: ${{ matrix.saleor }}
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         with:
           export-env: true
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op_service_account_token }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op-service-account-token }}
           TEST_SALEOR_API_URL: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/TEST_SALEOR_API_URL"
           REST_APL_TOKEN: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/REST_APL_TOKEN"
           REST_APL_ENDPOINT: "op://Shop-ex/saleor-app-avatax-e2e-${{ env.SALEOR_VERSION }}/REST_APL_ENDPOINT"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,10 @@
 name: Run e2e tests
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      token:
+        description: "Saleor token"
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,7 +17,7 @@ jobs:
       matrix:
         saleor: [318, 319]
     env:
-      ACCESS_TOKEN: ${{ secrets.SALEOR_TOKEN }}
+      ACCESS_TOKEN: ${{ secrets.token }}
       SALEOR_VERSION: ${{ matrix.saleor }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-e2e-dispatch.yml
+++ b/.github/workflows/run-e2e-dispatch.yml
@@ -4,3 +4,6 @@ on: workflow_dispatch
 jobs:
   e2e-dispatch:
     uses: saleor/apps/.github/workflows/e2e.yml@main
+    secrets:
+      saleor-token: ${{ secrets.SALEOR_TOKEN }}
+      op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-dispatch.yml
+++ b/.github/workflows/run-e2e-dispatch.yml
@@ -1,0 +1,6 @@
+name: E2E staging (dispatched)
+on: workflow_dispatch
+
+jobs:
+  e2e-dispatch:
+    uses: saleor/apps/.github/workflows/e2e.yml@v1

--- a/.github/workflows/run-e2e-dispatch.yml
+++ b/.github/workflows/run-e2e-dispatch.yml
@@ -3,4 +3,4 @@ on: workflow_dispatch
 
 jobs:
   e2e-dispatch:
-    uses: saleor/apps/.github/workflows/e2e.yml@v1
+    uses: saleor/apps/.github/workflows/e2e.yml@main

--- a/.github/workflows/run-e2e-dispatch.yml
+++ b/.github/workflows/run-e2e-dispatch.yml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 
 jobs:
   e2e-dispatch:
-    uses: saleor/apps/.github/workflows/e2e.yml@main
+    uses: ./.github/workflows/e2e.yml
     secrets:
       saleor-token: ${{ secrets.SALEOR_TOKEN }}
       op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -4,6 +4,8 @@ on:
     types: [labeled]
 
 jobs:
-  e2e-label:
+  run:
     if: ${{ github.event.label.name == 'run e2e' }}
     uses: saleor/apps/.github/workflows/e2e.yml@update-e2e-workflow-dispatch
+    secrets:
+      token: ${{ secrets.SALEOR_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -8,5 +8,5 @@ jobs:
     if: ${{ github.event.label.name == 'run e2e' }}
     uses: saleor/apps/.github/workflows/e2e.yml@update-e2e-workflow-dispatch
     secrets:
-      saleor_token: ${{ secrets.SALEOR_TOKEN }}
-      op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      saleor-token: ${{ secrets.SALEOR_TOKEN }}
+      op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -8,4 +8,5 @@ jobs:
     if: ${{ github.event.label.name == 'run e2e' }}
     uses: saleor/apps/.github/workflows/e2e.yml@update-e2e-workflow-dispatch
     secrets:
-      token: ${{ secrets.SALEOR_TOKEN }}
+      saleor_token: ${{ secrets.SALEOR_TOKEN }}
+      op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   e2e-label:
     if: ${{ github.event.label.name == 'run e2e' }}
-    uses: saleor/apps/.github/workflows/e2e.yml@v1
+    uses: saleor/apps/.github/workflows/e2e.yml@update-e2e-workflow-dispatch

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   run:
     if: ${{ github.event.label.name == 'run e2e' }}
-    uses: saleor/apps/.github/workflows/e2e.yml@update-e2e-workflow-dispatch
+    uses: saleor/apps/.github/workflows/e2e.yml@main
     secrets:
       saleor-token: ${{ secrets.SALEOR_TOKEN }}
       op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   run:
     if: ${{ github.event.label.name == 'run e2e' }}
-    uses: saleor/apps/.github/workflows/e2e.yml@main
+    uses: ./.github/workflows/e2e.yml
     secrets:
       saleor-token: ${{ secrets.SALEOR_TOKEN }}
       op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/run-e2e-label.yml
+++ b/.github/workflows/run-e2e-label.yml
@@ -1,0 +1,9 @@
+name: E2E staging (label)
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  e2e-label:
+    if: ${{ github.event.label.name == 'run e2e' }}
+    uses: saleor/apps/.github/workflows/e2e.yml@v1

--- a/apps/avatax/README.md
+++ b/apps/avatax/README.md
@@ -98,3 +98,5 @@ To start the migration run command:
 ```bash
 pnpm migrate
 ```
+
+Noop

--- a/apps/avatax/README.md
+++ b/apps/avatax/README.md
@@ -98,5 +98,3 @@ To start the migration run command:
 ```bash
 pnpm migrate
 ```
-
-Noop


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
We want e2e workflow to run:
1. When label is added
2. When dispatched manually (or via other workflow)

To accomplish this I splitted workflow in two.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
