### PR TITLE
Add more e2e tests for discounts applied to checkout or draft order

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        saleor: [318, 319, 320]
+        saleor: [319, 320]
     env:
       ACCESS_TOKEN: ${{ secrets.saleor-token }}
       SALEOR_VERSION: ${{ matrix.saleor }}

--- a/apps/avatax/e2e/data/maps/product.json
+++ b/apps/avatax/e2e/data/maps/product.json
@@ -9,6 +9,11 @@
       "variantId": "UHJvZHVjdFZhcmlhbnQ6Mzg0",
       "id": "UHJvZHVjdDoxNTI=",
       "name": "Apple Juice"
+    },
+    "ExpensiveTshirt": {
+      "variantId": "UHJvZHVjdFZhcmlhbnQ6Mzkw",
+      "id": "UHJvZHVjdDoxNTc=",
+      "name": "Reversed Monotype Tee"
     }
   }
 }

--- a/apps/avatax/e2e/data/maps/voucher.json
+++ b/apps/avatax/e2e/data/maps/voucher.json
@@ -4,6 +4,11 @@
       "id": "Vm91Y2hlcjo0",
       "code": "test_voucher_15percentage",
       "name": "VOUCHER 15%"
+    },
+    "FreeShipping": {
+      "id": "Vm91Y2hlcjox",
+      "code": "FREESHIPPING",
+      "name": "Free shipping"
     }
   }
 }

--- a/apps/avatax/e2e/data/templates/addVoucher.json
+++ b/apps/avatax/e2e/data/templates/addVoucher.json
@@ -2,5 +2,9 @@
   "AddVoucher:USA:Percentage": {
     "checkoutId": "$S{CheckoutId}",
     "promoCode": "$M{Voucher.Percentage.code}"
+  },
+  "AddVoucher:USA:FreeShipping": {
+    "checkoutId": "$S{CheckoutId}",
+    "promoCode": "$M{Voucher.FreeShipping.code}"
   }
 }

