### PR TITLE
Improve error parser constructor

### DIFF
--- a/.changeset/early-kangaroos-boil.md
+++ b/.changeset/early-kangaroos-boil.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Improved error parser class constructor: now `parse` method will have optional parameter of error capture instead of constructor. This change will not have effect on clients.

--- a/apps/avatax/src/modules/avatax/avatax-errors-parser.test.ts
+++ b/apps/avatax/src/modules/avatax/avatax-errors-parser.test.ts
@@ -11,7 +11,7 @@ describe("AvataxErrorsParser", () => {
   });
 
   it("should parse know error", () => {
-    const parser = new AvataxErrorsParser(mockErrorCapture);
+    const parser = new AvataxErrorsParser();
     const error = {
       code: "InvalidAddress",
       details: [
@@ -23,20 +23,20 @@ describe("AvataxErrorsParser", () => {
       ],
     };
 
-    const result = parser.parse(error);
+    const result = parser.parse(error, mockErrorCapture);
 
     expect(result).toBeInstanceOf(AvataxInvalidAddressError);
     expect(mockErrorCapture).not.toHaveBeenCalled();
   });
 
   it("should normalize unknown error and capture it into error tracking", () => {
-    const parser = new AvataxErrorsParser(mockErrorCapture);
+    const parser = new AvataxErrorsParser();
     const error = {
       code: "UnknownError",
       details: [],
     };
 
-    const result = parser.parse(error);
+    const result = parser.parse(error, mockErrorCapture);
 
     expect(result).toBeInstanceOf(AvataxTaxCalculationError);
     expect(mockErrorCapture).toHaveBeenCalledWith(

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/nextjs";
-
 import { createLogger } from "../../../logger";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
 import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
@@ -10,7 +8,7 @@ import { AvataxCalculateTaxesResponseTransformer } from "./avatax-calculate-taxe
 export type AvataxCalculateTaxesTarget = CreateTransactionArgs;
 export type AvataxCalculateTaxesResponse = CalculateTaxesResponse;
 
-const errorParser = new AvataxErrorsParser(Sentry.captureException);
+const errorParser = new AvataxErrorsParser();
 
 export class AvataxCalculateTaxesAdapter {
   private logger = createLogger("AvataxCalculateTaxesAdapter");

--- a/apps/avatax/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/nextjs";
 import { fromPromise } from "neverthrow";
 
 import { avataxAddressFactory } from "../address-factory";
@@ -6,7 +5,7 @@ import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
 import { AvataxErrorsParser } from "../avatax-errors-parser";
 
-const errorParser = new AvataxErrorsParser(Sentry.captureException);
+const errorParser = new AvataxErrorsParser();
 
 export class AvataxAddressValidationService {
   constructor(private avataxClient: AvataxClient) {}

--- a/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.ts
+++ b/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.ts
@@ -1,5 +1,3 @@
-import { captureException } from "@sentry/nextjs";
-
 import { BaseError } from "@/error";
 import { AvataxErrorsParser } from "@/modules/avatax/avatax-errors-parser";
 import { AvataxEntityNotFoundError } from "@/modules/taxes/tax-error";
@@ -16,13 +14,7 @@ export type AvataxOrderCancelledTarget = VoidTransactionArgs;
 
 export class AvataxOrderCancelledAdapter implements WebhookAdapter<{ avataxId: string }, void> {
   private logger = createLogger("AvataxOrderCancelledAdapter");
-  private errorParser = new AvataxErrorsParser((error) => {
-    captureException(
-      new Error("AvataxOrderCancelledAdapter: Unhandled error caught from Avatax", {
-        cause: error,
-      }),
-    );
-  });
+  private errorParser = new AvataxErrorsParser();
 
   static AvaTaxOrderCancelledAdapterError = BaseError.subclass("AvaTaxOrderCancelledAdapterError");
   static DocumentNotFoundError =


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Improved error parser class constructor: now `parse` method will have optional parameter of error capture instead of constructor. This change will not have effect on clients.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
