### PR TITLE
Fix skipping first page cursor

### DIFF
--- a/.changeset/friendly-apes-compare.md
+++ b/.changeset/friendly-apes-compare.md
@@ -1,0 +1,5 @@
+---
+"products-feed": patch
+---
+
+Respect the cursor for the first page

--- a/apps/products-feed/src/modules/google-feed/fetch-product-data.ts
+++ b/apps/products-feed/src/modules/google-feed/fetch-product-data.ts
@@ -18,6 +18,12 @@ export const getCursors = async ({ client, channel }: { client: Client; channel:
 
   const cursors: Array<string> = [];
 
+  const fistCusror = result.data?.productVariants?.pageInfo.endCursor;
+
+  if (fistCusror) {
+    cursors.push(fistCusror);
+  }
+
   while (result.data?.productVariants?.pageInfo.hasNextPage) {
     result = await client
       .query(FetchProductCursorsDocument, {


### PR DESCRIPTION
## Scope of the PR

The cursor for the first page was not used. The code directly always took the second page.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
