### PR TITLE
[E2E] Add tests for discounts on draft orders

### DIFF
--- a/apps/avatax/e2e/data/maps/product.json
+++ b/apps/avatax/e2e/data/maps/product.json
@@ -14,6 +14,11 @@
       "variantId": "UHJvZHVjdFZhcmlhbnQ6Mzkw",
       "id": "UHJvZHVjdDoxNTc=",
       "name": "Reversed Monotype Tee"
+    },
+    "ProductOnCatalogPromotion": {
+      "variantId": "UHJvZHVjdFZhcmlhbnQ6MzM1",
+      "id": "UHJvZHVjdDoxMjk=",
+      "name": "Dash Force"
     }
   }
 }

--- a/apps/avatax/e2e/data/templates/order.json
+++ b/apps/avatax/e2e/data/templates/order.json
@@ -2,12 +2,21 @@
   "DraftOrder:PricesWithTax": {
     "channelID": "$M{Channel.PricesWithTax.id}"
   },
-  "DraftOrder:PricesWithTax:Address": {
+  "DraftOrder:Address": {
     "billingAddress": "$M{Address.NewYork}",
     "shippingAddress": "$M{Address.NewYork}",
     "userEmail": "$F{UserEmail}"
   },
   "DraftOrder:PricesWithTax:ShippingMethod": {
     "deliveryMethodId": "$M{Channel.PricesWithTax.deliveryMethodId}"
+  },
+  "DraftOrder:PricesWithoutTax": {
+    "channelID": "$M{Channel.USA.id}"
+  },
+  "DraftOrder:PricesWithoutTax:ShippingMethod": {
+    "deliveryMethodId": "$M{Channel.USA.deliveryMethodId}"
+  },
+  "DraftOrder:VoucherCode": {
+    "voucherCode": "$M{Voucher.Percentage.code}"
   }
 }

--- a/apps/avatax/e2e/graphql/fragments/OrderDetails.graphql
+++ b/apps/avatax/e2e/graphql/fragments/OrderDetails.graphql
@@ -22,4 +22,15 @@ fragment OrderDetailsFragment on Order {
       ...Money
     }
   }
+  undiscountedTotal {
+    gross {
+      ...Money
+    }
+    net {
+      ...Money
+    }
+    tax {
+      ...Money
+    }
+  }
 }

--- a/apps/avatax/e2e/graphql/fragments/OrderDetails.graphql
+++ b/apps/avatax/e2e/graphql/fragments/OrderDetails.graphql
@@ -33,4 +33,19 @@ fragment OrderDetailsFragment on Order {
       ...Money
     }
   }
+  lines {
+    id
+    quantity
+    totalPrice {
+      gross {
+        ...Money
+      }
+      net {
+        ...Money
+      }
+      tax {
+        ...Money
+      }
+    }
+  }
 }

--- a/apps/avatax/e2e/graphql/fragments/OrderDiscounts.graphql
+++ b/apps/avatax/e2e/graphql/fragments/OrderDiscounts.graphql
@@ -1,0 +1,10 @@
+fragment Discounts on OrderDiscount {
+  name
+  reason
+  type
+  valueType
+  value
+  amount {
+    amount
+  }
+}

