### PR TITLE
Set Avatax e2e tests to print DEBUG level logs

### DIFF
--- a/apps/avatax/e2e/setup.ts
+++ b/apps/avatax/e2e/setup.ts
@@ -29,6 +29,7 @@ beforeAll(() => {
 
   settings.setRequestDefaultRetryCount(3); // retry up to 3 times by default
   settings.setRequestDefaultRetryDelay(50); // wait 50ms between retries
+  settings.setLogLevel("DEBUG");
 
   /*
    * We have to use baseUrl (without /graphql/ suffix)


### PR DESCRIPTION
Try to print more verbose logs from Pactum, so failed tests will be easier to debug (hopefully)