--- a/apps/avatax/e2e/data/templates/checkout.json
+++ b/apps/avatax/e2e/data/templates/checkout.json
@@ -1,13 +1,23 @@
 {
   "Checkout:USA": {
     "channelSlug": "$M{Channel.USA.slug}",
-    "variantId": "$M{Product.Regular.variantId}",
+    "lines": [
+      {
+        "variantId": "$M{Product.Regular.variantId}",
+        "quantity": 10
+      }
+    ],
     "email": "$F{UserEmail}",
     "address": "$M{Address.NewYork}"
   },
   "Checkout:PricesWithTax": {
     "channelSlug": "$M{Channel.PricesWithTax.slug}",
-    "variantId": "$M{Product.Regular.variantId}",
+    "lines": [
+      {
+        "variantId": "$M{Product.Regular.variantId}",
+        "quantity": 10
+      }
+    ],
     "email": "$F{UserEmail}",
     "address": "$M{Address.NewYork}"
   }

--- a/apps/avatax/e2e/data/templates/updateCheckoutLines.json
+++ b/apps/avatax/e2e/data/templates/updateCheckoutLines.json
@@ -1,0 +1,11 @@
+{
+  "UpdateLines": {
+    "checkoutId": "$S{CheckoutId}",
+    "lines": [
+      {
+        "lineId": "$S{CheckoutLineId}",
+        "quantity": 2
+      }
+    ]
+  }
+}

--- a/apps/avatax/e2e/graphql/fragments/CheckoutDetails.graphql
+++ b/apps/avatax/e2e/graphql/fragments/CheckoutDetails.graphql
@@ -1,7 +1,11 @@
 fragment CheckoutDetails on Checkout {
   id
   lines {
+    id
     undiscountedTotalPrice {
+      ...Money
+    }
+    undiscountedUnitPrice{
       ...Money
     }
     totalPrice {

--- a/apps/avatax/e2e/graphql/mutations/CheckoutLinesUpdate.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CheckoutLinesUpdate.graphql
@@ -1,0 +1,10 @@
+mutation CheckoutLinesUpdate($checkoutId: ID!, $lines: [CheckoutLineUpdateInput!]!) {
+  checkoutLinesUpdate(id: $checkoutId, lines: $lines) {
+    errors {
+      ...CheckoutError
+    }
+    checkout {
+      ...CheckoutDetails
+    }
+  }
+}

--- a/apps/avatax/e2e/graphql/mutations/CreateCheckout.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CreateCheckout.graphql
@@ -1,13 +1,13 @@
 mutation CreateCheckout(
   $channelSlug: String!
-  $variantId: ID!
   $email: String!
   $address: AddressInput!
+  $lines: [CheckoutLineInput!]!
 ) {
   checkoutCreate(
     input: {
       channel: $channelSlug
-      lines: [{ quantity: 10, variantId: $variantId }]
+      lines: $lines
       email: $email
       shippingAddress: $address
       billingAddress: $address

--- a/apps/avatax/e2e/graphql/mutations/CreateCheckoutNoAddress.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CreateCheckoutNoAddress.graphql
@@ -1,8 +1,8 @@
-mutation CreateCheckoutNoAddress($channelSlug: String!, $variantId: ID!, $email: String!) {
+mutation CreateCheckoutNoAddress($channelSlug: String!, $lines: [CheckoutLineInput!]!, $email: String!) {
   checkoutCreate(
     input: {
       channel: $channelSlug
-      lines: [{ quantity: 10, variantId: $variantId }]
+      lines: $lines
       email: $email
       languageCode: EN_US
     }

--- a/apps/avatax/e2e/graphql/mutations/OrderAddDiscount.graphql
+++ b/apps/avatax/e2e/graphql/mutations/OrderAddDiscount.graphql
@@ -1,0 +1,10 @@
+mutation OrderDiscountAdd($orderId: ID!, $input: OrderDiscountCommonInput!) {
+  orderDiscountAdd(orderId: $orderId, input: $input) {
+    errors {
+      ...OrderError
+    }
+    order {
+      ...OrderDetailsFragment
+    }
+  }
+}

--- a/apps/avatax/e2e/tests/checkout_address_change_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change_with_product_tax.spec.ts
@@ -235,6 +235,27 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           },
         },
       })
-      .stores("StaffUserToken", "data.tokenCreate.token");
+      .stores("StaffUserToken", "data.tokenCreate.token")
+      .retry();
+  });
+
+  it("should have metadata with 'avataxId' key", async () => {
+    await testCase
+      .step("Check if order has metadata with 'avataxId' key")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(OrderDetails)
+      .withGraphQLVariables({
+        id: "$S{OrderID}",
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJsonLike("data.order.metadata[key=avataxId]", {
+        key: "avataxId",
+        value: "typeof $V === 'string'",
+      })
+      .retry(4, 2000);
   });
 });

--- a/apps/avatax/e2e/tests/checkout_address_change_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change_with_product_tax.spec.ts
@@ -50,7 +50,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
       .withGraphQLVariables({
         "@DATA:TEMPLATE@": "Checkout:PricesWithTax",
         "@OVERRIDES@": {
-          variantId: "$M{Product.Juice.variantId}",
+          lines: [{ quantity: 10, variantId: "$M{Product.Juice.variantId}" }],
           channelSlug: "$M{Channel.PricesWithTax.slug}",
         },
       })
@@ -236,25 +236,5 @@ describe("App should calculate taxes for checkout on update shipping address TC:
         },
       })
       .stores("StaffUserToken", "data.tokenCreate.token");
-  });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
   });
 });

--- a/apps/avatax/e2e/tests/checkout_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_product_tax.spec.ts
@@ -163,7 +163,8 @@ describe("App should calculate taxes for checkout with product with tax class TC
           },
         },
       })