--- a/apps/avatax/e2e/graphql/mutations/CreateOrderLines.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CreateOrderLines.graphql
@@ -1,5 +1,5 @@
-mutation CreateOrderLines($variantId: ID!, $orderId: ID!) {
-  orderLinesCreate(id: $orderId, input: { quantity: 10, variantId: $variantId }) {
+mutation CreateOrderLines($orderId: ID!, $input:[OrderLineCreateInput!]!) {
+  orderLinesCreate(id: $orderId, input: $input) {
     order {
       ...OrderDetailsFragment
     }

--- a/apps/avatax/e2e/graphql/mutations/DraftOrderUpdateVoucher.graphql
+++ b/apps/avatax/e2e/graphql/mutations/DraftOrderUpdateVoucher.graphql
@@ -6,15 +6,8 @@ mutation DraftOrderUpdateVoucher($orderId: ID!, $voucherCode: String) {
     order {
       ...OrderDetailsFragment
       voucherCode
-      discounts{
-        name
-        reason
-        type
-        valueType
-        value
-        amount{
-          amount
-        }
+      discounts {
+        ...Discounts
       }
     }
   }

--- a/apps/avatax/e2e/graphql/mutations/DraftOrderUpdateVoucher.graphql
+++ b/apps/avatax/e2e/graphql/mutations/DraftOrderUpdateVoucher.graphql
@@ -1,0 +1,21 @@
+mutation DraftOrderUpdateVoucher($orderId: ID!, $voucherCode: String) {
+  draftOrderUpdate(id: $orderId, input: {voucherCode: $voucherCode}) {
+    errors {
+      ...OrderError
+    }
+    order {
+      ...OrderDetailsFragment
+      voucherCode
+      discounts{
+        name
+        reason
+        type
+        valueType
+        value
+        amount{
+          amount
+        }
+      }
+    }
+  }
+}

--- a/apps/avatax/e2e/graphql/mutations/OrderAddDiscount.graphql
+++ b/apps/avatax/e2e/graphql/mutations/OrderAddDiscount.graphql
@@ -5,6 +5,9 @@ mutation OrderDiscountAdd($orderId: ID!, $input: OrderDiscountCommonInput!) {
     }
     order {
       ...OrderDetailsFragment
+      discounts {
+        ...Discounts
+      }
     }
   }
 }

--- a/apps/avatax/e2e/graphql/mutations/OrderLineUpdate.graphql
+++ b/apps/avatax/e2e/graphql/mutations/OrderLineUpdate.graphql
@@ -1,0 +1,10 @@
+mutation OrderLineUpdate($lineId: ID!, $input: OrderLineInput!) {
+  orderLineUpdate(id: $lineId, input: $input) {
+    order {
+      ...OrderDetailsFragment
+      discounts {
+        ...Discounts
+      }
+    }
+  }
+}

--- a/apps/avatax/e2e/tests/checkout_address_change.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change.spec.ts
@@ -184,47 +184,4 @@ describe("App should calculate taxes for checkout on update shipping address TC:
       )
       .stores("OrderID", "data.checkoutComplete.order.id");
   });
-
-  /*
-   * It takes few seconds for metadata do be populated with `avataxId` key
-   * That's why we need to do it in a separate step
-   */
-  it("creates token for staff user", async () => {
-    await testCase
-      .step("Create token for staff user")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(StaffUserTokenCreate)
-      .withGraphQLVariables(staffCredentials)
-      .expectStatus(200)
-      .expectJsonLike({
-        data: {
-          tokenCreate: {
-            token: "typeof $V === 'string'",
-          },
-        },
-      })
-      .stores("StaffUserToken", "data.tokenCreate.token")
-      .retry();
-  });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
-  });
 });

--- a/apps/avatax/e2e/tests/checkout_address_change.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { e2e } from "pactum";
-import { string } from "pactum-matchers";
 import { describe, it } from "vitest";
 
 import {
@@ -9,8 +8,6 @@ import {
   CheckoutUpdateDeliveryMethod,
   CompleteCheckout,
   CreateCheckoutNoAddress,
-  OrderDetails,
-  StaffUserTokenCreate,
 } from "../generated/graphql";
 import { getCompleteMoney } from "../utils/moneyUtils";
 

--- a/apps/avatax/e2e/tests/checkout_address_change.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change.spec.ts
@@ -22,6 +22,8 @@ describe("App should calculate taxes for checkout on update shipping address TC:
     password: process.env.E2E_USER_PASSWORD as string,
   };
 
+  const CURRENCY = "USD";
+
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 13.78;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.22;
@@ -60,6 +62,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           tax: 0,
+          currency: CURRENCY,
         }),
       )
       .stores("CheckoutId", "data.checkoutCreate.checkout.id");
@@ -88,6 +91,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       );
   });
@@ -117,6 +121,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       );
   });
@@ -137,6 +142,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -145,6 +151,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       );
   });
@@ -163,6 +170,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -171,6 +179,7 @@ describe("App should calculate taxes for checkout on update shipping address TC:
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .stores("OrderID", "data.checkoutComplete.order.id");

--- a/apps/avatax/e2e/tests/checkout_address_change.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_address_change.spec.ts
@@ -17,10 +17,6 @@ import { getCompleteMoney } from "../utils/moneyUtils";
 // Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18385
 describe("App should calculate taxes for checkout on update shipping address TC: AVATAX_21", () => {
   const testCase = e2e("Checkout for product with tax class [pricesEnteredWithTax: True]");
-  const staffCredentials = {
-    email: process.env.E2E_USER_NAME as string,
-    password: process.env.E2E_USER_PASSWORD as string,
-  };
 
   const CURRENCY = "USD";
 

--- a/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
@@ -1,14 +1,11 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { e2e } from "pactum";
-import { string } from "pactum-matchers";
 import { describe, it } from "vitest";
 
 import {
   CheckoutUpdateDeliveryMethod,
   CompleteCheckout,
   CreateCheckout,
-  OrderDetails,
-  StaffUserTokenCreate,
 } from "../generated/graphql";
 import { getCompleteMoney } from "../utils/moneyUtils";
 

--- a/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
@@ -20,6 +20,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
     password: process.env.E2E_USER_PASSWORD as string,
   };
 
+  const CURRENCY = "USD";
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 13.78;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.22;
@@ -52,6 +53,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .stores("CheckoutId", "data.checkoutCreate.checkout.id");
@@ -73,6 +75,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -81,6 +84,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       );
   });
