### PR TITLE
use type instead enums in codegen types

### DIFF
--- a/apps/avatax/.graphqlrc.ts
+++ b/apps/avatax/.graphqlrc.ts
@@ -43,7 +43,11 @@ const config: IGraphQLConfig = {
           generates: {
             "generated/graphql.ts": {
               plugins: [
-                "typescript",
+                {
+                  typescript: {
+                    enumsAsTypes: true,
+                  },
+                },
                 "typescript-operations",
                 {
                   "typescript-urql": {

--- a/apps/avatax/src/mocks.ts
+++ b/apps/avatax/src/mocks.ts
@@ -13,13 +13,13 @@ export const defaultOrder: OrderConfirmedSubscriptionFragment = {
   number: "1234",
   avataxEntityCode: null,
   created: "2023-05-25T09:18:55.203440+00:00",
-  status: OrderStatus.Unfulfilled,
+  status: "UNFULFILLED",
   channel: {
     id: "Q2hhbm5lbDox",
     slug: "default-channel",
     taxConfiguration: {
       pricesEnteredWithTax: true,
-      taxCalculationStrategy: TaxCalculationStrategy.TaxApp,
+      taxCalculationStrategy: "TAX_APP",
     },
   },
   shippingAddress: {

--- a/apps/avatax/src/modules/saleor/mock-order-factory.ts
+++ b/apps/avatax/src/modules/saleor/mock-order-factory.ts
@@ -1,4 +1,3 @@
-import { TaxCalculationStrategy } from "../../../generated/graphql";
 import { SaleorOrder } from "./order";
 
 export class SaleorMockOrderFactory {
@@ -7,7 +6,7 @@ export class SaleorMockOrderFactory {
       channel: {
         taxConfiguration: {
           pricesEnteredWithTax,
-          taxCalculationStrategy: TaxCalculationStrategy.TaxApp,
+          taxCalculationStrategy: "TAX_APP" as const,
         },
         slug: "test",
       },

--- a/apps/avatax/src/modules/saleor/order.ts
+++ b/apps/avatax/src/modules/saleor/order.ts
@@ -13,7 +13,7 @@ export class SaleorOrder {
       channel: z.object({
         taxConfiguration: z.object({
           pricesEnteredWithTax: z.boolean(),
-          taxCalculationStrategy: z.nativeEnum(TaxCalculationStrategy),
+          taxCalculationStrategy: z.union([z.literal("TAX_APP"), z.literal("FLAT_RATES")]),
         }),
         slug: z.string(),
       }),
@@ -37,10 +37,7 @@ export class SaleorOrder {
   }
 
   public isStrategyFlatRates() {
-    return (
-      this.data.order.channel.taxConfiguration.taxCalculationStrategy ===
-      TaxCalculationStrategy.FlatRates
-    );
+    return this.data.order.channel.taxConfiguration.taxCalculationStrategy === "FLAT_RATES";
   }
 
   public get id() {


### PR DESCRIPTION
## Scope of the PR

Before:
![CleanShot 2024-04-07 at 18 55 46@2x](https://github.com/saleor/apps/assets/9268745/1bd2d1d8-27cf-469f-ac15-27c6e3dfd402)


After
![CleanShot 2024-04-07 at 18 54 48@2x](https://github.com/saleor/apps/assets/9268745/b6537da1-47de-4722-9da9-d071ed972811)

when researching found that we should update graphql-codegen

1. https://the-guild.dev/graphql/codegen/plugins/typescript/typed-document-node this should not be used directly
2. https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-document-nodes this can be configured to use JSON instead `gql` which may be smaller in bundle size (gql has a lot of whitespace) → need to be checked
3. using client-preset is recommended so we should migrate


<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
