### PR TITLE
Restore sequential migration script

### DIFF
--- a/apps/avatax/scripts/run-webhooks-migration.ts
+++ b/apps/avatax/scripts/run-webhooks-migration.ts
@@ -85,7 +85,7 @@ const runMigrations = async () => {
           const baseUrl = new URL(targetUrl).origin;
 
           // All webhooks in this application are turned on or off. If any of them is enabled, we enable all of them.
-          return appWebhooks.map((w) => ({ ...w.getWebhookManifest(baseUrl), enabled }));
+          return appWebhooks.map((w) => ({ ...w.getWebhookManifest(baseUrl), isActive: enabled }));
         },
       });
 


### PR DESCRIPTION
Despite being faster, some of the migration calls were rejected due to underlying Saleor mechanisms

This PR restores "slow" migration but it will be rate-limited again, hopefully making it reliable

In the future we can control this via env:
- in production make it slow but reliable
- in dev/staging make it fast, but accept the failure