@@ -99,6 +103,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -107,6 +112,7 @@ describe("App should calculate taxes for checkout with product with tax class TC
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .stores("OrderID", "data.checkoutComplete.order.id");

--- a/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
@@ -15,10 +15,6 @@ import { getCompleteMoney } from "../utils/moneyUtils";
 // Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18384
 describe("App should calculate taxes for checkout with product with tax class TC: AVATAX_20", () => {
   const testCase = e2e("Checkout for product with tax class [pricesEnteredWithTax: True]");
-  const staffCredentials = {
-    email: process.env.E2E_USER_NAME as string,
-    password: process.env.E2E_USER_PASSWORD as string,
-  };
 
   const CURRENCY = "USD";
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;

--- a/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_basic_product_with_tax_code.spec.ts
@@ -117,47 +117,4 @@ describe("App should calculate taxes for checkout with product with tax class TC
       )
       .stores("OrderID", "data.checkoutComplete.order.id");
   });
-
-  /*
-   * It takes few seconds for metadata do be populated with `avataxId` key
-   * That's why we need to do it in a separate step
-   */
-  it("creates token for staff user", async () => {
-    await testCase
-      .step("Create token for staff user")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(StaffUserTokenCreate)
-      .withGraphQLVariables(staffCredentials)
-      .expectStatus(200)
-      .expectJsonLike({
-        data: {
-          tokenCreate: {
-            token: "typeof $V === 'string'",
-          },
-        },
-      })
-      .stores("StaffUserToken", "data.tokenCreate.token")
-      .retry();
-  });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
-  });
 });