-      .stores("StaffUserToken", "data.tokenCreate.token");
+      .stores("StaffUserToken", "data.tokenCreate.token")
+      .retry();
   });
 
   it("should have metadata with 'avataxId' key", async () => {

--- a/apps/avatax/e2e/tests/checkout_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_product_tax.spec.ts
@@ -42,7 +42,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
       .withGraphQLVariables({
         "@DATA:TEMPLATE@": "Checkout:PricesWithTax",
         "@OVERRIDES@": {
-          variantId: "$M{Product.Juice.variantId}",
+          lines: [{ quantity: 10, variantId: "$M{Product.Juice.variantId}" }],
           channelSlug: "$M{Channel.PricesWithTax.slug}",
         },
       })

--- a/apps/avatax/e2e/tests/checkout_with_voucher_free_shipping.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_voucher_free_shipping.spec.ts
@@ -10,10 +10,10 @@ import {
   MoneyFragment,
 } from "../generated/graphql";
 
-// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=16236
-describe("App should calculate taxes for checkout with entire order voucher applied TC: AVATAX_5", () => {
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=16237
+describe("App should calculate taxes for checkout with free shipping voucher applied TC: AVATAX_6", () => {
   const testCase = e2e(
-    "Product without tax class [pricesEnteredWithTax: False], voucher [type: ENTIRE_ORDER, discountValueType: PERCENTAGE]",
+    "Product with tax class [pricesEnteredWithTax: False], voucher [type: SHIPPING, discountValueType: PERCENTAGE]",
   );
 
   const CURRENCY = "USD";
@@ -30,19 +30,15 @@ describe("App should calculate taxes for checkout with entire order voucher appl
   const TOTAL_TAX_PRICE_AFTER_SHIPPING = 7.48;
   const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 91.79;
 
-  const VOUCHER_AMOUNT = 2.25;
+  const VOUCHER_AMOUNT = SHIPPING_NET_PRICE;
 
-  const SHIPPING_NET_PRICE_AFTER_VOUCHER = 69.31;
-  const SHIPPING_TAX_PRICE_AFTER_VOUCHER = 6.15;
-  const SHIPPING_GROSS_PRICE_AFTER_VOUCHER = 75.46;
+  const SHIPPING_NET_PRICE_AFTER_VOUCHER = 0;
+  const SHIPPING_TAX_PRICE_AFTER_VOUCHER = 0;
+  const SHIPPING_GROSS_PRICE_AFTER_VOUCHER = 0;
 
-  const PRODUCT_NET_PRICE_AFTER_VOUCHER = 12.75;
-  const PRODUCT_TAX_PRICE_AFTER_VOUCHER = 1.13;
-  const PRODUCT_GROSS_PRICE_AFTER_VOUCHER = 13.88;
-
-  const TOTAL_NET_PRICE_AFTER_VOUCHER = 82.06;
-  const TOTAL_TAX_PRICE_AFTER_VOUCHER = 7.28;
-  const TOTAL_GROSS_PRICE_AFTER_VOUCHER = 89.34;
+  const TOTAL_NET_PRICE_AFTER_VOUCHER = TOTAL_NET_PRICE_BEFORE_SHIPPING;
+  const TOTAL_TAX_PRICE_AFTER_VOUCHER = TOTAL_TAX_PRICE_BEFORE_SHIPPING;
+  const TOTAL_GROSS_PRICE_AFTER_VOUCHER = TOTAL_GROSS_PRICE_BEFORE_SHIPPING;
 
   const getMoney = (amount: number): MoneyFragment => {
     return {
@@ -129,22 +125,13 @@ describe("App should calculate taxes for checkout with entire order voucher appl
       .post("/graphql/")
       .withGraphQLQuery(CheckoutAddVoucher)
       .withGraphQLVariables({
-        "@DATA:TEMPLATE@": "AddVoucher:USA:Percentage",
+        "@DATA:TEMPLATE@": "AddVoucher:USA:FreeShipping",
       })
-      .expectJson("data.checkoutAddPromoCode.checkout.discountName", "$M{Voucher.Percentage.name}")
+      .expectJson(
+        "data.checkoutAddPromoCode.checkout.discountName",
+        "$M{Voucher.FreeShipping.name}",
+      )
       .expectJson("data.checkoutAddPromoCode.checkout.discount", getMoney(VOUCHER_AMOUNT))
-      .expectJson(
-        "data.checkoutAddPromoCode.checkout.lines[0].totalPrice",
-        getCompleteMoney({
-          gross: PRODUCT_GROSS_PRICE_AFTER_VOUCHER,
-          net: PRODUCT_NET_PRICE_AFTER_VOUCHER,
-          tax: PRODUCT_TAX_PRICE_AFTER_VOUCHER,
-        }),
-      )
-      .expectJson(
-        "data.checkoutAddPromoCode.checkout.lines[0].undiscountedTotalPrice",
-        getMoney(TOTAL_NET_PRICE_BEFORE_SHIPPING),
-      )
       .expectJson(
         "data.checkoutAddPromoCode.checkout.shippingPrice",
         getCompleteMoney({

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -8,7 +8,6 @@ import {
   DraftOrderComplete,
   DraftOrderUpdateAddress,
   DraftOrderUpdateShippingMethod,
-  OrderDetails,
   OrderDiscountAdd,
   StaffUserTokenCreate,
 } from "../generated/graphql";
@@ -71,7 +70,8 @@ describe("App should calculate taxes for draft order with manual total discount 
           },
         },
       })
-      .stores("StaffUserToken", "data.tokenCreate.token");
+      .stores("StaffUserToken", "data.tokenCreate.token")
+      .retry();
   });
   it("creates order in channel pricesEnteredWithTax: True", async () => {
     await testCase

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -8,6 +8,7 @@ import {
   DraftOrderComplete,
   DraftOrderUpdateAddress,
   DraftOrderUpdateShippingMethod,
+  MoneyFragment,
   OrderDiscountAdd,
   StaffUserTokenCreate,
 } from "../generated/graphql";

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -181,7 +181,7 @@ describe("App should calculate taxes for draft order with manual total discount 
 
   it("should add manual discount for total as staff user", async () => {
     await testCase
-      .step("add manual discouny to draft order")
+      .step("add manual discount to draft order")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(OrderDiscountAdd)

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -9,11 +9,12 @@ import {
   DraftOrderUpdateAddress,
   DraftOrderUpdateShippingMethod,
   OrderDetails,
+  OrderDiscountAdd,
   StaffUserTokenCreate,
 } from "../generated/graphql";
 
-// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18382
-describe("App should calculate taxes for draft order with product with tax class TC: AVATAX_18", () => {
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18386
+describe("App should calculate taxes for draft order with manual total discount applied TC: AVATAX_22", () => {
   const testCase = e2e("Product with tax class [pricesEnteredWithTax: True]");
   const staffCredentials = {
     email: process.env.E2E_USER_NAME as string,
@@ -33,6 +34,14 @@ describe("App should calculate taxes for draft order with product with tax class
   const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 84.31;
   const TOTAL_NET_PRICE_AFTER_SHIPPING = 77.44;
   const TOTAL_TAX_PRICE_AFTER_SHIPPING = 6.87;
+
+  const TOTAL_GROSS_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT = 69.1;
+  const TOTAL_NET_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT = 63.47;
+  const TOTAL_TAX_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT = 5.63;
+
+  const TOTAL_GROSS_SHIPPING_PRICE_AFTER_DISCOUNT = 55.45;
+  const TOTAL_NET_SHIPPING_PRICE_AFTER_DISCOUNT = 50.93;
+  const TOTAL_TAX_SHIPPING_PRICE_AFTER_DISCOUNT = 4.52;
 
   const getMoney = (amount: number): MoneyFragment => {
     return {
@@ -64,9 +73,9 @@ describe("App should calculate taxes for draft order with product with tax class
       })
       .stores("StaffUserToken", "data.tokenCreate.token");
   });
-  it("creates order with product with tax class", async () => {
+  it("creates order in channel pricesEnteredWithTax: True", async () => {
     await testCase
-      .step("Create order with product with tax class")
+      .step("Create order in channel")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(CreateDraftOrder)
@@ -170,6 +179,42 @@ describe("App should calculate taxes for draft order with product with tax class
       );
   });
 
+  it("should add manual discount for total as staff user", async () => {
+    await testCase
+      .step("add manual discouny to draft order")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(OrderDiscountAdd)
+      .withGraphQLVariables({
+        orderId: "$S{OrderID}",
+        input: {
+          reason: "manual discount for client",
+          value: 10,
+          valueType: "PERCENTAGE",
+        },
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJson("data.orderDiscountAdd.order.id", "$S{OrderID}")
+      .expectJson(
+        "data.orderDiscountAdd.order.total",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
+          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
+        }),
+      )
+      .expectJson(
+        "data.orderDiscountAdd.order.shippingPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_SHIPPING_PRICE_AFTER_DISCOUNT,
+          net: TOTAL_NET_SHIPPING_PRICE_AFTER_DISCOUNT,
+          tax: TOTAL_TAX_SHIPPING_PRICE_AFTER_DISCOUNT,
+        }),
+      );
+  });
   it("should complete draft order", async () => {
     await testCase
       .step("Complete draft order")
@@ -184,25 +229,5 @@ describe("App should calculate taxes for draft order with product with tax class
       })
       .expectStatus(200)
       .expectJson("data.draftOrderComplete.order.id", "$S{OrderID}");
-  });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
   });
 });

--- a/apps/avatax/e2e/tests/order_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/order_with_product_tax.spec.ts
@@ -8,6 +8,7 @@ import {
   DraftOrderComplete,
   DraftOrderUpdateAddress,
   DraftOrderUpdateShippingMethod,
+  MoneyFragment,
   OrderDetails,
   StaffUserTokenCreate,
 } from "../generated/graphql";

--- a/apps/avatax/e2e/tests/order_with_product_tax.spec.ts
+++ b/apps/avatax/e2e/tests/order_with_product_tax.spec.ts
@@ -62,7 +62,8 @@ describe("App should calculate taxes for draft order with product with tax class
           },
         },
       })
-      .stores("StaffUserToken", "data.tokenCreate.token");
+      .stores("StaffUserToken", "data.tokenCreate.token")
+      .retry();
   });
   it("creates order with product with tax class", async () => {
     await testCase


### PR DESCRIPTION
## Scope of the PR
Add 3 more tests to cover 

- checkout with a free shipping voucher - discount only on shipping
- checkout with order promotion with subtotal reward - discount only on subtotal
- draft order with manual discount - discount on subtotal and shipping



<!-- Describe briefly changed made in this PR -->

## Related issues

https://linear.app/saleor/issue/SHOPX-1341/add-e2e-test-in-avatax
<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
