### PR TITLE
Add logger that will log specific app configuration log

### DIFF
--- a/.changeset/rare-insects-remain.md
+++ b/.changeset/rare-insects-remain.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Add log that will print anonymized app config once its retrieved in the webhook

--- a/apps/avatax/src/lib/app-configuration-logger.test.ts
+++ b/apps/avatax/src/lib/app-configuration-logger.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AppConfigurationLogger } from "./app-configuration-logger";
+import { AppConfig } from "./app-config";
+import { ObservabilityAttributes } from "@saleor/apps-otel/src/lib/observability-attributes";
+
+describe("AppConfigurationLogger", () => {
+  const mockWarn = vi.fn();
+  const mockInfo = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("Logs warning if config cant be parsed properly", () => {
+    const logger = new AppConfigurationLogger({ warn: mockWarn, info: mockInfo });
+
+    logger.logConfiguration(
+      AppConfig.createFromParsedConfig({
+        channels: [
+          {
+            id: "1",
+            config: {
+              slug: "default-channel",
+              providerConnectionId: "pci-1",
+            },
+          },
+        ],
+        providerConnections: [],
+      }),
+      "default-channel",
+    );
+
+    expect(mockWarn).toHaveBeenCalledWith("Failed to resolve configuration properly", {
+      [ObservabilityAttributes.CHANNEL_SLUG]: "default-channel",
+      error: expect.any(AppConfig.MissingConfigurationError),
+    });
+  });
+
+  it("Logs info with redacted config contents", () => {
+    const logger = new AppConfigurationLogger({ warn: mockWarn, info: mockInfo });
+
+    logger.logConfiguration(
+      AppConfig.createFromParsedConfig({
+        channels: [
+          {
+            id: "1",
+            config: {
+              slug: "default-channel",
+              providerConnectionId: "pci-1",
+            },
+          },
+        ],
+        providerConnections: [
+          {
+            provider: "avatax",
+            id: "pci-1",
+            config: {
+              companyCode: "test",
+              credentials: {
+                password: "test",
+                username: "test",
+              },
+              address: {
+                city: "test",
+                country: "test",
+                zip: "10111",
+                state: "NY",
+                street: "test",
+              },
+              isSandbox: false,
+              name: "config",
+              isAutocommit: false,
+              isDocumentRecordingEnabled: false,
+              shippingTaxCode: "123",
+            },
+          },
+        ],
+      }),
+      "default-channel",
+    );
+
+    expect(mockInfo).toHaveBeenCalledWith("Received configuration", {
+      address: {
+        city: "test",
+        country: "test",
+        zip: "10111",
+        state: "NY",
+        street: "test",
+      },
+      appConfigName: "config",
+      channelSlug: "default-channel",
+      companyCode: "test",
+      isAutocommit: false,
+      isDocumentRecordingEnabled: false,
+      isSandbox: false,
+      password: "<Exists>",
+      shippingTaxCode: "123",
+      username: "tes...",
+    });
+  });
+});

--- a/apps/avatax/src/lib/app-configuration-logger.ts
+++ b/apps/avatax/src/lib/app-configuration-logger.ts
@@ -1,0 +1,39 @@
+import { logger } from "../logger";
+import { AppConfig } from "./app-config";
+import { ObservabilityAttributes } from "@saleor/apps-otel/src/lib/observability-attributes";
+
+export class AppConfigurationLogger {
+  constructor(private injectedLogger: Pick<typeof logger, "info" | "warn">) {}
+
+  logConfiguration(configuration: AppConfig, channelSlug: string) {
+    const config = configuration.getConfigForChannelSlug(channelSlug);
+
+    if (config.isErr()) {
+      this.injectedLogger.warn("Failed to resolve configuration properly", {
+        error: config.error,
+        [ObservabilityAttributes.CHANNEL_SLUG]: channelSlug,
+      });
+
+      return;
+    }
+
+    const resolvedAvataxConfig = config.value.avataxConfig;
+
+    this.injectedLogger.info("Received configuration", {
+      [ObservabilityAttributes.CHANNEL_SLUG]: channelSlug,
+      /**
+       * Be careful changing these values. They are likely used as a metric in Datadog
+       */
+
+      appConfigName: resolvedAvataxConfig.config.name,
+      shippingTaxCode: resolvedAvataxConfig.config.shippingTaxCode,
+      companyCode: resolvedAvataxConfig.config.companyCode,
+      address: resolvedAvataxConfig.config.address,
+      isSandbox: resolvedAvataxConfig.config.isSandbox,
+      isAutocommit: resolvedAvataxConfig.config.isAutocommit,
+      isDocumentRecordingEnabled: resolvedAvataxConfig.config.isDocumentRecordingEnabled,
+      username: resolvedAvataxConfig.config.credentials.username.slice(0, 3) + "...",
+      password: resolvedAvataxConfig.config.credentials.password ? "<Exists>" : "<EMPTY>",
+    });
+  }
+}

--- a/apps/avatax/src/modules/taxes/get-active-connection-service.ts
+++ b/apps/avatax/src/modules/taxes/get-active-connection-service.ts
@@ -11,6 +11,11 @@ import { captureException } from "@sentry/nextjs";
 import { AppConfigurationLogger } from "../../lib/app-configuration-logger";
 import { AppConfig } from "../../lib/app-config";
 
+/**
+ * Error raised when loggic configuration fails
+ */
+const LogConfigurationMetricError = BaseError.subclass("LogConfigurationMetricError");
+
 export function getActiveConnectionService(
   channelSlug: string | undefined,
   encryptedMetadata: MetadataItem[],
@@ -53,7 +58,9 @@ export function getActiveConnectionService(
       channelSlug,
     );
   } catch (e) {
-    captureException(new Error("Failed to log configuration metric", { cause: e }));
+    captureException(
+      new LogConfigurationMetricError("Failed to log configuration metric", { cause: e }),
+    );
   }
 
   const { providerConnections, channels } = appConfigResult.value;

--- a/apps/avatax/src/modules/taxes/get-active-connection-service.ts
+++ b/apps/avatax/src/modules/taxes/get-active-connection-service.ts
@@ -7,6 +7,9 @@ import { err, fromThrowable, ok } from "neverthrow";
 import { AvataxClient } from "../avatax/avatax-client";
 import { AvataxSdkClientFactory } from "../avatax/avatax-sdk-client-factory";
 import { ActiveConnectionServiceErrors } from "./get-active-connection-service-errors";
+import { captureException } from "@sentry/nextjs";
+import { AppConfigurationLogger } from "../../lib/app-configuration-logger";
+import { AppConfig } from "../../lib/app-config";
 
 export function getActiveConnectionService(
   channelSlug: string | undefined,
@@ -36,6 +39,21 @@ export function getActiveConnectionService(
 
   if (appConfigResult.isErr()) {
     return err(appConfigResult.error);
+  }
+
+  /**
+   * This class is called on every webhook and config is resolved here for now. Before we refactor, we log here
+   * resolved configuration.
+   * Since this is constant refactor, wrap it in try/catch so broken log doesn't break the app.
+   * In the future we should extract configuration retrieval higher and pass in down the app's logic.
+   */
+  try {
+    new AppConfigurationLogger(logger).logConfiguration(
+      AppConfig.createFromParsedConfig(appConfigResult.value),
+      channelSlug,
+    );
+  } catch (e) {
+    captureException(new Error("Failed to log configuration metric", { cause: e }));
   }
 
   const { providerConnections, channels } = appConfigResult.value;


### PR DESCRIPTION
## Scope of the PR

With this log, datadog etc can consume specific values, like errors in config, or if some options are set, for debugging

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
