### PR TITLE
Add env 320 to e2e matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        saleor: [318, 319]
+        saleor: [318, 319, 320]
     env:
       ACCESS_TOKEN: ${{ secrets.saleor-token }}
       SALEOR_VERSION: ${{ matrix.saleor }}


### PR DESCRIPTION
## Scope of the PR

I want to extend workflow matrix to run e2e for the AvaTax App on the 3.20 Saleor version

I tested the workflow from the branch and looks like all pieces were setup correctly and we can start running CI on 3.20 version.
<img width="914" alt="image" src="https://github.com/user-attachments/assets/2eb15a15-1bcd-40d0-8c61-01a72d3c62a2">



## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
