### PR TITLE
Refactor - Avatax: Extract services dependencies

### DIFF
--- a/.changeset/tidy-spiders-compare.md
+++ b/.changeset/tidy-spiders-compare.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Refactor: Extracted dependencies to the highest possible creation place. This should not introduce any functional change

--- a/apps/avatax/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/avatax/src/modules/avatax/avatax-connection.router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { metadataCache } from "@/lib/app-metadata-cache";
+import { Obfuscator } from "@/lib/obfuscator";
 import { createSettingsManager } from "@/modules/app/metadata-manager";
 import { AvataxObfuscator } from "@/modules/avatax/avatax-obfuscator";
 import { AvataxConnectionService } from "@/modules/avatax/configuration/avatax-connection.service";
@@ -153,6 +154,7 @@ export const avataxConnectionRouter = router({
               ),
             ),
           ),
+          new Obfuscator(),
         ),
       );
 
@@ -218,6 +220,7 @@ export const avataxConnectionRouter = router({
               ),
             ),
           ),
+          new Obfuscator(),
         ),
       );
 

--- a/apps/avatax/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/avatax/src/modules/avatax/avatax-connection.router.ts
@@ -48,11 +48,11 @@ const protectedWithConnectionService = protectedClientProcedure.use(({ next, ctx
       connectionService: new PublicAvataxConnectionService(
         new AvataxConnectionService(
           new AvataxConnectionRepository(
-            new CrudSettingsManager(
-              createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
-              ctx.saleorApiUrl,
-              TAX_PROVIDER_KEY,
-            ),
+            new CrudSettingsManager({
+              saleorApiUrl: ctx.saleorApiUrl,
+              metadataKey: TAX_PROVIDER_KEY,
+              metadataManager: createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+            }),
           ),
         ),
         new AvataxObfuscator(),
@@ -147,11 +147,11 @@ export const avataxConnectionRouter = router({
         new AvataxPatchInputTransformer(
           new AvataxConnectionService(
             new AvataxConnectionRepository(
-              new CrudSettingsManager(
-                createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
-                ctx.saleorApiUrl,
-                TAX_PROVIDER_KEY,
-              ),
+              new CrudSettingsManager({
+                saleorApiUrl: ctx.saleorApiUrl,
+                metadataKey: TAX_PROVIDER_KEY,
+                metadataManager: createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+              }),
             ),
           ),
           new Obfuscator(),
@@ -213,11 +213,11 @@ export const avataxConnectionRouter = router({
         new AvataxPatchInputTransformer(
           new AvataxConnectionService(
             new AvataxConnectionRepository(
-              new CrudSettingsManager(
-                createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
-                ctx.saleorApiUrl,
-                TAX_PROVIDER_KEY,
-              ),
+              new CrudSettingsManager({
+                saleorApiUrl: ctx.saleorApiUrl,
+                metadataKey: TAX_PROVIDER_KEY,
+                metadataManager: createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+              }),
             ),
           ),
           new Obfuscator(),

--- a/apps/avatax/src/modules/avatax/avatax-connection.router.ts
+++ b/apps/avatax/src/modules/avatax/avatax-connection.router.ts
@@ -1,5 +1,14 @@
 import { z } from "zod";
 
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
+import { AvataxObfuscator } from "@/modules/avatax/avatax-obfuscator";
+import { AvataxConnectionService } from "@/modules/avatax/configuration/avatax-connection.service";
+import { AvataxConnectionRepository } from "@/modules/avatax/configuration/avatax-connection-repository";
+import { AvataxPatchInputTransformer } from "@/modules/avatax/configuration/avatax-patch-input-transformer";
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
+
 import { createLogger } from "../../logger";
 import { protectedClientProcedure } from "../trpc/protected-client-procedure";
 import { router } from "../trpc/trpc-server";
@@ -35,11 +44,18 @@ const avataxErrorsToTrpcErrorsMapper = new AvataxErrorToTrpcErrorMapper();
 const protectedWithConnectionService = protectedClientProcedure.use(({ next, ctx }) =>
   next({
     ctx: {
-      connectionService: new PublicAvataxConnectionService({
-        appId: ctx.appId!,
-        client: ctx.apiClient,
-        saleorApiUrl: ctx.saleorApiUrl,
-      }),
+      connectionService: new PublicAvataxConnectionService(
+        new AvataxConnectionService(
+          new AvataxConnectionRepository(
+            new CrudSettingsManager(
+              createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+              ctx.saleorApiUrl,
+              TAX_PROVIDER_KEY,
+            ),
+          ),
+        ),
+        new AvataxObfuscator(),
+      ),
     },
   }),
 );
@@ -126,11 +142,19 @@ export const avataxConnectionRouter = router({
 
       logger.debug("Route called");
 
-      const addressValidationService = new AvataxEditAddressValidationService({
-        appId: ctx.appId!,
-        client: ctx.apiClient,
-        saleorApiUrl: ctx.saleorApiUrl,
-      });
+      const addressValidationService = new AvataxEditAddressValidationService(
+        new AvataxPatchInputTransformer(
+          new AvataxConnectionService(
+            new AvataxConnectionRepository(
+              new CrudSettingsManager(
+                createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+                ctx.saleorApiUrl,
+                TAX_PROVIDER_KEY,
+              ),
+            ),
+          ),
+        ),
+      );
 
       const result = await addressValidationService.validate(input.id, input.value);
 
@@ -183,11 +207,19 @@ export const avataxConnectionRouter = router({
         saleorApiUrl: ctx.saleorApiUrl,
       });
 
-      const authValidation = new AvataxEditAuthValidationService({
-        appId: ctx.appId!,
-        client: ctx.apiClient,
-        saleorApiUrl: ctx.saleorApiUrl,
-      });
+      const authValidation = new AvataxEditAuthValidationService(
+        new AvataxPatchInputTransformer(
+          new AvataxConnectionService(
+            new AvataxConnectionRepository(
+              new CrudSettingsManager(
+                createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+                ctx.saleorApiUrl,
+                TAX_PROVIDER_KEY,
+              ),
+            ),
+          ),
+        ),
+      );
 
       await authValidation.validate(input.id, input.value);
 

--- a/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.test.ts
+++ b/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.test.ts
@@ -13,7 +13,7 @@ describe("AvataxEntityTypeMatcher", () => {
       ),
     } as any as AvataxClient;
 
-    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+    const matcher = new AvataxEntityTypeMatcher(mockAvataxClient);
     const result = await matcher.match(null);
 
     expect(result).toBe("");
@@ -23,7 +23,7 @@ describe("AvataxEntityTypeMatcher", () => {
       getEntityUseCode: mockGetEntityUseCode.mockReturnValue(Promise.resolve({})),
     } as any as AvataxClient;
 
-    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+    const matcher = new AvataxEntityTypeMatcher(mockAvataxClient);
 
     const result = await matcher.match("entityCode");
 
@@ -36,7 +36,7 @@ describe("AvataxEntityTypeMatcher", () => {
       ),
     } as any as AvataxClient;
 
-    const matcher = new AvataxEntityTypeMatcher({ client: mockAvataxClient });
+    const matcher = new AvataxEntityTypeMatcher(mockAvataxClient);
 
     const result = await matcher.match("entityCode");
 

--- a/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -8,12 +8,9 @@ import { AvataxClient } from "./avatax-client";
 const AVATAX_ENTITY_CODE = "avataxEntityCode";
 
 export class AvataxEntityTypeMatcher {
-  private client: AvataxClient;
   private logger = createLogger("AvataxEntityTypeMatcher");
 
-  constructor({ client }: { client: AvataxClient }) {
-    this.client = client;
-  }
+  constructor(private avataxClient: Pick<AvataxClient, "getEntityUseCode">) {}
 
   private returnFallback() {
     // Empty string will be treated as non existing entity code.
@@ -21,7 +18,7 @@ export class AvataxEntityTypeMatcher {
   }
 
   private async validateEntityCode(entityCode: string) {
-    const result = await this.client.getEntityUseCode(entityCode);
+    const result = await this.avataxClient.getEntityUseCode(entityCode);
 
     // If verified, return the entity code. If not, return empty string.
     return result.value?.[0].code || this.returnFallback();

--- a/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -1,12 +1,6 @@
 import { createLogger } from "../../logger";
 import { AvataxClient } from "./avatax-client";
 
-/*
- * Arbitrary key-value pair that is used to store the entity code in the metadata.
- * see: https://docs.saleor.io/docs/3.x/developer/app-store/apps/taxes/avatax#mapping-the-entity-type
- */
-const AVATAX_ENTITY_CODE = "avataxEntityCode";
-
 export class AvataxEntityTypeMatcher {
   private logger = createLogger("AvataxEntityTypeMatcher");
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
@@ -1,18 +1,10 @@
-import { AuthData } from "@saleor/app-sdk/APL";
 import * as Sentry from "@sentry/nextjs";
 
 import { createLogger } from "../../../logger";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
-import { WebhookAdapter } from "../../taxes/tax-webhook-adapter";
-import { CalculateTaxesPayload } from "../../webhooks/payloads/calculate-taxes-payload";
 import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
-import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxErrorsParser } from "../avatax-errors-parser";
-import { AutomaticallyDistributedDiscountsStrategy } from "../discounts";
 import { extractTransactionRedactedLogProperties } from "../extract-transaction-redacted-log-properties";
-import { AvataxTaxCodeMatchesService } from "../tax-code/avatax-tax-code-matches.service";
-import { AvataxCalculateTaxesPayloadService } from "./avatax-calculate-taxes-payload.service";
-import { AvataxCalculateTaxesPayloadTransformer } from "./avatax-calculate-taxes-payload-transformer";
 import { AvataxCalculateTaxesResponseTransformer } from "./avatax-calculate-taxes-response-transformer";
 
 export type AvataxCalculateTaxesTarget = CreateTransactionArgs;
@@ -20,37 +12,23 @@ export type AvataxCalculateTaxesResponse = CalculateTaxesResponse;
 
 const errorParser = new AvataxErrorsParser(Sentry.captureException);
 
-export class AvataxCalculateTaxesAdapter
-  implements WebhookAdapter<CalculateTaxesPayload, AvataxCalculateTaxesResponse>
-{
+export class AvataxCalculateTaxesAdapter {
   private logger = createLogger("AvataxCalculateTaxesAdapter");
 
   constructor(private avataxClient: AvataxClient) {}
 
-  async send(
-    payload: CalculateTaxesPayload,
-    config: AvataxConfig,
-    authData: AuthData,
-    discountStrategy: AutomaticallyDistributedDiscountsStrategy,
-  ): Promise<AvataxCalculateTaxesResponse> {
+  async send(avataxModel: AvataxCalculateTaxesTarget): Promise<AvataxCalculateTaxesResponse> {
     this.logger.debug("Transforming the Saleor payload for calculating taxes with AvaTax...");
-
-    const payloadService = new AvataxCalculateTaxesPayloadService(
-      AvataxTaxCodeMatchesService.createFromAuthData(authData),
-      new AvataxCalculateTaxesPayloadTransformer(),
-    );
-
-    const target = await payloadService.getPayload(payload, config, discountStrategy);
 
     this.logger.info(
       "Calling AvaTax createTransaction with transformed payload for calculate taxes event",
       {
-        ...extractTransactionRedactedLogProperties(target.model),
+        ...extractTransactionRedactedLogProperties(avataxModel.model),
       },
     );
 
     try {
-      const response = await this.avataxClient.createTransaction(target);
+      const response = await this.avataxClient.createTransaction(avataxModel);
 
       this.logger.info("AvaTax createTransaction successfully responded", {
         taxCalculationSummary: response.summary,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
@@ -15,7 +15,10 @@ const errorParser = new AvataxErrorsParser(Sentry.captureException);
 export class AvataxCalculateTaxesAdapter {
   private logger = createLogger("AvataxCalculateTaxesAdapter");
 
-  constructor(private avataxClient: AvataxClient) {}
+  constructor(
+    private avataxClient: AvataxClient,
+    private avataxCalculateTaxesResponseTransformer: AvataxCalculateTaxesResponseTransformer,
+  ) {}
 
   async send(avataxModel: AvataxCalculateTaxesTarget): Promise<AvataxCalculateTaxesResponse> {
     this.logger.debug("Transforming the Saleor payload for calculating taxes with AvaTax...");
@@ -34,9 +37,7 @@ export class AvataxCalculateTaxesAdapter {
         taxCalculationSummary: response.summary,
       });
 
-      const responseTransformer = new AvataxCalculateTaxesResponseTransformer();
-
-      const transformedResponse = responseTransformer.transform(response);
+      const transformedResponse = this.avataxCalculateTaxesResponseTransformer.transform(response);
 
       this.logger.debug("Transformed AvaTax createTransaction response");
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import { AvataxCalculateTaxesTaxCodeMatcher } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher";
+
 import { DEFAULT_TAX_CLASS_ID } from "../constants";
 import { AutomaticallyDistributedDiscountsStrategy } from "../discounts";
 import { AvataxCalculateTaxesMockGenerator } from "./avatax-calculate-taxes-mock-generator";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";
 
-const transformer = new AvataxCalculateTaxesPayloadLinesTransformer();
+const transformer = new AvataxCalculateTaxesPayloadLinesTransformer(
+  new AvataxCalculateTaxesTaxCodeMatcher(),
+);
 
 const discountsStrategy = new AutomaticallyDistributedDiscountsStrategy();
 

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer.ts
@@ -9,6 +9,8 @@ import { avataxProductLine } from "./avatax-product-line";
 import { avataxShippingLine } from "./avatax-shipping-line";
 
 export class AvataxCalculateTaxesPayloadLinesTransformer {
+  constructor(private avataxCalculateTaxesTaxCodeMatcher: AvataxCalculateTaxesTaxCodeMatcher) {}
+
   transform(
     taxBase: TaxBaseFragment,
     config: AvataxConfig,
@@ -19,8 +21,7 @@ export class AvataxCalculateTaxesPayloadLinesTransformer {
 
     // Price reduction discounts - we send totalPrices with or without discounts and let AvaTax calculate the tax
     const productLines: LineItemModel[] = taxBase.lines.map((line) => {
-      const matcher = new AvataxCalculateTaxesTaxCodeMatcher();
-      const taxCode = matcher.match(line, matches);
+      const taxCode = this.avataxCalculateTaxesTaxCodeMatcher.match(line, matches);
 
       return avataxProductLine.create({
         amount: line.totalPrice.amount,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -1,6 +1,9 @@
 import { DocumentType } from "avatax/lib/enums/DocumentType";
 import { describe, expect, it } from "vitest";
 
+import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
+import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
+
 import { CalculateTaxesPayload } from "../../webhooks/payloads/calculate-taxes-payload";
 import { AutomaticallyDistributedDiscountsStrategy } from "../discounts";
 import { AvataxCalculateTaxesMockGenerator } from "./avatax-calculate-taxes-mock-generator";
@@ -22,12 +25,15 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
       },
     } as unknown as CalculateTaxesPayload;
 
-    const payload = await new AvataxCalculateTaxesPayloadTransformer().transform(
-      payloadMock,
-      avataxConfigMock,
-      matchesMock,
-      discountsStrategy,
-    );
+    const payload = await new AvataxCalculateTaxesPayloadTransformer(
+      new AvataxCalculateTaxesPayloadLinesTransformer(),
+      new AvataxEntityTypeMatcher({
+        async getEntityUseCode() {
+          // todo
+          return { "@recordsetCount": 1, value: [] };
+        },
+      }),
+    ).transform(payloadMock, avataxConfigMock, matchesMock, discountsStrategy);
 
     expect(payload.model.type).toBe(DocumentType.SalesOrder);
   });
@@ -47,12 +53,15 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
       },
     } as unknown as CalculateTaxesPayload;
 
-    const payload = await new AvataxCalculateTaxesPayloadTransformer().transform(
-      payloadMock,
-      avataxConfigMock,
-      matchesMock,
-      discountsStrategy,
-    );
+    const payload = await new AvataxCalculateTaxesPayloadTransformer(
+      new AvataxCalculateTaxesPayloadLinesTransformer(),
+      new AvataxEntityTypeMatcher({
+        async getEntityUseCode() {
+          // todo
+          return { "@recordsetCount": 1, value: [] };
+        },
+      }),
+    ).transform(payloadMock, avataxConfigMock, matchesMock, discountsStrategy);
 
     expect(payload.model.discount).toBe(21.37);
   });

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
+import { AvataxCalculateTaxesTaxCodeMatcher } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher";
 
 import { CalculateTaxesPayload } from "../../webhooks/payloads/calculate-taxes-payload";
 import { AutomaticallyDistributedDiscountsStrategy } from "../discounts";
@@ -26,7 +27,7 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
     } as unknown as CalculateTaxesPayload;
 
     const payload = await new AvataxCalculateTaxesPayloadTransformer(
-      new AvataxCalculateTaxesPayloadLinesTransformer(),
+      new AvataxCalculateTaxesPayloadLinesTransformer(new AvataxCalculateTaxesTaxCodeMatcher()),
       new AvataxEntityTypeMatcher({
         async getEntityUseCode() {
           // todo
@@ -54,7 +55,7 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
     } as unknown as CalculateTaxesPayload;
 
     const payload = await new AvataxCalculateTaxesPayloadTransformer(
-      new AvataxCalculateTaxesPayloadLinesTransformer(),
+      new AvataxCalculateTaxesPayloadLinesTransformer(new AvataxCalculateTaxesTaxCodeMatcher()),
       new AvataxEntityTypeMatcher({
         async getEntityUseCode() {
           // todo

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -27,9 +27,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
   }
 
   /**
-   * TODO: Get rid off async mapping!
-   * - Extract all dynamic stuff outside
-   * - Only map, without side effects here
+   * https://linear.app/saleor/issue/SHOPX-1313/tech-debt-avatax-refactor-async-transformers
    */
   async transform(
     payload: CalculateTaxesPayload,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -2,11 +2,10 @@ import { DocumentType } from "avatax/lib/enums/DocumentType";
 
 import { CalculateTaxesPayload } from "../../webhooks/payloads/calculate-taxes-payload";
 import { avataxAddressFactory } from "../address-factory";
-import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
+import { CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
 import { avataxCustomerCode } from "../avatax-customer-code-resolver";
 import { AvataxEntityTypeMatcher } from "../avatax-entity-type-matcher";
-import { AvataxSdkClientFactory } from "../avatax-sdk-client-factory";
 import { AutomaticallyDistributedDiscountsStrategy } from "../discounts";
 import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-repository";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -38,11 +38,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
     matches: AvataxTaxCodeMatches,
     discountsStrategy: AutomaticallyDistributedDiscountsStrategy,
   ): Promise<CreateTransactionArgs> {
-    const payloadLinesTransformer = new AvataxCalculateTaxesPayloadLinesTransformer();
-    const avataxClient = new AvataxClient(new AvataxSdkClientFactory().createClient(avataxConfig));
-    const entityTypeMatcher = new AvataxEntityTypeMatcher(avataxClient);
-
-    const entityUseCode = await entityTypeMatcher.match(
+    const entityUseCode = await this.avataxEntityTypeMatcher.match(
       payload.taxBase.sourceObject.avataxEntityCode,
     );
 
@@ -67,7 +63,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
           shipTo: avataxAddressFactory.fromSaleorAddress(payload.taxBase.address!),
         },
         currencyCode: payload.taxBase.currency,
-        lines: payloadLinesTransformer.transform(
+        lines: this.avaTaxCalculateTaxesPayloadLinesTransformer.transform(
           payload.taxBase,
           avataxConfig,
           matches,

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.ts
@@ -12,6 +12,11 @@ import { AvataxTaxCodeMatches } from "../tax-code/avatax-tax-code-match-reposito
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "./avatax-calculate-taxes-payload-lines-transformer";
 
 export class AvataxCalculateTaxesPayloadTransformer {
+  constructor(
+    private avaTaxCalculateTaxesPayloadLinesTransformer: AvataxCalculateTaxesPayloadLinesTransformer,
+    private avataxEntityTypeMatcher: AvataxEntityTypeMatcher,
+  ) {}
+
   private matchDocumentType(config: AvataxConfig): DocumentType {
     /*
      * * For calculating taxes, we always use DocumentType.SalesOrder because it doesn't cause transaction recording.
@@ -22,6 +27,11 @@ export class AvataxCalculateTaxesPayloadTransformer {
     return DocumentType.SalesOrder;
   }
 
+  /**
+   * TODO: Get rid off async mapping!
+   * - Extract all dynamic stuff outside
+   * - Only map, without side effects here
+   */
   async transform(
     payload: CalculateTaxesPayload,
     avataxConfig: AvataxConfig,
@@ -30,7 +40,7 @@ export class AvataxCalculateTaxesPayloadTransformer {
   ): Promise<CreateTransactionArgs> {
     const payloadLinesTransformer = new AvataxCalculateTaxesPayloadLinesTransformer();
     const avataxClient = new AvataxClient(new AvataxSdkClientFactory().createClient(avataxConfig));
-    const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: avataxClient });
+    const entityTypeMatcher = new AvataxEntityTypeMatcher(avataxClient);
 
     const entityUseCode = await entityTypeMatcher.match(
       payload.taxBase.sourceObject.avataxEntityCode,

--- a/apps/avatax/src/modules/avatax/configuration/avatax-connection-repository.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-connection-repository.ts
@@ -1,12 +1,8 @@
-import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
-
-import { createLogger } from "../../../logger";
 import { CrudSettingsManager } from "../../crud-settings/crud-settings.service";
 import {
   ProviderConnections,
   providerConnectionsSchema,
 } from "../../provider-connections/provider-connections";
-import { TAX_PROVIDER_KEY } from "../../provider-connections/public-provider-connections.service";
 import {
   AvataxConfig,
   AvataxConnection,
@@ -16,17 +12,7 @@ import {
 const getSchema = avataxConnectionSchema.strict();
 
 export class AvataxConnectionRepository {
-  private crudSettingsManager: CrudSettingsManager;
-  private logger = createLogger("AvataxConnectionRepository", {
-    metadataKey: TAX_PROVIDER_KEY,
-  });
-  constructor(settingsManager: EncryptedMetadataManager, saleorApiUrl: string) {
-    this.crudSettingsManager = new CrudSettingsManager(
-      settingsManager,
-      saleorApiUrl,
-      TAX_PROVIDER_KEY,
-    );
-  }
+  constructor(private crudSettingsManager: CrudSettingsManager) {}
 
   private filterAvataxConnections(connections: ProviderConnections): AvataxConnection[] {
     return connections.filter(

--- a/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -1,6 +1,9 @@
 import { DeepPartial, TRPCError } from "@trpc/server";
 import { Client } from "urql";
 
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
+
 import { metadataCache } from "../../../lib/app-metadata-cache";
 import { createLogger } from "../../../logger";
 import { createSettingsManager } from "../../app/metadata-manager";
@@ -12,7 +15,6 @@ import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
 import { AvataxConnectionRepository } from "./avatax-connection-repository";
 
 export class AvataxConnectionService {
-  private logger = createLogger("AvataxConnectionService");
   private avataxConnectionRepository: AvataxConnectionRepository;
 
   constructor({
@@ -26,7 +28,9 @@ export class AvataxConnectionService {
   }) {
     const settingsManager = createSettingsManager(client, appId, metadataCache);
 
-    this.avataxConnectionRepository = new AvataxConnectionRepository(settingsManager, saleorApiUrl);
+    this.avataxConnectionRepository = new AvataxConnectionRepository(
+      new CrudSettingsManager(settingsManager, saleorApiUrl, TAX_PROVIDER_KEY),
+    );
   }
 
   private async checkIfAuthorized(input: AvataxConfig) {

--- a/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-connection.service.ts
@@ -1,12 +1,5 @@
 import { DeepPartial, TRPCError } from "@trpc/server";
-import { Client } from "urql";
 
-import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
-import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
-
-import { metadataCache } from "../../../lib/app-metadata-cache";
-import { createLogger } from "../../../logger";
-import { createSettingsManager } from "../../app/metadata-manager";
 import { AvataxInvalidCredentialsError } from "../../taxes/tax-error";
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig, AvataxConnection } from "../avatax-connection-schema";
@@ -15,23 +8,7 @@ import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
 import { AvataxConnectionRepository } from "./avatax-connection-repository";
 
 export class AvataxConnectionService {
-  private avataxConnectionRepository: AvataxConnectionRepository;
-
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    const settingsManager = createSettingsManager(client, appId, metadataCache);
-
-    this.avataxConnectionRepository = new AvataxConnectionRepository(
-      new CrudSettingsManager(settingsManager, saleorApiUrl, TAX_PROVIDER_KEY),
-    );
-  }
+  constructor(private avataxConnectionRepository: AvataxConnectionRepository) {}
 
   private async checkIfAuthorized(input: AvataxConfig) {
     const avataxClient = new AvataxClient(new AvataxSdkClientFactory().createClient(input));

--- a/apps/avatax/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
@@ -1,5 +1,12 @@
 import { Client } from "urql";
 
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
+import { AvataxConnectionService } from "@/modules/avatax/configuration/avatax-connection.service";
+import { AvataxConnectionRepository } from "@/modules/avatax/configuration/avatax-connection-repository";
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
+
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxSdkClientFactory } from "../avatax-sdk-client-factory";
@@ -26,11 +33,17 @@ export class AvataxEditAddressValidationService {
   }
 
   async validate(id: string, input: AvataxConfig) {
-    const transformer = new AvataxPatchInputTransformer({
-      client: this.client,
-      appId: this.appId,
-      saleorApiUrl: this.saleorApiUrl,
-    });
+    const transformer = new AvataxPatchInputTransformer(
+      new AvataxConnectionService(
+        new AvataxConnectionRepository(
+          new CrudSettingsManager(
+            createSettingsManager(this.client, this.appId, metadataCache),
+            this.saleorApiUrl,
+            TAX_PROVIDER_KEY,
+          ),
+        ),
+      ),
+    );
 
     const config = await transformer.patchInput(id, input);
 

--- a/apps/avatax/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-edit-address-validation.service.ts
@@ -1,12 +1,3 @@
-import { Client } from "urql";
-
-import { metadataCache } from "@/lib/app-metadata-cache";
-import { createSettingsManager } from "@/modules/app/metadata-manager";
-import { AvataxConnectionService } from "@/modules/avatax/configuration/avatax-connection.service";
-import { AvataxConnectionRepository } from "@/modules/avatax/configuration/avatax-connection-repository";
-import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
-import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
-
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxSdkClientFactory } from "../avatax-sdk-client-factory";
@@ -14,38 +5,10 @@ import { AvataxAddressValidationService } from "./avatax-address-validation.serv
 import { AvataxPatchInputTransformer } from "./avatax-patch-input-transformer";
 
 export class AvataxEditAddressValidationService {
-  private client: Client;
-  private appId: string;
-  private saleorApiUrl: string;
-
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    this.client = client;
-    this.appId = appId;
-    this.saleorApiUrl = saleorApiUrl;
-  }
+  constructor(private avataxPatchInputTransformer: AvataxPatchInputTransformer) {}
 
   async validate(id: string, input: AvataxConfig) {
-    const transformer = new AvataxPatchInputTransformer(
-      new AvataxConnectionService(
-        new AvataxConnectionRepository(
-          new CrudSettingsManager(
-            createSettingsManager(this.client, this.appId, metadataCache),
-            this.saleorApiUrl,
-            TAX_PROVIDER_KEY,
-          ),
-        ),
-      ),
-    );
-
-    const config = await transformer.patchInput(id, input);
+    const config = await this.avataxPatchInputTransformer.patchInput(id, input);
 
     const avataxClient = new AvataxClient(new AvataxSdkClientFactory().createClient(config));
     const addressValidation = new AvataxAddressValidationService(avataxClient);

--- a/apps/avatax/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-edit-auth-validation.service.ts
@@ -1,7 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { Client } from "urql";
 
-import { createLogger } from "../../../logger";
 import { AvataxInvalidCredentialsError } from "../../taxes/tax-error";
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
@@ -10,32 +9,13 @@ import { AvataxAuthValidationService } from "./avatax-auth-validation.service";
 import { AvataxPatchInputTransformer } from "./avatax-patch-input-transformer";
 
 export class AvataxEditAuthValidationService {
-  private logger = createLogger("AvataxAuthValidationService");
-  private client: Client;
-  private appId: string;
-  private saleorApiUrl: string;
-
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    this.client = client;
-    this.appId = appId;
-    this.saleorApiUrl = saleorApiUrl;
-  }
+  constructor(private avataxPatchInputTransformer: AvataxPatchInputTransformer) {}
 
   async validate(id: string, input: Pick<AvataxConfig, "credentials" | "isSandbox">) {
-    const transformer = new AvataxPatchInputTransformer({
-      client: this.client,
-      appId: this.appId,
-      saleorApiUrl: this.saleorApiUrl,
-    });
-    const credentials = await transformer.patchCredentials(id, input.credentials);
+    const credentials = await this.avataxPatchInputTransformer.patchCredentials(
+      id,
+      input.credentials,
+    );
     const avataxClient = new AvataxClient(
       new AvataxSdkClientFactory().createClient({ ...input, credentials }),
     );

--- a/apps/avatax/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
@@ -1,7 +1,4 @@
-import { Client } from "urql";
-
 import { Obfuscator } from "../../../lib/obfuscator";
-import { createLogger } from "../../../logger";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxConnectionService } from "./avatax-connection.service";
 
@@ -10,20 +7,9 @@ import { AvataxConnectionService } from "./avatax-connection.service";
  * The input from the edit UI is obfuscated, so we need to filter out those fields, and merge it with the existing configuration.
  */
 export class AvataxPatchInputTransformer {
-  private logger = createLogger("AvataxPatchInputTransformer");
-  private connection: AvataxConnectionService;
   private obfuscator: Obfuscator;
 
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    this.connection = new AvataxConnectionService({ client, appId, saleorApiUrl });
+  constructor(private avataxConnectionService: AvataxConnectionService) {
     this.obfuscator = new Obfuscator();
   }
 
@@ -35,7 +21,7 @@ export class AvataxPatchInputTransformer {
   }
 
   async patchCredentials(id: string, input: AvataxConfig["credentials"]) {
-    const connection = await this.connection.getById(id);
+    const connection = await this.avataxConnectionService.getById(id);
 
     const credentials: AvataxConfig["credentials"] = {
       ...connection.config.credentials,

--- a/apps/avatax/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-patch-input-transformer.ts
@@ -7,11 +7,10 @@ import { AvataxConnectionService } from "./avatax-connection.service";
  * The input from the edit UI is obfuscated, so we need to filter out those fields, and merge it with the existing configuration.
  */
 export class AvataxPatchInputTransformer {
-  private obfuscator: Obfuscator;
-
-  constructor(private avataxConnectionService: AvataxConnectionService) {
-    this.obfuscator = new Obfuscator();
-  }
+  constructor(
+    private avataxConnectionService: AvataxConnectionService,
+    private obfuscator: Obfuscator,
+  ) {}
 
   private checkIfNotObfuscated(config: AvataxConfig) {
     return (

--- a/apps/avatax/src/modules/avatax/configuration/public-avatax-connection.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/public-avatax-connection.service.ts
@@ -6,47 +6,37 @@ import { AvataxObfuscator } from "../avatax-obfuscator";
 import { AvataxConnectionService } from "./avatax-connection.service";
 
 export class PublicAvataxConnectionService {
-  private readonly connectionService: AvataxConnectionService;
-  private readonly obfuscator: AvataxObfuscator;
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    this.connectionService = new AvataxConnectionService({ client, appId, saleorApiUrl });
-    this.obfuscator = new AvataxObfuscator();
-  }
+  constructor(
+    private avataxConnectionService: AvataxConnectionService,
+    private avataxObfuscator: AvataxObfuscator,
+  ) {}
 
   async getAll() {
-    const connections = await this.connectionService.getAll();
+    const connections = await this.avataxConnectionService.getAll();
 
-    return this.obfuscator.obfuscateAvataxConnections(connections);
+    return this.avataxObfuscator.obfuscateAvataxConnections(connections);
   }
 
   async getById(id: string) {
-    const connection = await this.connectionService.getById(id);
+    const connection = await this.avataxConnectionService.getById(id);
 
-    return this.obfuscator.obfuscateAvataxConnection(connection);
+    return this.avataxObfuscator.obfuscateAvataxConnection(connection);
   }
 
   async create(config: AvataxConfig) {
-    return this.connectionService.create(config);
+    return this.avataxConnectionService.create(config);
   }
 
   async update(id: string, config: DeepPartial<AvataxConfig>) {
-    return this.connectionService.update(id, config);
+    return this.avataxConnectionService.update(id, config);
   }
 
   async delete(id: string) {
-    return this.connectionService.delete(id);
+    return this.avataxConnectionService.delete(id);
   }
 
   async verifyConnections() {
-    const connections = await this.connectionService.getAll();
+    const connections = await this.avataxConnectionService.getAll();
 
     if (connections.length === 0) {
       throw new Error("No AvaTax connections found");

--- a/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.ts
+++ b/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.ts
@@ -11,13 +11,15 @@ export type AvataxOrderCancelledTarget = VoidTransactionArgs;
 export class AvataxOrderCancelledAdapter implements WebhookAdapter<{ avataxId: string }, void> {
   private logger = createLogger("AvataxOrderCancelledAdapter");
 
-  constructor(private avataxClient: AvataxClient) {}
+  constructor(
+    private avataxClient: AvataxClient,
+    private avataxOrderCancelledPayloadTransformer: AvataxOrderCancelledPayloadTransformer,
+  ) {}
 
   async send(payload: CancelOrderPayload, config: AvataxConfig) {
     this.logger.info("Transforming the Saleor payload for cancelling transaction with AvaTax...");
 
-    const payloadTransformer = new AvataxOrderCancelledPayloadTransformer();
-    const target = payloadTransformer.transform(
+    const target = this.avataxOrderCancelledPayloadTransformer.transform(
       payload,
       config.companyCode ?? defaultAvataxConfig.companyCode,
     );

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-adapter.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-adapter.ts
@@ -1,11 +1,5 @@
 import { AuthData } from "@saleor/app-sdk/APL";
 
-import { AvataxCalculationDateResolver } from "@/modules/avatax/avatax-calculation-date-resolver";
-import { AvataxDocumentCodeResolver } from "@/modules/avatax/avatax-document-code-resolver";
-import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
-import { AvataxOrderConfirmedPayloadTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer";
-import { SaleorOrderToAvataxLinesTransformer } from "@/modules/avatax/order-confirmed/saleor-order-to-avatax-lines-transformer";
-
 import { createLogger } from "../../../logger";
 import {
   DeprecatedOrderConfirmedSubscriptionFragment,

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.test.ts
@@ -1,6 +1,11 @@
 import { DocumentType } from "avatax/lib/enums/DocumentType";
 import { describe, expect, it } from "vitest";
 
+import { AvataxCalculationDateResolver } from "@/modules/avatax/avatax-calculation-date-resolver";
+import { AvataxDocumentCodeResolver } from "@/modules/avatax/avatax-document-code-resolver";
+import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
+import { SaleorOrderToAvataxLinesTransformer } from "@/modules/avatax/order-confirmed/saleor-order-to-avatax-lines-transformer";
+
 import { SaleorOrderConfirmedEventMockFactory } from "../../saleor/order-confirmed/mocks";
 import { AvataxClient } from "../avatax-client";
 import { AvataxSdkClientFactory } from "../avatax-sdk-client-factory";
@@ -20,7 +25,12 @@ const orderMock = mockGenerator.generateOrder();
 export const avataxConfigMock = mockGenerator.generateAvataxConfig();
 
 const transformer = new AvataxOrderConfirmedPayloadTransformer(
-  new AvataxClient(new AvataxSdkClientFactory().createClient(avataxConfigMock)),
+  new SaleorOrderToAvataxLinesTransformer(),
+  new AvataxEntityTypeMatcher(
+    new AvataxClient(new AvataxSdkClientFactory().createClient(avataxConfigMock)),
+  ),
+  new AvataxCalculationDateResolver(),
+  new AvataxDocumentCodeResolver(),
 );
 
 describe("AvataxOrderConfirmedPayloadTransformer", () => {

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -61,7 +61,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
     discountsStrategy: PriceReductionDiscountsStrategy;
   }): Promise<CreateTransactionArgs> {
     const saleorOrderToAvataxLinesTransformer = new SaleorOrderToAvataxLinesTransformer();
-    const entityTypeMatcher = new AvataxEntityTypeMatcher({ client: this.avataxClient });
+    const entityTypeMatcher = new AvataxEntityTypeMatcher(this.avataxClient);
     const dateResolver = new AvataxCalculationDateResolver();
     const documentCodeResolver = new AvataxDocumentCodeResolver();
 

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -10,7 +10,7 @@ import {
 import { TaxBadPayloadError } from "../../taxes/tax-error";
 import { avataxAddressFactory } from "../address-factory";
 import { AvataxCalculationDateResolver } from "../avatax-calculation-date-resolver";
-import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
+import { CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig, defaultAvataxConfig } from "../avatax-connection-schema";
 import { avataxCustomerCode } from "../avatax-customer-code-resolver";
 import { AvataxDocumentCodeResolver } from "../avatax-document-code-resolver";
@@ -22,7 +22,12 @@ import { SaleorOrderToAvataxLinesTransformer } from "./saleor-order-to-avatax-li
 export class AvataxOrderConfirmedPayloadTransformer {
   private logger = createLogger("AvataxOrderConfirmedPayloadTransformer");
 
-  constructor(private avataxClient: AvataxClient) {}
+  constructor(
+    private saleorOrderToAvataxLinesTransformer: SaleorOrderToAvataxLinesTransformer,
+    private avataxEntityTypeMatcher: AvataxEntityTypeMatcher,
+    private avataxCalculationDateResolver: AvataxCalculationDateResolver,
+    private avataxDocumentCodeResolver: AvataxDocumentCodeResolver,
+  ) {}
 
   private matchDocumentType(config: AvataxConfig): DocumentType {
     if (!config.isDocumentRecordingEnabled) {
@@ -60,14 +65,12 @@ export class AvataxOrderConfirmedPayloadTransformer {
     matches: AvataxTaxCodeMatches;
     discountsStrategy: PriceReductionDiscountsStrategy;
   }): Promise<CreateTransactionArgs> {
-    const saleorOrderToAvataxLinesTransformer = new SaleorOrderToAvataxLinesTransformer();
-    const entityTypeMatcher = new AvataxEntityTypeMatcher(this.avataxClient);
-    const dateResolver = new AvataxCalculationDateResolver();
-    const documentCodeResolver = new AvataxDocumentCodeResolver();
-
-    const entityUseCode = await entityTypeMatcher.match(order.avataxEntityCode);
-    const date = dateResolver.resolve(order.avataxTaxCalculationDate, order.created);
-    const code = documentCodeResolver.resolve({
+    const entityUseCode = await this.avataxEntityTypeMatcher.match(order.avataxEntityCode);
+    const date = this.avataxCalculationDateResolver.resolve(
+      order.avataxTaxCalculationDate,
+      order.created,
+    );
+    const code = this.avataxDocumentCodeResolver.resolve({
       avataxDocumentCode: order.avataxDocumentCode,
       orderId: order.id,
     });
@@ -105,7 +108,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
         currencyCode: order.total.currency,
         // we can fall back to empty string because email is not a required field
         email: order.user?.email ?? order.userEmail ?? "",
-        lines: saleorOrderToAvataxLinesTransformer.transform({
+        lines: this.saleorOrderToAvataxLinesTransformer.transform({
           confirmedOrderEvent,
           matches,
           avataxConfig,

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload.service.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload.service.ts
@@ -4,14 +4,16 @@ import {
   DeprecatedOrderConfirmedSubscriptionFragment,
   SaleorOrderConfirmedEvent,
 } from "../../saleor";
-import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
+import { CreateTransactionArgs } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { PriceReductionDiscountsStrategy } from "../discounts";
 import { AvataxTaxCodeMatchesService } from "../tax-code/avatax-tax-code-matches.service";
 import { AvataxOrderConfirmedPayloadTransformer } from "./avatax-order-confirmed-payload-transformer";
 
 export class AvataxOrderConfirmedPayloadService {
-  constructor(private avataxClient: AvataxClient) {}
+  constructor(
+    private avataxOrderConfirmedPayloadTransformer: AvataxOrderConfirmedPayloadTransformer,
+  ) {}
 
   private getMatches(authData: AuthData) {
     const taxCodeMatchesService = AvataxTaxCodeMatchesService.createFromAuthData(authData);
@@ -27,9 +29,8 @@ export class AvataxOrderConfirmedPayloadService {
     discountsStrategy: PriceReductionDiscountsStrategy,
   ): Promise<CreateTransactionArgs> {
     const matches = await this.getMatches(authData);
-    const payloadTransformer = new AvataxOrderConfirmedPayloadTransformer(this.avataxClient);
 
-    return payloadTransformer.transform({
+    return this.avataxOrderConfirmedPayloadTransformer.transform({
       order,
       confirmedOrderEvent,
       avataxConfig,

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-match-repository.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-match-repository.ts
@@ -1,7 +1,5 @@
-import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
 import { z } from "zod";
 
-import { createLogger } from "../../../logger";
 import { CrudSettingsManager } from "../../crud-settings/crud-settings.service";
 
 export const avataxTaxCodeMatchSchema = z.object({
@@ -20,16 +18,10 @@ const avataxTaxCodeMatchesSchema = z.array(
 
 export type AvataxTaxCodeMatches = z.infer<typeof avataxTaxCodeMatchesSchema>;
 
-const metadataKey = "avatax-tax-code-map";
-
 export class AvataxTaxCodeMatchRepository {
-  private crudSettingsManager: CrudSettingsManager;
-  private logger = createLogger("AvataxTaxCodeMatchRepository", {
-    metadataKey,
-  });
-  constructor(settingsManager: EncryptedMetadataManager, saleorApiUrl: string) {
-    this.crudSettingsManager = new CrudSettingsManager(settingsManager, saleorApiUrl, metadataKey);
-  }
+  static metadataKey = "avatax-tax-code-map";
+
+  constructor(private crudSettingsManager: CrudSettingsManager) {}
 
   async getAll(): Promise<AvataxTaxCodeMatches> {
     const { data } = await this.crudSettingsManager.readAll();

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
@@ -1,5 +1,7 @@
 import { AuthData } from "@saleor/app-sdk/APL";
 
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+
 import { metadataCache } from "../../../lib/app-metadata-cache";
 import { createInstrumentedGraphqlClient } from "../../../lib/create-instrumented-graphql-client";
 import { createSettingsManager } from "../../app/metadata-manager";
@@ -37,8 +39,11 @@ export class AvataxTaxCodeMatchesService {
     const settingsManager = createSettingsManager(client, authData.appId, metadataCache);
 
     const taxCodeMatchRepository = new AvataxTaxCodeMatchRepository(
-      settingsManager,
-      authData.saleorApiUrl,
+      new CrudSettingsManager(
+        settingsManager,
+        authData.saleorApiUrl,
+        AvataxTaxCodeMatchRepository.metadataKey,
+      ),
     );
 
     return new AvataxTaxCodeMatchesService(taxCodeMatchRepository);

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-code-matches.service.ts
@@ -39,11 +39,11 @@ export class AvataxTaxCodeMatchesService {
     const settingsManager = createSettingsManager(client, authData.appId, metadataCache);
 
     const taxCodeMatchRepository = new AvataxTaxCodeMatchRepository(
-      new CrudSettingsManager(
-        settingsManager,
-        authData.saleorApiUrl,
-        AvataxTaxCodeMatchRepository.metadataKey,
-      ),
+      new CrudSettingsManager({
+        metadataManager: settingsManager,
+        saleorApiUrl: authData.saleorApiUrl,
+        metadataKey: AvataxTaxCodeMatchRepository.metadataKey,
+      }),
     );
 
     return new AvataxTaxCodeMatchesService(taxCodeMatchRepository);

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
@@ -34,11 +34,11 @@ export const avataxTaxCodesRouter = router({
 
     const connectionService = new AvataxConnectionService(
       new AvataxConnectionRepository(
-        new CrudSettingsManager(
-          createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
-          ctx.saleorApiUrl,
-          TAX_PROVIDER_KEY,
-        ),
+        new CrudSettingsManager({
+          metadataManager: createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+          saleorApiUrl: ctx.saleorApiUrl,
+          metadataKey: TAX_PROVIDER_KEY,
+        }),
       ),
     );
 

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.router.ts
@@ -1,7 +1,12 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
 import { AvataxClientTaxCodeService } from "@/modules/avatax/avatax-client-tax-code.service";
+import { AvataxConnectionRepository } from "@/modules/avatax/configuration/avatax-connection-repository";
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
 
 import { createLogger } from "../../../logger";
 import { protectedClientProcedure } from "../../trpc/protected-client-procedure";
@@ -27,11 +32,15 @@ export const avataxTaxCodesRouter = router({
       filter: input.filter,
     });
 
-    const connectionService = new AvataxConnectionService({
-      appId: ctx.appId!,
-      client: ctx.apiClient,
-      saleorApiUrl: ctx.saleorApiUrl,
-    });
+    const connectionService = new AvataxConnectionService(
+      new AvataxConnectionRepository(
+        new CrudSettingsManager(
+          createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+          ctx.saleorApiUrl,
+          TAX_PROVIDER_KEY,
+        ),
+      ),
+    );
 
     const connection = await connectionService.getById(input.connectionId).catch((err) => {
       logger.error("Failed to resolve connection from settings", { error: err });

--- a/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.ts
+++ b/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.ts
@@ -18,6 +18,8 @@ import { verifyCalculateTaxesPayload } from "../../webhooks/validate-webhook-pay
 export class CalculateTaxesUseCase {
   private logger = createLogger("CalculateTaxesUseCase");
 
+  private discountsStrategy = new AutomaticallyDistributedDiscountsStrategy();
+
   static CalculateTaxesUseCaseError = BaseError.subclass("CalculateTaxesUseCaseError");
   static ExpectedIncompletePayloadError = this.CalculateTaxesUseCaseError.subclass(
     "ExpectedIncompletePayloadError",
@@ -165,14 +167,12 @@ export class CalculateTaxesUseCase {
       );
     }
 
-    const discountsStrategy = new AutomaticallyDistributedDiscountsStrategy();
-
     return fromPromise(
       taxProvider.calculateTaxes(
         payload,
         providerConfig.value.avataxConfig.config,
         authData,
-        discountsStrategy,
+        this.discountsStrategy,
       ),
       (err) =>
         new CalculateTaxesUseCase.FailedCalculatingTaxesError("Failed to calculate taxes", {

--- a/apps/avatax/src/modules/channel-configuration/channel-configuration-repository.ts
+++ b/apps/avatax/src/modules/channel-configuration/channel-configuration-repository.ts
@@ -10,6 +10,7 @@ import { ChannelConfig, channelsSchema } from "./channel-config";
 
 export class ChannelConfigurationRepository {
   private crudSettingsManager: CrudSettingsManager;
+
   constructor(settingsManager: EncryptedMetadataManager, saleorApiUrl: string) {
     this.crudSettingsManager = new CrudSettingsManager({
       saleorApiUrl,

--- a/apps/avatax/src/modules/channel-configuration/channel-configuration-repository.ts
+++ b/apps/avatax/src/modules/channel-configuration/channel-configuration-repository.ts
@@ -1,18 +1,21 @@
 import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
 
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
+import { TAX_PROVIDER_KEY } from "@/modules/provider-connections/public-provider-connections.service";
+
 import { createLogger } from "../../logger";
 import { CrudSettingsManager } from "../crud-settings/crud-settings.service";
 import { ChannelConfig, channelsSchema } from "./channel-config";
 
 export class ChannelConfigurationRepository {
   private crudSettingsManager: CrudSettingsManager;
-  private logger = createLogger("ChannelConfigurationRepository");
   constructor(settingsManager: EncryptedMetadataManager, saleorApiUrl: string) {
-    this.crudSettingsManager = new CrudSettingsManager(
-      settingsManager,
+    this.crudSettingsManager = new CrudSettingsManager({
       saleorApiUrl,
-      "channel-configuration",
-    );
+      metadataKey: "channel-configuration",
+      metadataManager: settingsManager,
+    });
   }
 
   async getAll() {

--- a/apps/avatax/src/modules/channel-configuration/channel-configuration.router.ts
+++ b/apps/avatax/src/modules/channel-configuration/channel-configuration.router.ts
@@ -1,3 +1,8 @@
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
+import { ChannelConfigurationRepository } from "@/modules/channel-configuration/channel-configuration-repository";
+import { ChannelsFetcher } from "@/modules/channel-configuration/channel-fetcher";
+
 import { createLogger } from "../../logger";
 import { protectedClientProcedure } from "../trpc/protected-client-procedure";
 import { router } from "../trpc/trpc-server";
@@ -8,9 +13,11 @@ const protectedWithConfigurationService = protectedClientProcedure.use(({ next, 
   next({
     ctx: {
       connectionService: new ChannelConfigurationService(
-        ctx.apiClient,
-        ctx.appId!,
-        ctx.saleorApiUrl,
+        new ChannelConfigurationRepository(
+          createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+          ctx.saleorApiUrl,
+        ),
+        new ChannelsFetcher(ctx.apiClient),
       ),
     },
   }),

--- a/apps/avatax/src/modules/channel-configuration/channel-configuration.service.ts
+++ b/apps/avatax/src/modules/channel-configuration/channel-configuration.service.ts
@@ -1,37 +1,16 @@
-import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
-import { Client } from "urql";
-
-import { metadataCache } from "../../lib/app-metadata-cache";
-import { createLogger } from "../../logger";
-import { createSettingsManager } from "../app/metadata-manager";
 import { ChannelConfigProperties } from "./channel-config";
 import { ChannelConfigurationMerger } from "./channel-configuration-merger";
 import { ChannelConfigurationRepository } from "./channel-configuration-repository";
 import { ChannelsFetcher } from "./channel-fetcher";
 
 export class ChannelConfigurationService {
-  private configurationRepository: ChannelConfigurationRepository;
-  private logger = createLogger("ChannelConfigurationService");
-  private settingsManager: EncryptedMetadataManager;
   constructor(
-    private client: Client,
-    private appId: string,
-    private saleorApiUrl: string,
-  ) {
-    const settingsManager = createSettingsManager(client, appId, metadataCache);
-
-    this.settingsManager = settingsManager;
-
-    this.configurationRepository = new ChannelConfigurationRepository(
-      settingsManager,
-      saleorApiUrl,
-    );
-  }
+    private configurationRepository: ChannelConfigurationRepository,
+    private channelsFetcher: ChannelsFetcher,
+  ) {}
 
   async getAll() {
-    const channelsFetcher = new ChannelsFetcher(this.client);
-
-    const channels = await channelsFetcher.fetchChannels();
+    const channels = await this.channelsFetcher.fetchChannels();
 
     const channelConfiguration = await this.configurationRepository.getAll();
 

--- a/apps/avatax/src/modules/crud-settings/crud-settings.service.test.ts
+++ b/apps/avatax/src/modules/crud-settings/crud-settings.service.test.ts
@@ -19,7 +19,11 @@ describe("CrudSettingsService", () => {
       delete: vi.fn(),
     };
 
-    service = new CrudSettingsManager(mockSettingsManager, "apiUrl", "metadataKey");
+    service = new CrudSettingsManager({
+      metadataManager: mockSettingsManager,
+      saleorApiUrl: "apiUrl",
+      metadataKey: "metadataKey",
+    });
   });
 
   describe("readAll", () => {

--- a/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
+++ b/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
@@ -7,6 +7,12 @@ import { createLogger } from "../../logger";
 const settingSchema = z.record(z.any()).and(z.object({ id: z.string() }));
 const settingsSchema = z.array(settingSchema);
 
+type Params = {
+  metadataManager: SettingsManager;
+  saleorApiUrl: string;
+  metadataKey: string;
+};
+
 export class CrudSettingsManager {
   private logger = createLogger("CrudSettingsManager");
 
@@ -24,15 +30,14 @@ export class CrudSettingsManager {
      * (like creating an "id" field, or how it updates the data).
      * So if you make a mistake in data transformations in your class, you will not get any errors.
      */
-    private metadataManager: SettingsManager,
-    private saleorApiUrl: string,
-    private metadataKey: string,
-  ) {
-    this.metadataKey = metadataKey;
-  }
+    private params: Params,
+  ) {}
 
   async readAll() {
-    const result = await this.metadataManager.get(this.metadataKey, this.saleorApiUrl);
+    const result = await this.params.metadataManager.get(
+      this.params.metadataKey,
+      this.params.saleorApiUrl,
+    );
 
     if (!result) {
       return { data: [] };
@@ -44,7 +49,7 @@ export class CrudSettingsManager {
     if (!validation.success) {
       this.logger.error("Error while validating metadata", {
         error: validation.error,
-        metadataKey: this.metadataKey,
+        metadataKey: this.params.metadataKey,
       });
       throw new Error("Error while validating metadata");
     }
@@ -61,7 +66,7 @@ export class CrudSettingsManager {
     const item = settings.find((item) => item.id === id);
 
     if (!item) {
-      this.logger.error("Item not found", { id, metadataKey: this.metadataKey });
+      this.logger.error("Item not found", { id, metadataKey: this.params.metadataKey });
       throw new Error("Item not found");
     }
 
@@ -77,10 +82,10 @@ export class CrudSettingsManager {
     const id = createId();
     const newData = [...prevData, { ...data, id }];
 
-    await this.metadataManager.set({
-      key: this.metadataKey,
+    await this.params.metadataManager.set({
+      key: this.params.metadataKey,
       value: JSON.stringify(newData),
-      domain: this.saleorApiUrl,
+      domain: this.params.saleorApiUrl,
     });
 
     return {
@@ -93,10 +98,10 @@ export class CrudSettingsManager {
     const prevData = settings.data;
     const nextData = prevData.filter((item) => item.id !== id);
 
-    await this.metadataManager.set({
-      key: this.metadataKey,
+    await this.params.metadataManager.set({
+      key: this.params.metadataKey,
       value: JSON.stringify(nextData),
-      domain: this.saleorApiUrl,
+      domain: this.params.saleorApiUrl,
     });
   }
 
@@ -111,10 +116,10 @@ export class CrudSettingsManager {
       return item;
     });
 
-    await this.metadataManager.set({
-      key: this.metadataKey,
+    await this.params.metadataManager.set({
+      key: this.params.metadataKey,
       value: JSON.stringify(nextSettings),
-      domain: this.saleorApiUrl,
+      domain: this.params.saleorApiUrl,
     });
   }
 }

--- a/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
+++ b/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
@@ -10,6 +10,10 @@ const settingsSchema = z.array(settingSchema);
 export class CrudSettingsManager {
   private logger = createLogger("CrudSettingsManager");
 
+  /**
+   * TODO: Remove this class...
+   * ...and also move auth data to methods, not constructor, so it can be created ahead of time
+   */
   constructor(
     /*
      * // todo: invoke createSettingsManager in constructor

--- a/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
+++ b/apps/avatax/src/modules/crud-settings/crud-settings.service.ts
@@ -13,16 +13,14 @@ type Params = {
   metadataKey: string;
 };
 
+/**
+ * https://linear.app/saleor/issue/SHOPX-1312/refactor-and-remove-crud-settings-service-avatax
+ */
 export class CrudSettingsManager {
   private logger = createLogger("CrudSettingsManager");
 
-  /**
-   * TODO: Remove this class...
-   * ...and also move auth data to methods, not constructor, so it can be created ahead of time
-   */
   constructor(
     /*
-     * // todo: invoke createSettingsManager in constructor
      * // todo: constructor should accept schema that should be used to validate data
      * Currently, CrudSettingsManager has a big limitation of not validating the inputs in any way.
      * We rely on the classes that implement CrudSettingsManager to provide the data in the correct format,

--- a/apps/avatax/src/modules/provider-connections/provider-connections.router.ts
+++ b/apps/avatax/src/modules/provider-connections/provider-connections.router.ts
@@ -1,17 +1,37 @@
+import { metadataCache } from "@/lib/app-metadata-cache";
+import { createSettingsManager } from "@/modules/app/metadata-manager";
+import { AvataxObfuscator } from "@/modules/avatax/avatax-obfuscator";
+import { AvataxConnectionService } from "@/modules/avatax/configuration/avatax-connection.service";
+import { AvataxConnectionRepository } from "@/modules/avatax/configuration/avatax-connection-repository";
+import { PublicAvataxConnectionService } from "@/modules/avatax/configuration/public-avatax-connection.service";
+import { CrudSettingsManager } from "@/modules/crud-settings/crud-settings.service";
+
 import { createLogger } from "../../logger";
 import { protectedClientProcedure } from "../trpc/protected-client-procedure";
 import { router } from "../trpc/trpc-server";
-import { PublicProviderConnectionsService } from "./public-provider-connections.service";
+import {
+  PublicProviderConnectionsService,
+  TAX_PROVIDER_KEY,
+} from "./public-provider-connections.service";
 
 export const providerConnectionsRouter = router({
   getAll: protectedClientProcedure.query(async ({ ctx }) => {
     const logger = createLogger("providerConnectionsRouter.getAll");
 
-    const items = await new PublicProviderConnectionsService({
-      appId: ctx.appId!,
-      client: ctx.apiClient,
-      saleorApiUrl: ctx.saleorApiUrl,
-    }).getAll();
+    const items = await new PublicProviderConnectionsService(
+      new PublicAvataxConnectionService(
+        new AvataxConnectionService(
+          new AvataxConnectionRepository(
+            new CrudSettingsManager(
+              createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+              ctx.saleorApiUrl,
+              TAX_PROVIDER_KEY,
+            ),
+          ),
+        ),
+        new AvataxObfuscator(),
+      ),
+    ).getAll();
 
     logger.info("Returning tax providers configuration");
 

--- a/apps/avatax/src/modules/provider-connections/provider-connections.router.ts
+++ b/apps/avatax/src/modules/provider-connections/provider-connections.router.ts
@@ -22,11 +22,11 @@ export const providerConnectionsRouter = router({
       new PublicAvataxConnectionService(
         new AvataxConnectionService(
           new AvataxConnectionRepository(
-            new CrudSettingsManager(
-              createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
-              ctx.saleorApiUrl,
-              TAX_PROVIDER_KEY,
-            ),
+            new CrudSettingsManager({
+              saleorApiUrl: ctx.saleorApiUrl,
+              metadataKey: TAX_PROVIDER_KEY,
+              metadataManager: createSettingsManager(ctx.apiClient, ctx.appId, metadataCache),
+            }),
           ),
         ),
         new AvataxObfuscator(),

--- a/apps/avatax/src/modules/provider-connections/public-provider-connections.service.ts
+++ b/apps/avatax/src/modules/provider-connections/public-provider-connections.service.ts
@@ -1,33 +1,12 @@
-import { Client } from "urql";
-
-import { createLogger } from "../../logger";
 import { PublicAvataxConnectionService } from "../avatax/configuration/public-avatax-connection.service";
 
 export const TAX_PROVIDER_KEY = "tax-providers-v2";
 
 export class PublicProviderConnectionsService {
-  private avataxConnectionService: PublicAvataxConnectionService;
-  private logger = createLogger("PublicProviderConnectionsService", {
-    metadataKey: TAX_PROVIDER_KEY,
-  });
-  constructor({
-    client,
-    appId,
-    saleorApiUrl,
-  }: {
-    client: Client;
-    appId: string;
-    saleorApiUrl: string;
-  }) {
-    this.avataxConnectionService = new PublicAvataxConnectionService({
-      client,
-      appId,
-      saleorApiUrl,
-    });
-  }
+  constructor(private publicAvataxConnectionService: PublicAvataxConnectionService) {}
 
   async getAll() {
-    const avatax = await this.avataxConnectionService.getAll();
+    const avatax = await this.publicAvataxConnectionService.getAll();
 
     return avatax;
   }

--- a/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
+++ b/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
@@ -1,5 +1,12 @@
 import { err, ok } from "neverthrow";
 
+import { AvataxCalculateTaxesAdapter } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter";
+import { AvataxCalculateTaxesPayloadService } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload.service";
+import { AvataxCalculateTaxesPayloadTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer";
+import { AvataxOrderCancelledAdapter } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-adapter";
+import { AvataxOrderConfirmedAdapter } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-adapter";
+import { AvataxTaxCodeMatchesService } from "@/modules/avatax/tax-code/avatax-tax-code-matches.service";
+
 import { BaseError } from "../../error";
 import { AppConfig } from "../../lib/app-config";
 import { AvataxClient } from "../avatax/avatax-client";
@@ -25,10 +32,16 @@ export class AvataxWebhookServiceFactory {
       );
     }
 
+    const avaTaxSdk = new AvataxSdkClientFactory().createClient(
+      channelConfig.value.avataxConfig.config,
+    );
+    const avaTaxClient = new AvataxClient(avaTaxSdk);
+
     const taxProvider = new AvataxWebhookService(
-      new AvataxClient(
-        new AvataxSdkClientFactory().createClient(channelConfig.value.avataxConfig.config),
-      ),
+      new AvataxCalculateTaxesAdapter(avaTaxClient),
+      new AvataxCalculateTaxesPayloadTransformer(),
+      new AvataxOrderCancelledAdapter(avaTaxClient),
+      new AvataxOrderConfirmedAdapter(avaTaxClient),
     );
 
     return ok({ taxProvider });

--- a/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
+++ b/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
@@ -7,7 +7,10 @@ import { AvataxCalculateTaxesAdapter } from "@/modules/avatax/calculate-taxes/av
 import { AvataxCalculateTaxesPayloadService } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload.service";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
 import { AvataxCalculateTaxesPayloadTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer";
+import { AvataxCalculateTaxesResponseTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-transformer";
+import { AvataxCalculateTaxesTaxCodeMatcher } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher";
 import { AvataxOrderCancelledAdapter } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-adapter";
+import { AvataxOrderCancelledPayloadTransformer } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-payload-transformer";
 import { AvataxOrderConfirmedAdapter } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-adapter";
 import { AvataxOrderConfirmedPayloadService } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload.service";
 import { AvataxOrderConfirmedPayloadTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer";
@@ -45,13 +48,17 @@ export class AvataxWebhookServiceFactory {
     );
     const avaTaxClient = new AvataxClient(avaTaxSdk);
 
+    /**
+     * Compose dependencies - as much as possible lifted as high as possible.
+     * Next steps of refactor - remove not needed classes and lift them even higher. And inject into use case
+     */
     const taxProvider = new AvataxWebhookService(
-      new AvataxCalculateTaxesAdapter(avaTaxClient),
+      new AvataxCalculateTaxesAdapter(avaTaxClient, new AvataxCalculateTaxesResponseTransformer()),
       new AvataxCalculateTaxesPayloadTransformer(
-        new AvataxCalculateTaxesPayloadLinesTransformer(),
+        new AvataxCalculateTaxesPayloadLinesTransformer(new AvataxCalculateTaxesTaxCodeMatcher()),
         new AvataxEntityTypeMatcher(avaTaxClient),
       ),
-      new AvataxOrderCancelledAdapter(avaTaxClient),
+      new AvataxOrderCancelledAdapter(avaTaxClient, new AvataxOrderCancelledPayloadTransformer()),
       new AvataxOrderConfirmedAdapter(
         avaTaxClient,
         new AvataxOrderConfirmedResponseTransformer(),

--- a/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
+++ b/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
@@ -4,7 +4,6 @@ import { AvataxCalculationDateResolver } from "@/modules/avatax/avatax-calculati
 import { AvataxDocumentCodeResolver } from "@/modules/avatax/avatax-document-code-resolver";
 import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
 import { AvataxCalculateTaxesAdapter } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter";
-import { AvataxCalculateTaxesPayloadService } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload.service";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
 import { AvataxCalculateTaxesPayloadTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer";
 import { AvataxCalculateTaxesResponseTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-transformer";
@@ -16,7 +15,6 @@ import { AvataxOrderConfirmedPayloadService } from "@/modules/avatax/order-confi
 import { AvataxOrderConfirmedPayloadTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer";
 import { AvataxOrderConfirmedResponseTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-response-transformer";
 import { SaleorOrderToAvataxLinesTransformer } from "@/modules/avatax/order-confirmed/saleor-order-to-avatax-lines-transformer";
-import { AvataxTaxCodeMatchesService } from "@/modules/avatax/tax-code/avatax-tax-code-matches.service";
 
 import { BaseError } from "../../error";
 import { AppConfig } from "../../lib/app-config";

--- a/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
+++ b/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
@@ -1,5 +1,7 @@
 import { err, ok } from "neverthrow";
 
+import { AvataxCalculationDateResolver } from "@/modules/avatax/avatax-calculation-date-resolver";
+import { AvataxDocumentCodeResolver } from "@/modules/avatax/avatax-document-code-resolver";
 import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
 import { AvataxCalculateTaxesAdapter } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter";
 import { AvataxCalculateTaxesPayloadService } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload.service";
@@ -7,6 +9,10 @@ import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/ca
 import { AvataxCalculateTaxesPayloadTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer";
 import { AvataxOrderCancelledAdapter } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-adapter";
 import { AvataxOrderConfirmedAdapter } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-adapter";
+import { AvataxOrderConfirmedPayloadService } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload.service";
+import { AvataxOrderConfirmedPayloadTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer";
+import { AvataxOrderConfirmedResponseTransformer } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-response-transformer";
+import { SaleorOrderToAvataxLinesTransformer } from "@/modules/avatax/order-confirmed/saleor-order-to-avatax-lines-transformer";
 import { AvataxTaxCodeMatchesService } from "@/modules/avatax/tax-code/avatax-tax-code-matches.service";
 
 import { BaseError } from "../../error";
@@ -46,7 +52,18 @@ export class AvataxWebhookServiceFactory {
         new AvataxEntityTypeMatcher(avaTaxClient),
       ),
       new AvataxOrderCancelledAdapter(avaTaxClient),
-      new AvataxOrderConfirmedAdapter(avaTaxClient),
+      new AvataxOrderConfirmedAdapter(
+        avaTaxClient,
+        new AvataxOrderConfirmedResponseTransformer(),
+        new AvataxOrderConfirmedPayloadService(
+          new AvataxOrderConfirmedPayloadTransformer(
+            new SaleorOrderToAvataxLinesTransformer(),
+            new AvataxEntityTypeMatcher(avaTaxClient),
+            new AvataxCalculationDateResolver(),
+            new AvataxDocumentCodeResolver(),
+          ),
+        ),
+      ),
     );
 
     return ok({ taxProvider });

--- a/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
+++ b/apps/avatax/src/modules/taxes/avatax-webhook-service-factory.ts
@@ -1,7 +1,9 @@
 import { err, ok } from "neverthrow";
 
+import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
 import { AvataxCalculateTaxesAdapter } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter";
 import { AvataxCalculateTaxesPayloadService } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload.service";
+import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
 import { AvataxCalculateTaxesPayloadTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer";
 import { AvataxOrderCancelledAdapter } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-adapter";
 import { AvataxOrderConfirmedAdapter } from "@/modules/avatax/order-confirmed/avatax-order-confirmed-adapter";
@@ -39,7 +41,10 @@ export class AvataxWebhookServiceFactory {
 
     const taxProvider = new AvataxWebhookService(
       new AvataxCalculateTaxesAdapter(avaTaxClient),
-      new AvataxCalculateTaxesPayloadTransformer(),
+      new AvataxCalculateTaxesPayloadTransformer(
+        new AvataxCalculateTaxesPayloadLinesTransformer(),
+        new AvataxEntityTypeMatcher(avaTaxClient),
+      ),
       new AvataxOrderCancelledAdapter(avaTaxClient),
       new AvataxOrderConfirmedAdapter(avaTaxClient),
     );

--- a/apps/avatax/src/modules/taxes/tax-provider-webhook.ts
+++ b/apps/avatax/src/modules/taxes/tax-provider-webhook.ts
@@ -1,34 +1,7 @@
-import { AuthData } from "@saleor/app-sdk/APL";
 import { SyncWebhookResponsesMap } from "@saleor/app-sdk/handlers/next";
-
-import { OrderConfirmedSubscriptionFragment } from "../../../generated/graphql";
-import { AvataxConfig } from "../avatax/avatax-connection-schema";
-import {
-  AutomaticallyDistributedDiscountsStrategy,
-  PriceReductionDiscountsStrategy,
-} from "../avatax/discounts";
-import { SaleorOrderConfirmedEvent } from "../saleor";
-import { CalculateTaxesPayload } from "../webhooks/payloads/calculate-taxes-payload";
 
 export type CalculateTaxesResponse = SyncWebhookResponsesMap["ORDER_CALCULATE_TAXES"];
 
 export type CreateOrderResponse = { id: string };
 
 export type CancelOrderPayload = { avataxId: string };
-
-export interface ProviderWebhookService {
-  calculateTaxes: (
-    payload: CalculateTaxesPayload,
-    avataxConfig: AvataxConfig,
-    authData: AuthData,
-    discountStrategy: AutomaticallyDistributedDiscountsStrategy,
-  ) => Promise<CalculateTaxesResponse>;
-  confirmOrder: (
-    payload: OrderConfirmedSubscriptionFragment,
-    saleorOrderConfirmedEvent: SaleorOrderConfirmedEvent,
-    avataxConfig: AvataxConfig,
-    authData: AuthData,
-    discountStrategy: PriceReductionDiscountsStrategy,
-  ) => Promise<CreateOrderResponse>;
-  cancelOrder: (payload: CancelOrderPayload, avataxConfig: AvataxConfig) => Promise<void>;
-}

--- a/apps/avatax/src/styles/globals.css
+++ b/apps/avatax/src/styles/globals.css
@@ -1,6 +1,17 @@
 body {
-  font-family: Inter, -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    Inter,
+    -apple-system,
+    "system-ui",
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    sans-serif;
   color: #111;
   padding: 1rem 2rem;
 }
@@ -12,8 +23,15 @@ code {
   display: inline-block;
   margin-top: 10px;
   padding: 0.75rem;
-  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-    Bitstream Vera Sans Mono, Courier New, monospace;
+  font-family:
+    Menlo,
+    Monaco,
+    Lucida Console,
+    Liberation Mono,
+    DejaVu Sans Mono,
+    Bitstream Vera Sans Mono,
+    Courier New,
+    monospace;
 }
 
 code::before {

--- a/apps/avatax/src/styles/globals.css
+++ b/apps/avatax/src/styles/globals.css
@@ -1,17 +1,6 @@
 body {
-  font-family:
-    Inter,
-    -apple-system,
-    "system-ui",
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Fira Sans",
-    "Droid Sans",
-    "Helvetica Neue",
-    sans-serif;
+  font-family: Inter, -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   color: #111;
   padding: 1rem 2rem;
 }
@@ -23,15 +12,8 @@ code {
   display: inline-block;
   margin-top: 10px;
   padding: 0.75rem;
-  font-family:
-    Menlo,
-    Monaco,
-    Lucida Console,
-    Liberation Mono,
-    DejaVu Sans Mono,
-    Bitstream Vera Sans Mono,
-    Courier New,
-    monospace;
+  font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
+    Bitstream Vera Sans Mono, Courier New, monospace;
 }
 
 code::before {


### PR DESCRIPTION
To approach spaghetti-dependencies, this refactor is extracting creating services (`new` statements) to as high as possible in the code execution tree.

Now, there are only few places in the codebase, where services are created. 
Props like auth data is no longer driller through the tree

Dependencies structure is also more clear.

As a next steps, it will be easier to remove unnecessary abstractions (services in the middle) to simplify the codebase