### PR TITLE
Check algolia errors and disable webhooks only if auth error occured

### DIFF
--- a/.changeset/hungry-beers-sip.md
+++ b/.changeset/hungry-beers-sip.md
@@ -1,0 +1,5 @@
+---
+"search": patch
+---
+
+Fixed problem when webhooks were disabled if _any_ error from Algolia was received. Now only 401 and 403 errors (invalid auth/credentials) will cause webhooks disabling, until app is configured again.

--- a/.changeset/lemon-drinks-cross.md
+++ b/.changeset/lemon-drinks-cross.md
@@ -1,0 +1,5 @@
+---
+"search": patch
+---
+
+Fixed logger execution to properly attach attributes

--- a/apps/search/src/domain/WebhookActivityToggler.service.ts
+++ b/apps/search/src/domain/WebhookActivityToggler.service.ts
@@ -37,12 +37,9 @@ export class WebhooksActivityClient implements IWebhooksActivityClient {
 
   private handleOperationFailure(r: OperationResult) {
     if (r.error || !r.data) {
-      logger.error(
-        {
-          error: r.error,
-        },
-        "Error disabling webhook",
-      );
+      logger.error("Error disabling webhook", {
+        error: r.error,
+      });
       throw new Error("Error disabling webhook");
     }
   }
@@ -138,7 +135,7 @@ export class WebhookActivityTogglerService implements IWebhookActivityTogglerSer
     const webhooksIds =
       webhooksIdsParam ?? (await this.webhooksClient.fetchAppWebhooksIDs(this.ownAppId));
 
-    logger.info(webhooksIds, "Disabling own webhooks");
+    logger.info("Disabling own webhooks", { webhooksIds });
 
     if (!webhooksIds) {
       throw new Error("Failed fetching webhooks");
@@ -150,7 +147,7 @@ export class WebhookActivityTogglerService implements IWebhookActivityTogglerSer
   async enableOwnWebhooks() {
     const webhooksIds = await this.webhooksClient.fetchAppWebhooksIDs(this.ownAppId);
 
-    logger.info(webhooksIds, "Enabling own webhooks");
+    logger.info("Enabling own webhooks", { webhooksIds });
 
     if (!webhooksIds) {
       throw new Error("Failed fetching webhooks");

--- a/apps/search/src/lib/algolia/algolia-error-parser.test.ts
+++ b/apps/search/src/lib/algolia/algolia-error-parser.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { AlgoliaErrorParser } from "./algolia-error-parser";
+
+describe("AlgoliaErrorParser", () => {
+  describe("isAuthError", () => {
+    it("Returns false if cant parse", () => {
+      expect(
+        AlgoliaErrorParser.isAuthError({
+          foo: "bar",
+        }),
+      ).toBe(false);
+    });
+
+    it("Returns true if 401 or 403 status attached to error", () => {
+      expect(
+        AlgoliaErrorParser.isAuthError({
+          status: 401,
+        }),
+      ).toBe(true);
+
+      expect(
+        AlgoliaErrorParser.isAuthError({
+          status: 403,
+        }),
+      ).toBe(true);
+    });
+
+    it.each([200, 400, 500])("Returns false for status: %s", (statusCode) => {
+      expect(
+        AlgoliaErrorParser.isAuthError({
+          status: statusCode,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/search/src/lib/algolia/algolia-error-parser.ts
+++ b/apps/search/src/lib/algolia/algolia-error-parser.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+/**
+ * We only care about the status at the moment but we can define more fields if needed
+ */
+const shape = z.object({
+  status: z.number(),
+});
+
+export const AlgoliaErrorParser = {
+  isAuthError: (error: unknown) => {
+    const parsed = shape.safeParse(error);
+
+    if (!parsed.success) {
+      return false;
+    }
+
+    return parsed.data.status === 403 || parsed.data.status === 401;
+  },
+};

--- a/apps/search/src/lib/algolia/algoliaSearchProvider.ts
+++ b/apps/search/src/lib/algolia/algoliaSearchProvider.ts
@@ -231,10 +231,10 @@ const groupVariantByIndexName = (
       );
 
       if (!productChannelListing) {
-        logger.debug(
-          { var: channelListing, prod: productChannelListing },
-          "no product channel listing found - abort",
-        );
+        logger.debug("no product channel listing found - abort", {
+          var: channelListing,
+          prod: productChannelListing,
+        });
         return false;
       }
 

--- a/apps/search/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/search/src/modules/trpc/protected-client-procedure.ts
@@ -2,10 +2,12 @@ import { verifyJWT } from "@saleor/app-sdk/verify-jwt";
 import { middleware, procedure } from "./trpc-server";
 import { TRPCError } from "@trpc/server";
 import { ProtectedHandlerError } from "@saleor/app-sdk/handlers/next";
-import { logger } from "@saleor/apps-shared";
 import { saleorApp } from "../../../saleor-app";
 import { createInstrumentedGraphqlClient } from "../../lib/create-instrumented-graphql-client";
 import { REQUIRED_SALEOR_PERMISSIONS } from "@saleor/apps-shared";
+import { createLogger } from "../../lib/logger";
+
+const logger = createLogger("protectedClientProcedure");
 
 const attachAppToken = middleware(async ({ ctx, next }) => {
   logger.debug("attachAppToken middleware");
@@ -71,8 +73,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
 
   if (!ctx.ssr) {
     try {
-      logger.debug("trying to verify JWT token from frontend");
-      logger.debug({ token: ctx.token ? `${ctx.token[0]}...` : undefined });
+      logger.debug("trying to verify JWT token from frontend", {
+        token: ctx.token ? `${ctx.token[0]}...` : undefined,
+      });
 
       await verifyJWT({
         appId: ctx.appId,

--- a/apps/search/src/pages/api/webhooks/saleor/product_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_created.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductCreated } from "../../../../webhooks/definitions/product-created";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -37,19 +38,23 @@ export const handler: NextWebhookApiHandler<ProductCreated> = async (req, res, c
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia createProduct failed. Webhooks will be disabled");
+      logger.info("Algolia createProduct failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductDeleted } from "../../../../webhooks/definitions/product-deleted";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -37,19 +38,23 @@ export const handler: NextWebhookApiHandler<ProductDeleted> = async (req, res, c
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia deleteProduct failed. Webhooks will be disabled");
+      logger.info("Algolia deleteProduct failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductUpdated } from "../../../../webhooks/definitions/product-updated";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -37,19 +38,23 @@ export const handler: NextWebhookApiHandler<ProductUpdated> = async (req, res, c
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia updateProduct failed. Webhooks will be disabled");
+      logger.info("Algolia updateProduct failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
@@ -38,7 +38,7 @@ export const handler: NextWebhookApiHandler<ProductUpdated> = async (req, res, c
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info("Algolia updateProduct failed.", { error: e });
+      logger.warn("Algolia updateProduct failed.", { error: e });
 
       if (AlgoliaErrorParser.isAuthError(e)) {
         logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductVariantBackInStock } from "../../../../webhooks/definitions/product-variant-back-in-stock";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -41,19 +42,23 @@ export const handler: NextWebhookApiHandler<ProductVariantBackInStock> = async (
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia updateProductVariant failed. Webhooks will be disabled");
+      logger.info("Algolia updateProductVariant failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductVariantCreated } from "../../../../webhooks/definitions/product-variant-created";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -37,19 +38,23 @@ export const handler: NextWebhookApiHandler<ProductVariantCreated> = async (req,
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia createProductVariant failed. Webhooks will be disabled");
+      logger.info("Algolia createProductVariant failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductVariantOutOfStock } from "../../../../webhooks/definitions/product-variant-out-of-stock";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -41,19 +42,23 @@ export const handler: NextWebhookApiHandler<ProductVariantOutOfStock> = async (
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia updateProductVariant failed. Webhooks will be disabled");
+      logger.info("Algolia updateProductVariant failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../../../../lib/logger";
 import { webhookProductVariantUpdated } from "../../../../webhooks/definitions/product-variant-updated";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 import { withOtel } from "@saleor/apps-otel";
+import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";
 
 export const config = {
   api: {
@@ -37,19 +38,23 @@ export const handler: NextWebhookApiHandler<ProductVariantUpdated> = async (req,
       res.status(200).end();
       return;
     } catch (e) {
-      logger.info(e, "Algolia updateProductVariant failed. Webhooks will be disabled");
+      logger.info("Algolia updateProductVariant failed.", { error: e });
 
-      const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
+      if (AlgoliaErrorParser.isAuthError(e)) {
+        logger.info("Detect Auth error from Algolia. Webhooks will be disabled", { error: e });
 
-      logger.trace("Will disable webhooks");
+        const webhooksToggler = new WebhookActivityTogglerService(authData.appId, apiClient);
 
-      await webhooksToggler.disableOwnWebhooks(
-        context.payload.recipient?.webhooks?.map((w) => w.id),
-      );
+        logger.trace("Will disable webhooks");
 
-      logger.trace("Webhooks disabling operation finished");
+        await webhooksToggler.disableOwnWebhooks(
+          context.payload.recipient?.webhooks?.map((w) => w.id),
+        );
 
-      return res.status(500).send("Operation failed, webhooks are disabled");
+        logger.trace("Webhooks disabling operation finished");
+      }
+
+      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     return res.status(400).json({


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->

Fixed problem when webhooks were disabled if _any_ error from Algolia was received. Now only 401 and 403 errors (invalid auth/credentials) will cause webhooks disabling, until app is configured again.


Fixed logger execution to properly attach attributes

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
