### PR TITLE
Replace "require" with import

### DIFF
--- a/.changeset/selfish-scissors-shop.md
+++ b/.changeset/selfish-scissors-shop.md
@@ -1,0 +1,5 @@
+---
+"smtp": patch
+---
+
+The "require" call was replaced by regular "import" which causes random timeouts on webhook processing in mjml usage.

--- a/apps/smtp/src/modules/smtp/services/mjml-compiler.ts
+++ b/apps/smtp/src/modules/smtp/services/mjml-compiler.ts
@@ -1,6 +1,8 @@
-import { createLogger } from "../../../logger";
+import compile from "mjml";
 import { err, fromThrowable, ok, Result } from "neverthrow";
+
 import { BaseError } from "../../../errors";
+import { createLogger } from "../../../logger";
 
 export interface IMjmlCompiler {
   compile(mjml: string): Result<string, InstanceType<typeof BaseError>>;
@@ -16,8 +18,7 @@ export class MjmlCompiler implements IMjmlCompiler {
     this.logger.debug("Trying to compile MJML template");
 
     const safeCompile = fromThrowable(
-      // Used require on purpose - when import where used, modules resolution failed
-      require("mjml"),
+      compile,
       (error) =>
         new MjmlCompiler.FailedToCompileError("Failed to compile MJML", {
           errors: [error],


### PR DESCRIPTION
## Scope of the PR

Context:
- Some time ago [we have changed](https://github.com/saleor/apps/pull/1450) "import" to "require" due to silent timeouts
- It did solve the problem, but turns out not completelly, timeouts still happen, the execution time is lower, however still sometimes exceeds the limit
- When `bundlePagesExternals` is enabled, and mjml is mentioned in `serverComponentsExternalPackages`, the regular "import" seems working fine, reducing webhook processing calls to ~2s

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