--- a/apps/avatax/e2e/tests/checkout_basic_product_without_tax_code.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_basic_product_without_tax_code.spec.ts
@@ -13,6 +13,7 @@ import { getCompleteMoney, getMoney } from "../utils/moneyUtils";
 describe("App should calculate taxes for checkout with product without tax class TC: AVATAX_1", () => {
   const testCase = e2e("Product without tax class [pricesEnteredWithTax: False]");
 
+  const CURRENCY = "USD";
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 300;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 26.63;
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 326.63;
@@ -41,6 +42,7 @@ describe("App should calculate taxes for checkout with product without tax class
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .retry()
@@ -63,6 +65,7 @@ describe("App should calculate taxes for checkout with product without tax class
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -71,6 +74,7 @@ describe("App should calculate taxes for checkout with product without tax class
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .retry();

--- a/apps/avatax/e2e/tests/checkout_order_promotion_subtotal_reward.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_order_promotion_subtotal_reward.spec.ts
@@ -57,6 +57,7 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .stores("CheckoutId", "data.checkoutCreate.checkout.id")
@@ -79,6 +80,7 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -87,6 +89,7 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .retry();
@@ -107,11 +110,12 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: PRODUCT_GROSS_PRICE_AFTER_PROMOTION,
           net: PRODUCT_NET_PRICE_AFTER_PROMOTION,
           tax: PRODUCT_TAX_PRICE_AFTER_PROMOTION,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
         "data.checkoutLinesUpdate.checkout.lines[0].undiscountedUnitPrice",
-        getMoney(TOTAL_NET_PRICE_BEFORE_SHIPPING),
+        getMoney(TOTAL_NET_PRICE_BEFORE_SHIPPING, CURRENCY),
       )
       .expectJson(
         "data.checkoutLinesUpdate.checkout.shippingPrice",
@@ -119,6 +123,7 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -127,6 +132,7 @@ describe("App should calculate taxes for checkout with order promotion with subt
           gross: TOTAL_GROSS_PRICE_INCLUDING_ORDER_PROMOTION,
           net: TOTAL_NET_PRICE_INCLUDING_ORDER_PROMOTION,
           tax: TOTAL_TAX_PRICE_INCLUDING_ORDER_PROMOTION,
+          currency: CURRENCY,
         }),
       )
       .retry();

--- a/apps/avatax/e2e/tests/checkout_with_entire_voucher.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_entire_voucher.spec.ts
@@ -15,7 +15,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
   const testCase = e2e(
     "Product without tax class [pricesEnteredWithTax: False], voucher [type: ENTIRE_ORDER, discountValueType: PERCENTAGE]",
   );
-
+  const CURRENCY = "USD";
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.33;
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 16.33;
@@ -61,6 +61,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .retry()
@@ -83,6 +84,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -91,6 +93,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .retry();
@@ -106,18 +109,19 @@ describe("App should calculate taxes for checkout with entire order voucher appl
         "@DATA:TEMPLATE@": "AddVoucher:USA:Percentage",
       })
       .expectJson("data.checkoutAddPromoCode.checkout.discountName", "$M{Voucher.Percentage.name}")
-      .expectJson("data.checkoutAddPromoCode.checkout.discount", getMoney(VOUCHER_AMOUNT))
+      .expectJson("data.checkoutAddPromoCode.checkout.discount", getMoney(VOUCHER_AMOUNT, CURRENCY))
       .expectJson(
         "data.checkoutAddPromoCode.checkout.lines[0].totalPrice",
         getCompleteMoney({
           gross: PRODUCT_GROSS_PRICE_AFTER_VOUCHER,
           net: PRODUCT_NET_PRICE_AFTER_VOUCHER,
           tax: PRODUCT_TAX_PRICE_AFTER_VOUCHER,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
         "data.checkoutAddPromoCode.checkout.lines[0].undiscountedTotalPrice",
-        getMoney(TOTAL_NET_PRICE_BEFORE_SHIPPING),
+        getMoney(TOTAL_NET_PRICE_BEFORE_SHIPPING, CURRENCY),
       )
       .expectJson(
         "data.checkoutAddPromoCode.checkout.shippingPrice",
@@ -125,6 +129,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
           gross: SHIPPING_GROSS_PRICE_AFTER_VOUCHER,
           net: SHIPPING_NET_PRICE_AFTER_VOUCHER,
           tax: SHIPPING_TAX_PRICE_AFTER_VOUCHER,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -133,6 +138,7 @@ describe("App should calculate taxes for checkout with entire order voucher appl
           gross: TOTAL_GROSS_PRICE_AFTER_VOUCHER,
           net: TOTAL_NET_PRICE_AFTER_VOUCHER,
           tax: TOTAL_TAX_PRICE_AFTER_VOUCHER,
+          currency: CURRENCY,
         }),
       )
       .retry();

--- a/apps/avatax/e2e/tests/checkout_with_voucher_free_shipping.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_voucher_free_shipping.spec.ts
@@ -16,6 +16,7 @@ describe("App should calculate taxes for checkout with free shipping voucher app
     "Product with tax class [pricesEnteredWithTax: False], voucher [type: SHIPPING, discountValueType: PERCENTAGE]",
   );
 
+  const CURRENCY = "USD";
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.33;
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 16.33;
@@ -57,6 +58,7 @@ describe("App should calculate taxes for checkout with free shipping voucher app
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .retry()
@@ -79,6 +81,7 @@ describe("App should calculate taxes for checkout with free shipping voucher app
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -87,6 +90,7 @@ describe("App should calculate taxes for checkout with free shipping voucher app
           gross: SHIPPING_GROSS_PRICE,
           net: SHIPPING_NET_PRICE,
           tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
         }),
       )
       .retry();
@@ -105,13 +109,14 @@ describe("App should calculate taxes for checkout with free shipping voucher app
         "data.checkoutAddPromoCode.checkout.discountName",
         "$M{Voucher.FreeShipping.name}",
       )
-      .expectJson("data.checkoutAddPromoCode.checkout.discount", getMoney(VOUCHER_AMOUNT))
+      .expectJson("data.checkoutAddPromoCode.checkout.discount", getMoney(VOUCHER_AMOUNT, CURRENCY))
       .expectJson(
         "data.checkoutAddPromoCode.checkout.shippingPrice",
         getCompleteMoney({
           gross: SHIPPING_GROSS_PRICE_AFTER_VOUCHER,
           net: SHIPPING_NET_PRICE_AFTER_VOUCHER,
           tax: SHIPPING_TAX_PRICE_AFTER_VOUCHER,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -120,6 +125,7 @@ describe("App should calculate taxes for checkout with free shipping voucher app
           gross: TOTAL_GROSS_PRICE_AFTER_VOUCHER,
           net: TOTAL_NET_PRICE_AFTER_VOUCHER,
           tax: TOTAL_TAX_PRICE_AFTER_VOUCHER,
+          currency: CURRENCY,
         }),
       )
       .retry();

--- a/apps/avatax/e2e/tests/draft_order_basic.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_basic.spec.ts
@@ -104,7 +104,7 @@ describe("App should calculate taxes for draft order with product with tax class
       .post("/graphql/")
       .withGraphQLQuery(DraftOrderUpdateAddress)
       .withGraphQLVariables({
-        "@DATA:TEMPLATE@": "DraftOrder:PricesWithTax:Address",
+        "@DATA:TEMPLATE@": "DraftOrder:Address",
         "@OVERRIDES@": {
           orderId: "$S{OrderID}",
         },

--- a/apps/avatax/e2e/tests/draft_order_basic.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_basic.spec.ts
@@ -8,8 +8,6 @@ import {
   DraftOrderComplete,
   DraftOrderUpdateAddress,
   DraftOrderUpdateShippingMethod,
-  MoneyFragment,
-  OrderDetails,
   StaffUserTokenCreate,
 } from "../generated/graphql";
 import { getCompleteMoney } from "../utils/moneyUtils";

--- a/apps/avatax/e2e/tests/draft_order_basic.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_basic.spec.ts
@@ -177,24 +177,4 @@ describe("App should calculate taxes for draft order with product with tax class
       .expectStatus(200)
       .expectJson("data.draftOrderComplete.order.id", "$S{OrderID}");
   });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
-  });
 });

--- a/apps/avatax/e2e/tests/draft_order_catalog_promotion.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_catalog_promotion.spec.ts
@@ -12,28 +12,34 @@ import {
   OrderDetails,
   StaffUserTokenCreate,
 } from "../generated/graphql";
-import { getCompleteMoney } from "../utils/moneyUtils";
+import { getCompleteMoney, getMoney } from "../utils/moneyUtils";
 
-// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18382
-describe("App should calculate taxes for draft order with product with tax class TC: AVATAX_18", () => {
-  const testCase = e2e("Product with tax class [pricesEnteredWithTax: True]");
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=4846&case_id=18388
+describe("App should calculate taxes on draft order with products on catalog promotion TC: AVATAX_24", () => {
+  const testCase = e2e(
+    "Draft order with products on catalog promotion [pricesEnteredWithTax: True]",
+  );
   const staffCredentials = {
     email: process.env.E2E_USER_NAME as string,
     password: process.env.E2E_USER_PASSWORD as string,
   };
 
   const CURRENCY = "USD";
-  const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;
-  const TOTAL_NET_PRICE_BEFORE_SHIPPING = 13.78;
-  const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.22;
+  const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 328.22;
+  const TOTAL_NET_PRICE_BEFORE_SHIPPING = 301.46;
+  const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 26.76;
 
   const TOTAL_GROSS_SHIPPING_PRICE = 69.31;
   const TOTAL_NET_SHIPPING_PRICE = 63.66;
   const TOTAL_TAX_SHIPPING_PRICE = 5.65;
 
-  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 84.31;
-  const TOTAL_NET_PRICE_AFTER_SHIPPING = 77.44;
-  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 6.87;
+  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 397.53;
+  const TOTAL_NET_PRICE_AFTER_SHIPPING = 365.12;
+  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 32.41;
+
+  const UNDISCOUNTED_TOTAL_GROSS_PRICE_AFTER_SHIPPING = 414.81;
+  const UNDISCOUNTED_TOTAL_NET_PRICE_AFTER_SHIPPING = 381;
+  const UNDISCOUNTED_TOTAL_TAX_PRICE_AFTER_SHIPPING = 33.81;
 
   it("creates token for staff user", async () => {
     await testCase
@@ -53,9 +59,9 @@ describe("App should calculate taxes for draft order with product with tax class
       .stores("StaffUserToken", "data.tokenCreate.token")
       .retry();
   });
-  it("creates order with product with tax class", async () => {
+  it("creates order in channel pricesEnteredWithTax: True", async () => {
     await testCase
-      .step("Create order with product with tax class")
+      .step("Create order in channel")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(CreateDraftOrder)
@@ -77,29 +83,34 @@ describe("App should calculate taxes for draft order with product with tax class
       })
       .stores("OrderID", "data.draftOrderCreate.order.id");
   });
-  it("should create order lines as staff user", async () => {
+  it("should add lines to draft order", async () => {
     await testCase
-      .step("Create order lines as staff user")
+      .step("add prodcuts")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(CreateOrderLines)
       .withGraphQLVariables({
         orderId: "$S{OrderID}",
-        input: [{ quantity: 10, variantId: "$M{Product.Juice.variantId}" }],
+        input: [
+          {
+            quantity: 1,
+            variantId: "$M{Product.ProductOnCatalogPromotion.variantId}",
+          },
+        ],
       })
       .withHeaders({
         Authorization: "Bearer $S{StaffUserToken}",
       })
       .expectStatus(200)
-      .expectJson("data.orderLinesCreate.orderLines[0].quantity", 10)
+      .expectJson("data.orderLinesCreate.orderLines[0].quantity", 1)
       .expectJson(
-        "data.orderLinesCreate.order.total.gross.amount",
-        TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
+        "data.orderLinesCreate.order.total.gross",
+        getMoney(TOTAL_GROSS_PRICE_BEFORE_SHIPPING, CURRENCY),
       );
   });
-  it("should update order as staff user", async () => {
+  it("should update order address", async () => {
     await testCase
-      .step("Update order as staff user")
+      .step("Update addresses on draft order")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(DraftOrderUpdateAddress)
@@ -125,9 +136,9 @@ describe("App should calculate taxes for draft order with product with tax class
       );
   });
 
-  it("should update order's shipping method as staff user", async () => {
+  it("should update order's shipping method", async () => {
     await testCase
-      .step("Update shipping method as staff user")
+      .step("Add shipping method")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(DraftOrderUpdateShippingMethod)
@@ -159,6 +170,15 @@ describe("App should calculate taxes for draft order with product with tax class
           tax: TOTAL_TAX_SHIPPING_PRICE,
           currency: CURRENCY,
         }),
+      )
+      .expectJson(
+        "data.orderUpdateShipping.order.undiscountedTotal",
+        getCompleteMoney({
+          gross: UNDISCOUNTED_TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: UNDISCOUNTED_TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: UNDISCOUNTED_TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
+        }),
       );
   });
 
@@ -176,25 +196,5 @@ describe("App should calculate taxes for draft order with product with tax class
       })
       .expectStatus(200)
       .expectJson("data.draftOrderComplete.order.id", "$S{OrderID}");
-  });
-
-  it("should have metadata with 'avataxId' key", async () => {
-    await testCase
-      .step("Check if order has metadata with 'avataxId' key")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(OrderDetails)
-      .withGraphQLVariables({
-        id: "$S{OrderID}",
-      })
-      .withHeaders({
-        Authorization: "Bearer $S{StaffUserToken}",
-      })
-      .expectStatus(200)
-      .expectJsonLike("data.order.metadata[key=avataxId]", {
-        key: "avataxId",
-        value: "typeof $V === 'string'",
-      })
-      .retry(4, 2000);
   });
 });

--- a/apps/avatax/e2e/tests/draft_order_catalog_promotion.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_catalog_promotion.spec.ts
@@ -115,7 +115,7 @@ describe("App should calculate taxes on draft order with products on catalog pro
       .post("/graphql/")
       .withGraphQLQuery(DraftOrderUpdateAddress)
       .withGraphQLVariables({
-        "@DATA:TEMPLATE@": "DraftOrder:PricesWithTax:Address",
+        "@DATA:TEMPLATE@": "DraftOrder:Address",
         "@OVERRIDES@": {
           orderId: "$S{OrderID}",
         },

--- a/apps/avatax/e2e/tests/draft_order_with_entire_voucher.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_entire_voucher.spec.ts
@@ -15,7 +15,7 @@ import { getCompleteMoney } from "../utils/moneyUtils";
 
 // Testmo: https://saleor.testmo.net/repositories/6?group_id=4846&case_id=18392
 describe("App should calculate taxes on draft order with entire order voucher applied TC: AVATAX_28", () => {
-  const testCase = e2e("Draft order with voucher entire order [pricesEnteredWithTax: True]");
+  const testCase = e2e("Draft order with voucher entire order [pricesEnteredWithTax: False]");
   const staffCredentials = {
     email: process.env.E2E_USER_NAME as string,
     password: process.env.E2E_USER_PASSWORD as string,
@@ -27,9 +27,9 @@ describe("App should calculate taxes on draft order with entire order voucher ap
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 30;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 2.66;
 
-  const TOTAL_GROSS_SHIPPING_PRICE = 75.46;
-  const TOTAL_NET_SHIPPING_PRICE = 69.31;
-  const TOTAL_TAX_SHIPPING_PRICE = 6.15;
+  const SHIPPING_GROSS_PRICE = 75.46;
+  const SHIPPING_NET_PRICE = 69.31;
+  const SHIPPING_TAX_PRICE = 6.15;
 
   const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 108.12;
   const TOTAL_NET_PRICE_AFTER_SHIPPING = 99.31;
@@ -39,9 +39,9 @@ describe("App should calculate taxes on draft order with entire order voucher ap
   const TOTAL_NET_PRICE_AFTER_SHIPPING_AFTER_VOUCHER = 94.81;
   const TOTAL_TAX_PRICE_AFTER_SHIPPING_AFTER_VOUCHER = 8.41;
 
-  const TOTAL_GROSS_SHIPPING_PRICE_AFTER_VOUCHER = 75.45;
-  const TOTAL_NET_SHIPPING_PRICE_AFTER_VOUCHER = 69.31;
-  const TOTAL_TAX_SHIPPING_PRICE_AFTER_VOUCHER = 6.14;
+  const SHIPPING_GROSS_PRICE_AFTER_VOUCHER = 75.45;
+  const SHIPPING_NET_PRICE_AFTER_VOUCHER = 69.31;
+  const SHIPPING_TAX_PRICE_AFTER_VOUCHER = 6.14;
 
   it("creates token for staff user", async () => {
     await testCase
@@ -61,7 +61,7 @@ describe("App should calculate taxes on draft order with entire order voucher ap
       .stores("StaffUserToken", "data.tokenCreate.token")
       .retry();
   });
-  it("creates order in channel pricesEnteredWithTax: True", async () => {
+  it("creates order in channel pricesEnteredWithTax: False", async () => {
     await testCase
       .step("Create order in channel")
       .spec()
@@ -162,9 +162,9 @@ describe("App should calculate taxes on draft order with entire order voucher ap
       .expectJson(
         "data.orderUpdateShipping.order.shippingPrice",
         getCompleteMoney({
-          gross: TOTAL_GROSS_SHIPPING_PRICE,
-          net: TOTAL_NET_SHIPPING_PRICE,
-          tax: TOTAL_TAX_SHIPPING_PRICE,
+          gross: SHIPPING_GROSS_PRICE,
+          net: SHIPPING_NET_PRICE,
+          tax: SHIPPING_TAX_PRICE,
           currency: CURRENCY,
         }),
       );
@@ -199,9 +199,9 @@ describe("App should calculate taxes on draft order with entire order voucher ap
       .expectJson(
         "data.draftOrderUpdate.order.shippingPrice",
         getCompleteMoney({
-          gross: TOTAL_GROSS_SHIPPING_PRICE_AFTER_VOUCHER,
-          net: TOTAL_NET_SHIPPING_PRICE_AFTER_VOUCHER,
-          tax: TOTAL_TAX_SHIPPING_PRICE_AFTER_VOUCHER,
+          gross: SHIPPING_GROSS_PRICE_AFTER_VOUCHER,
+          net: SHIPPING_NET_PRICE_AFTER_VOUCHER,
+          tax: SHIPPING_TAX_PRICE_AFTER_VOUCHER,
           currency: CURRENCY,
         }),
       )

--- a/apps/avatax/e2e/tests/draft_order_with_entire_voucher.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_entire_voucher.spec.ts
@@ -213,7 +213,8 @@ describe("App should calculate taxes on draft order with entire order voucher ap
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
           currency: CURRENCY,
         }),
-      );
+      )
+      .expectJson("data.draftOrderUpdate.order.discounts[0].type", "VOUCHER");
   });
   it("should complete draft order", async () => {
     await testCase

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -132,7 +132,6 @@ describe("App should calculate taxes for draft order with manual total discount 
         }),
       );
   });
-
   it("should update order's shipping method as staff user", async () => {
     await testCase
       .step("Update shipping method as staff user")
@@ -169,7 +168,6 @@ describe("App should calculate taxes for draft order with manual total discount 
         }),
       );
   });
-
   it("should add manual discount for total as staff user", async () => {
     await testCase
       .step("add manual discount to draft order")
@@ -206,7 +204,8 @@ describe("App should calculate taxes for draft order with manual total discount 
           tax: TOTAL_TAX_SHIPPING_PRICE_AFTER_DISCOUNT,
           currency: CURRENCY,
         }),
-      );
+      )
+      .expectJson("data.orderDiscountAdd.order.discounts[0].type", "MANUAL");
   });
   it("should complete draft order", async () => {
     await testCase

--- a/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_manual_total_discount.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
+import { input } from "@saleor/macaw-ui/dist/components/SearchInput/SearchInput.css";
 import { e2e } from "pactum";
 import { describe, it } from "vitest";
 
@@ -20,6 +21,8 @@ describe("App should calculate taxes for draft order with manual total discount 
     email: process.env.E2E_USER_NAME as string,
     password: process.env.E2E_USER_PASSWORD as string,
   };
+
+  const CURRENCY = "USD";
 
   const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 13.78;
@@ -91,7 +94,7 @@ describe("App should calculate taxes for draft order with manual total discount 
       .withGraphQLQuery(CreateOrderLines)
       .withGraphQLVariables({
         orderId: "$S{OrderID}",
-        variantId: "$M{Product.Juice.variantId}",
+        input: [{ quantity: 10, variantId: "$M{Product.Juice.variantId}" }],
       })
       .withHeaders({
         Authorization: "Bearer $S{StaffUserToken}",
@@ -126,6 +129,7 @@ describe("App should calculate taxes for draft order with manual total discount 
           gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
           net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
           tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
         }),
       );
   });
@@ -153,6 +157,7 @@ describe("App should calculate taxes for draft order with manual total discount 
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -161,6 +166,7 @@ describe("App should calculate taxes for draft order with manual total discount 
           gross: TOTAL_GROSS_SHIPPING_PRICE,
           net: TOTAL_NET_SHIPPING_PRICE,
           tax: TOTAL_TAX_SHIPPING_PRICE,
+          currency: CURRENCY,
         }),
       );
   });
@@ -190,6 +196,7 @@ describe("App should calculate taxes for draft order with manual total discount 
           gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
           net: TOTAL_NET_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
           tax: TOTAL_TAX_PRICE_AFTER_SHIPPING_AFTER_DISCOUNT,
+          currency: CURRENCY,
         }),
       )
       .expectJson(
@@ -198,6 +205,7 @@ describe("App should calculate taxes for draft order with manual total discount 
           gross: TOTAL_GROSS_SHIPPING_PRICE_AFTER_DISCOUNT,
           net: TOTAL_NET_SHIPPING_PRICE_AFTER_DISCOUNT,
           tax: TOTAL_TAX_SHIPPING_PRICE_AFTER_DISCOUNT,
+          currency: CURRENCY,
         }),
       );
   });

--- a/apps/avatax/e2e/tests/draft_order_with_order_promotion_subtotal.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_order_promotion_subtotal.spec.ts
@@ -240,7 +240,8 @@ describe("App should calculate taxes on draft order when order promotion is appl
           tax: UNDISCOUNTE_TOTAL_TAX_PRICE,
           currency: CURRENCY,
         }),
-      );
+      )
+      .expectJson("data.orderLineUpdate.order.discounts[0].type", "ORDER_PROMOTION");
   });
 
   it("should complete draft order", async () => {

--- a/apps/avatax/e2e/utils/moneyUtils.ts
+++ b/apps/avatax/e2e/utils/moneyUtils.ts
@@ -1,11 +1,9 @@
 import { MoneyFragment } from "../generated/graphql";
 
-const CURRENCY = "USD";
-
-export const getMoney = (amount: number): MoneyFragment => {
+export const getMoney = (amount: number, currency: string): MoneyFragment => {
   return {
     amount,
-    currency: CURRENCY,
+    currency,
   };
 };
 
@@ -13,12 +11,14 @@ export const getCompleteMoney = ({
   gross,
   net,
   tax,
+  currency,
 }: {
   gross: number;
   net: number;
   tax: number;
+  currency: string;
 }) => ({
-  gross: getMoney(gross),
-  net: getMoney(net),
-  tax: getMoney(tax),
+  gross: getMoney(gross, currency),
+  net: getMoney(net, currency),
+  tax: getMoney(tax, currency),
 });


### PR DESCRIPTION
## Scope of the PR

Add new e2e for discounts on draft orders:
- draft order with products on catalog discount [AVATAX_24](https://saleor.testmo.net/repositories/6?group_id=4846&sort_column=repository_cases:custom_automated&sort_direction=asc&case_id=18388)
- draft order with voucher [AVATAX_28](https://saleor.testmo.net/repositories/6?group_id=4846&sort_column=repository_cases:custom_automated&sort_direction=asc&case_id=18392)
- draft order with order promotion [AVATAX_32](https://saleor.testmo.net/repositories/6?group_id=4846&sort_column=repository_cases:custom_automated&sort_direction=asc&case_id=24175)

Remove the check for metadata since it's flaky

<!-- Describe briefly changed made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
