### PR TITLE
fix Sentry breadcrumb dates

### DIFF
--- a/.changeset/honest-wombats-jump.md
+++ b/.changeset/honest-wombats-jump.md
@@ -1,0 +1,5 @@
+---
+"@saleor/apps-logger": patch
+---
+
+Fix Sentry breadcrumbs transport, to properly parse dates

--- a/apps/avatax/src/pages/api/manifest.ts
+++ b/apps/avatax/src/pages/api/manifest.ts
@@ -7,8 +7,6 @@ import packageJson from "../../../package.json";
 import { REQUIRED_SALEOR_VERSION } from "../../../saleor-app";
 import { appWebhooks } from "../../../webhooks";
 import { loggerContext } from "../../logger-context";
-import { addBreadcrumb, captureException } from "@sentry/nextjs";
-import { createLogger } from "../../logger";
 
 export default wrapWithLoggerContext(
   withOtel(
@@ -16,16 +14,6 @@ export default wrapWithLoggerContext(
       async manifestFactory({ appBaseUrl }) {
         const iframeBaseUrl = process.env.APP_IFRAME_BASE_URL ?? appBaseUrl;
         const apiBaseURL = process.env.APP_API_BASE_URL ?? appBaseUrl;
-
-        addBreadcrumb({
-          message: "Manual breadcrumb",
-          // @ts-ignore
-          timestamp: new Date().toISOString(),
-        });
-
-        createLogger("test logger").info("Message from logger");
-
-        captureException("test exception");
 
         const manifest: AppManifest = {
           about: "App connects with Avatax to dynamically calculate taxes",

--- a/apps/avatax/src/pages/api/manifest.ts
+++ b/apps/avatax/src/pages/api/manifest.ts
@@ -7,6 +7,8 @@ import packageJson from "../../../package.json";
 import { REQUIRED_SALEOR_VERSION } from "../../../saleor-app";
 import { appWebhooks } from "../../../webhooks";
 import { loggerContext } from "../../logger-context";
+import { addBreadcrumb, captureException } from "@sentry/nextjs";
+import { createLogger } from "../../logger";
 
 export default wrapWithLoggerContext(
   withOtel(
@@ -14,6 +16,16 @@ export default wrapWithLoggerContext(
       async manifestFactory({ appBaseUrl }) {
         const iframeBaseUrl = process.env.APP_IFRAME_BASE_URL ?? appBaseUrl;
         const apiBaseURL = process.env.APP_API_BASE_URL ?? appBaseUrl;
+
+        addBreadcrumb({
+          message: "Manual breadcrumb",
+          // @ts-ignore
+          timestamp: new Date().toISOString(),
+        });
+
+        createLogger("test logger").info("Message from logger");
+
+        captureException("test exception");
 
         const manifest: AppManifest = {
           about: "App connects with Avatax to dynamically calculate taxes",

--- a/packages/logger/src/logger-sentry-transport.ts
+++ b/packages/logger/src/logger-sentry-transport.ts
@@ -53,7 +53,8 @@ export const attachLoggerSentryTransport = (logger: Logger<ILogObj>) => {
         message: message,
         type: levelToBreadcrumbType(log._meta.logLevelName),
         level: loggerLevelToSentryLevel(log._meta.logLevelName),
-        timestamp: new Date().getTime(),
+        // @ts-ignore
+        timestamp: log._meta.date.toISOString(),
         data: attributes,
       });
     });

--- a/packages/logger/src/logger-sentry-transport.ts
+++ b/packages/logger/src/logger-sentry-transport.ts
@@ -53,7 +53,7 @@ export const attachLoggerSentryTransport = (logger: Logger<ILogObj>) => {
         message: message,
         type: levelToBreadcrumbType(log._meta.logLevelName),
         level: loggerLevelToSentryLevel(log._meta.logLevelName),
-        // @ts-ignore
+        // @ts-ignore - Sentry only allows number type, but ISOString is valid
         timestamp: log._meta.date.toISOString(),
         data: attributes,
       });


### PR DESCRIPTION
## Scope of the PR

Fixes sentry breadcrumbs timestamp

https://linear.app/saleor/issue/SHOPX-471/sentry-breadcrumbs-are-broken


![CleanShot 2024-04-02 at 10 41 27@2x](https://github.com/saleor/apps/assets/9268745/3b2c22a0-dec3-43b7-a017-d522e9801395)



<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
