### PR TITLE
Stringify attributes passed to console transport

### DIFF
--- a/packages/logger/src/logger-console-transport.ts
+++ b/packages/logger/src/logger-console-transport.ts
@@ -15,6 +15,11 @@ export const attachLoggerConsoleTransport = (logger: Logger<ILogObj>) => {
     const formattedName = `${(parentNames ?? []).join(":")}:${name}`;
     const formattedDate = date.toISOString();
 
-    console.log(`\x1b[2m ${formattedDate} ${formattedName}\x1b[0m \t${message}`, attributes);
+    console.log(
+      `\x1b[2m ${formattedDate} ${formattedName}\x1b[0m \t${message}`,
+      JSON.stringify(attributes),
+      null,
+      2,
+    );
   });
 };

--- a/packages/logger/src/logger-console-transport.ts
+++ b/packages/logger/src/logger-console-transport.ts
@@ -17,9 +17,7 @@ export const attachLoggerConsoleTransport = (logger: Logger<ILogObj>) => {
 
     console.log(
       `\x1b[2m ${formattedDate} ${formattedName}\x1b[0m \t${message}`,
-      JSON.stringify(attributes),
-      null,
-      2,
+      JSON.stringify(attributes, null, 2),
     );
   });
 };

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -1,9 +1,10 @@
+import { logs } from "@opentelemetry/api-logs";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { describe, expect, it, vi } from "vitest";
+
 import { createLogger } from "./logger";
 import { attachLoggerConsoleTransport } from "./logger-console-transport";
 import { attachLoggerOtelTransport } from "./logger-otel-transport";
-import { logs } from "@opentelemetry/api-logs";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 
 vi.spyOn(console, "log");
 vi.setSystemTime(new Date(2024, 1, 1, 5, 15));
@@ -29,12 +30,16 @@ describe("Logger", () => {
 
       expect(console.log).toBeCalledWith(
         "\x1B[2m 2024-02-01T05:15:00.000Z :Test Logger\x1B[0m \tTest Message",
-        {
-          rootScopePrimitiveArg: 1,
-          rootScopeObjectArg: { objectKey: "objectValue" },
-          childScopePrimitiveArg: 2,
-          childScopeObjectArg: { objectKey: "objectValue" },
-        },
+        JSON.stringify(
+          {
+            rootScopePrimitiveArg: 1,
+            rootScopeObjectArg: { objectKey: "objectValue" },
+            childScopePrimitiveArg: 2,
+            childScopeObjectArg: { objectKey: "objectValue" },
+          },
+          null,
+          2,
+        ),
       );
     });
   });


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
This stringfies attributes passed to logger. 

| Before | After |
| ------- | ------- |
| `log { array: [Object object] }` | `log {array: [{obj: key}]}` |
  

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
