### PR TITLE
Don't send handled error for `checkoutCalculateTaxes` event into Sentry

### DIFF
--- a/.changeset/sour-frogs-cheat.md
+++ b/.changeset/sour-frogs-cheat.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Don't send handled error for `checkoutCalculateTaxes` event into Sentry. It will be logged instead.

--- a/apps/avatax/src/lib/error-utils.test.ts
+++ b/apps/avatax/src/lib/error-utils.test.ts
@@ -11,7 +11,7 @@ describe("SubscriptionPayloadErrorChecker", () => {
   });
 
   it.each(["OrderCancelled", "OrderConfirmed", "CalculateTaxes"])(
-    "should log error when payload contains GraphQL error for %s",
+    "should log error when payload contains unhandled GraphQL error for %s",
     (typename) => {
       const payload = {
         __typename: typename,
@@ -30,10 +30,13 @@ describe("SubscriptionPayloadErrorChecker", () => {
 
       checker.checkPayload(payload);
 
-      expect(mockError).toHaveBeenCalledWith(`Payload contains GraphQL error for ${typename}`, {
-        error: expect.any(SubscriptionPayloadErrorChecker.SubscriptionPayloadError),
-        subscription: typename,
-      });
+      expect(mockError).toHaveBeenCalledWith(
+        `Payload contains unhandled GraphQL error for ${typename}`,
+        {
+          error: expect.any(SubscriptionPayloadErrorChecker.SubscriptionPayloadError),
+          subscription: typename,
+        },
+      );
       expect(mockErrorCapture).toHaveBeenCalledWith(
         expect.any(SubscriptionPayloadErrorChecker.SubscriptionPayloadError),
       );

--- a/apps/avatax/src/lib/error-utils.test.ts
+++ b/apps/avatax/src/lib/error-utils.test.ts
@@ -80,13 +80,13 @@ describe("SubscriptionPayloadErrorChecker", () => {
 
     checker.checkPayload(payload);
 
-    expect(mockInfo).toHaveBeenCalledWith("Payload contains handled GraphQL error", {
-      error: {
-        message: "Error message",
-        path: ["event", "taxBase", "sourceObject", "user"],
-        source: "Error source",
+    expect(mockInfo).toHaveBeenCalledWith(
+      "Payload contains handled GraphQL error for CalculateTaxes",
+      {
+        error: expect.any(SubscriptionPayloadErrorChecker.SubscriptionPayloadError),
+        subscription: "CalculateTaxes",
       },
-    });
+    );
 
     expect(mockError).not.toHaveBeenCalled();
     expect(mockErrorCapture).not.toHaveBeenCalled();

--- a/apps/avatax/src/lib/error-utils.ts
+++ b/apps/avatax/src/lib/error-utils.ts
@@ -54,7 +54,7 @@ export class SubscriptionPayloadErrorChecker {
           return;
         }
 
-        this.injectedLogger.error(`Payload contains GraphQL error for ${subscription}`, {
+        this.injectedLogger.error(`Payload contains unhandled GraphQL error for ${subscription}`, {
           error: graphQLError,
           subscription,
         });


### PR DESCRIPTION
## Scope of the PR
Don't send handled error for `checkoutCalculateTaxes` event into Sentry. It will be logged instead.

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
