### PR TITLE
[E2E] Add tests for metadata, digital checkout, and checkout with click and collect

### DIFF
--- a/apps/avatax/e2e/data/maps/channel.json
+++ b/apps/avatax/e2e/data/maps/channel.json
@@ -10,6 +10,7 @@
       "id": "Q2hhbm5lbDozNg==",
       "slug": "channel-us-with-tax",
       "deliveryMethodId": "U2hpcHBpbmdNZXRob2Q6MTY=",
+      "warehouseId": "V2FyZWhvdXNlOjJjYjY1NTk2LTRiOTEtNGRkYS1iMWY4LTA3ZjczOTFiNGMxZA==",
       "currency": "USD"
     }
   }

--- a/apps/avatax/e2e/data/maps/product.json
+++ b/apps/avatax/e2e/data/maps/product.json
@@ -19,6 +19,11 @@
       "variantId": "UHJvZHVjdFZhcmlhbnQ6MzM1",
       "id": "UHJvZHVjdDoxMjk=",
       "name": "Dash Force"
+    },
+    "DigitalProduct": {
+      "variantId": "UHJvZHVjdFZhcmlhbnQ6NDAx",
+      "id": "UHJvZHVjdDoxNjQ=",
+      "name": "Gift card 50"
     }
   }
 }

--- a/apps/avatax/e2e/data/templates/order.json
+++ b/apps/avatax/e2e/data/templates/order.json
@@ -1,6 +1,8 @@
 {
   "DraftOrder:PricesWithTax": {
-    "channelID": "$M{Channel.PricesWithTax.id}"
+    "input": {
+      "channelId": "$M{Channel.PricesWithTax.id}"
+    }
   },
   "DraftOrder:Address": {
     "billingAddress": "$M{Address.NewYork}",
@@ -11,12 +13,28 @@
     "deliveryMethodId": "$M{Channel.PricesWithTax.deliveryMethodId}"
   },
   "DraftOrder:PricesWithoutTax": {
-    "channelID": "$M{Channel.USA.id}"
+    "input": {
+      "channelId": "$M{Channel.USA.id}"
+    }
   },
   "DraftOrder:PricesWithoutTax:ShippingMethod": {
     "deliveryMethodId": "$M{Channel.USA.deliveryMethodId}"
   },
   "DraftOrder:VoucherCode": {
     "voucherCode": "$M{Voucher.Percentage.code}"
+  },
+  "DraftOrder:LinesAndAddresses": {
+    "input": {
+      "channelId": "$M{Channel.PricesWithTax.id}",
+      "billingAddress": "$M{Address.NewYork}",
+      "shippingAddress": "$M{Address.NewYork}",
+      "userEmail": "$F{UserEmail}",
+      "lines": [
+        {
+          "variantId": "$M{Product.Juice.variantId}",
+          "quantity": 10
+        }
+      ]
+    }
   }
 }

--- a/apps/avatax/e2e/data/templates/updateDeliveryMethod.json
+++ b/apps/avatax/e2e/data/templates/updateDeliveryMethod.json
@@ -2,5 +2,9 @@
   "UpdateDeliveryMethod:USA": {
     "deliveryMethodId": "$M{Channel.USA.deliveryMethodId}",
     "checkoutId": "$S{CheckoutId}"
+  },
+  "UpdateDeliveryMethod:PricesWithTax": {
+    "deliveryMethodId": "$M{Channel.PricesWithTax.deliveryMethodId}",
+    "checkoutId": "$S{CheckoutId}"
   }
 }

--- a/apps/avatax/e2e/graphql/mutations/CreateDraftOrder.graphql
+++ b/apps/avatax/e2e/graphql/mutations/CreateDraftOrder.graphql
@@ -1,7 +1,8 @@
-mutation CreateDraftOrder($channelID: ID!) {
-  draftOrderCreate(input: { channelId: $channelID }) {
+mutation CreateDraftOrder($input: DraftOrderCreateInput!) {
+  draftOrderCreate(input: $input) {
     order {
       id
+      ...OrderDetailsFragment
     }
   }
 }

--- a/apps/avatax/e2e/graphql/mutations/UpdateMetadata.graphql
+++ b/apps/avatax/e2e/graphql/mutations/UpdateMetadata.graphql
@@ -1,0 +1,24 @@
+mutation UpdateMetadata($id: ID!, $input: [MetadataInput!]!) {
+  updateMetadata(id: $id, input: $input) {
+    errors {
+      field
+      message
+    }
+    item {
+      ... on Checkout {
+        id
+        metadata {
+          key
+          value
+        }
+      }
+      ... on Order {
+        id
+        metadata {
+          key
+          value
+        }
+      }
+    }
+  }
+}

--- a/apps/avatax/e2e/tests/checkout_with_click_and_collect.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_click_and_collect.spec.ts
@@ -1,0 +1,109 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { e2e } from "pactum";
+import { describe, it } from "vitest";
+
+import {
+  CheckoutUpdateDeliveryMethod,
+  CompleteCheckout,
+  CreateCheckout,
+} from "../generated/graphql";
+import { getCompleteMoney } from "../utils/moneyUtils";
+
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=18383
+describe("App should calculate taxes for checkout with click and collect TC: AVATAX_19", () => {
+  const testCase = e2e("Checkout with click and collect [pricesEnteredWithTax: True]");
+
+  const CURRENCY = "USD";
+  const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 300;
+  const TOTAL_NET_PRICE_BEFORE_SHIPPING = 275.55;
+  const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 24.45;
+
+  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 300;
+  const TOTAL_NET_PRICE_AFTER_SHIPPING = 283.02;
+  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 16.98;
+
+  const SHIPPING_PRICE = 0;
+
+  it("should have created a checkout", async () => {
+    await testCase
+      .step("Create checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CreateCheckout)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "Checkout:PricesWithTax",
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutCreate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
+          net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
+          tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .stores("CheckoutId", "data.checkoutCreate.checkout.id");
+  });
+
+  it("should add warehouse as delivery method", async () => {
+    await testCase
+      .step("Add delivery method")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CheckoutUpdateDeliveryMethod)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "UpdateDeliveryMethod:PricesWithTax",
+        "@OVERRIDES@": {
+          deliveryMethodId: "$M{Channel.PricesWithTax.warehouseId}",
+        },
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.shippingPrice",
+        getCompleteMoney({
+          gross: SHIPPING_PRICE,
+          net: SHIPPING_PRICE,
+          tax: SHIPPING_PRICE,
+          currency: CURRENCY,
+        }),
+      );
+  });
+
+  it("should finalize the checkout", async () => {
+    await testCase
+      .step("Complete checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CompleteCheckout)
+      .withGraphQLVariables({ checkoutId: "$S{CheckoutId}" })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutComplete.order.total",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.checkoutComplete.order.shippingPrice",
+        getCompleteMoney({
+          gross: SHIPPING_PRICE,
+          net: SHIPPING_PRICE,
+          tax: SHIPPING_PRICE,
+          currency: CURRENCY,
+        }),
+      );
+  });
+});

--- a/apps/avatax/e2e/tests/checkout_with_customer_metadata.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_customer_metadata.spec.ts
@@ -1,0 +1,159 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { e2e } from "pactum";
+import { describe, it } from "vitest";
+
+import {
+  CheckoutUpdateDeliveryMethod,
+  CompleteCheckout,
+  CreateCheckout,
+  UpdateMetadata,
+} from "../generated/graphql";
+import { getCompleteMoney } from "../utils/moneyUtils";
+
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=16247
+describe("App should exempt taxes for checkout with metadata avataxCustomerCode TC: AVATAX_15", () => {
+  const testCase = e2e("Checkout with avataxCustomerCode  [pricesEnteredWithTax: False]");
+
+  const metadata = [
+    {
+      key: "avataxCustomerCode",
+      value: "SHOPX",
+    },
+  ];
+  const CURRENCY = "USD";
+  const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 16.33;
+  const TOTAL_NET_PRICE_BEFORE_SHIPPING = 15;
+  const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.33;
+
+  const SHIPPING_GROSS_PRICE = 75.45;
+  const SHIPPING_NET_PRICE = 69.31;
+  const SHIPPING_TAX_PRICE = 6.14;
+
+  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 91.79;
+  const TOTAL_NET_PRICE_AFTER_SHIPPING = 84.31;
+  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 7.48;
+
+  it("should have created a checkout", async () => {
+    await testCase
+      .step("Create checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CreateCheckout)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "Checkout:USA",
+        "@OVERRIDES@": {
+          lines: [{ quantity: 10, variantId: "$M{Product.Juice.variantId}" }],
+          channelSlug: "$M{Channel.USA.slug}",
+        },
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutCreate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
+          net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
+          tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .stores("CheckoutId", "data.checkoutCreate.checkout.id");
+  });
+  it("should update delivery method and calculate shipping price", async () => {
+    await testCase
+      .step("Add delivery method")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CheckoutUpdateDeliveryMethod)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "UpdateDeliveryMethod:USA",
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.shippingPrice",
+        getCompleteMoney({
+          gross: SHIPPING_GROSS_PRICE,
+          net: SHIPPING_NET_PRICE,
+          tax: SHIPPING_TAX_PRICE,
+          currency: CURRENCY,
+        }),
+      );
+  });
+  it("should apply the customer metadata to the checkout", async () => {
+    await testCase
+      .step("Update checkout with customer metadata")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(UpdateMetadata)
+      .withGraphQLVariables({
+        id: "$S{CheckoutId}",
+        input: metadata,
+      })
+      .expectStatus(200)
+      .expectJson("data.updateMetadata.item.metadata", metadata);
+  });
+  it("should update checkout to recalculate taxes after applying the metadata", async () => {
+    await testCase
+      .step("Update shipping method to recalculate taxes")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CheckoutUpdateDeliveryMethod)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "UpdateDeliveryMethod:USA",
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.checkoutDeliveryMethodUpdate.checkout.shippingPrice",
+        getCompleteMoney({
+          gross: SHIPPING_NET_PRICE,
+          net: SHIPPING_NET_PRICE,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      );
+  });
+  it("should finalize the checkout", async () => {
+    await testCase
+      .step("Complete checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CompleteCheckout)
+      .withGraphQLVariables({ checkoutId: "$S{CheckoutId}" })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutComplete.order.total",
+        getCompleteMoney({
+          gross: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.checkoutComplete.order.shippingPrice",
+        getCompleteMoney({
+          gross: SHIPPING_NET_PRICE,
+          net: SHIPPING_NET_PRICE,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      );
+  });
+});

--- a/apps/avatax/e2e/tests/checkout_with_digital_products.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_digital_products.spec.ts
@@ -1,0 +1,96 @@
+import { e2e } from "pactum";
+import { string } from "pactum-matchers";
+import { describe, it } from "vitest";
+
+import {
+  CheckoutAddBilling,
+  CompleteCheckout,
+  CreateCheckoutNoAddress,
+} from "../generated/graphql";
+import { getCompleteMoney } from "../utils/moneyUtils";
+
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=139&case_id=16239
+describe("App should calculate taxes for checkout with digital products only TC: AVATAX_8", () => {
+  const testCase = e2e("Digitak checkout [pricesEnteredWithTax: False]");
+
+  const CURRENCY = "USD";
+  const TOTAL_GROSS_PRICE = 54.44;
+  const TOTAL_NET_PRICE = 50;
+  const TOTAL_TAX_PRICE = 4.44;
+
+  const addressVerification = {
+    city: "$M{Address.NewYork.city}",
+    streetAddress1: "$M{Address.NewYork.streetAddress1}",
+    postalCode: "$M{Address.NewYork.postalCode}",
+  };
+
+  it("should crate checkout for digital product", async () => {
+    await testCase
+      .step("Create checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CreateCheckoutNoAddress)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "Checkout:USA",
+        "@OVERRIDES@": {
+          lines: [{ quantity: 1, variantId: "$M{Product.DigitalProduct.variantId}" }],
+        },
+      })
+      .expectStatus(200)
+      .expectJson(
+        "data.checkoutCreate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_NET_PRICE,
+          net: TOTAL_NET_PRICE,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      )
+      .retry()
+      .stores("CheckoutId", "data.checkoutCreate.checkout.id");
+  });
+
+  it("should add a valid billing address", async () => {
+    await testCase
+      .step("Add billing address")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CheckoutAddBilling)
+      .withGraphQLVariables({
+        id: "$S{CheckoutId}",
+        billingAddress: "$M{Address.NewYork}",
+      })
+      .expectStatus(200)
+      .expectJsonLike(
+        "data.checkoutBillingAddressUpdate.checkout.billingAddress",
+        addressVerification,
+      )
+      .expectJson(
+        "data.checkoutBillingAddressUpdate.checkout.totalPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE,
+          net: TOTAL_NET_PRICE,
+          tax: TOTAL_TAX_PRICE,
+          currency: CURRENCY,
+        }),
+      );
+  });
+
+  it("checkout should be able to complete", async () => {
+    await testCase
+      .step("Complete checkout")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CompleteCheckout)
+      .withGraphQLVariables({ checkoutId: "$S{CheckoutId}" })
+      .expectJsonMatch({
+        data: {
+          checkoutComplete: {
+            order: {
+              id: string(),
+            },
+          },
+        },
+      });
+  });
+});

--- a/apps/avatax/e2e/tests/draft_order_with_entity_code.spec.ts
+++ b/apps/avatax/e2e/tests/draft_order_with_entity_code.spec.ts
@@ -1,0 +1,195 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { e2e } from "pactum";
+import { describe, it } from "vitest";
+
+import {
+  CreateDraftOrder,
+  DraftOrderComplete,
+  DraftOrderUpdateShippingMethod,
+  StaffUserTokenCreate,
+  UpdateMetadata,
+} from "../generated/graphql";
+import { getCompleteMoney } from "../utils/moneyUtils";
+
+// Testmo: https://saleor.testmo.net/repositories/6?group_id=4846&case_id=24363
+describe("App should exempt taxes on draft order with metadata avataxEntityCode TC: AVATAX_36", () => {
+  const testCase = e2e("draft order with avataxEntityCode [pricesEnteredWithTax: True]");
+  const staffCredentials = {
+    email: process.env.E2E_USER_NAME as string,
+    password: process.env.E2E_USER_PASSWORD as string,
+  };
+
+  const metadata = [
+    {
+      key: "avataxEntityCode",
+      value: "A",
+    },
+  ];
+  const CURRENCY = "USD";
+  const TOTAL_GROSS_PRICE_BEFORE_SHIPPING = 15;
+  const TOTAL_NET_PRICE_BEFORE_SHIPPING = 13.78;
+  const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.22;
+
+  const TOTAL_GROSS_SHIPPING_PRICE = 69.31;
+  const TOTAL_NET_SHIPPING_PRICE = 63.66;
+  const TOTAL_TAX_SHIPPING_PRICE = 5.65;
+
+  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 84.31;
+  const TOTAL_NET_PRICE_AFTER_SHIPPING = 77.44;
+  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 6.87;
+
+  it("creates token for staff user", async () => {
+    await testCase
+      .step("Create token for staff user")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(StaffUserTokenCreate)
+      .withGraphQLVariables(staffCredentials)
+      .expectStatus(200)
+      .expectJsonLike({
+        data: {
+          tokenCreate: {
+            token: "typeof $V === 'string'",
+          },
+        },
+      })
+      .stores("StaffUserToken", "data.tokenCreate.token")
+      .retry();
+  });
+  it("creates order with lines and addresses", async () => {
+    await testCase
+      .step("Create order with lines and addressess")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(CreateDraftOrder)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "DraftOrder:LinesAndAddresses",
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJsonLike({
+        data: {
+          draftOrderCreate: {
+            order: {
+              id: "typeof $V === 'string'",
+            },
+          },
+        },
+      })
+      .expectJson(
+        "data.draftOrderCreate.order.total",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_BEFORE_SHIPPING,
+          net: TOTAL_NET_PRICE_BEFORE_SHIPPING,
+          tax: TOTAL_TAX_PRICE_BEFORE_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .stores("OrderID", "data.draftOrderCreate.order.id");
+  });
+  it("should update order's shipping method as staff user", async () => {
+    await testCase
+      .step("Update shipping method as staff user")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(DraftOrderUpdateShippingMethod)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "DraftOrder:PricesWithTax:ShippingMethod",
+        "@OVERRIDES@": {
+          orderId: "$S{OrderID}",
+        },
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJson("data.orderUpdateShipping.order.id", "$S{OrderID}")
+      .expectJson(
+        "data.orderUpdateShipping.order.total",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
+          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.orderUpdateShipping.order.shippingPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_SHIPPING_PRICE,
+          net: TOTAL_NET_SHIPPING_PRICE,
+          tax: TOTAL_TAX_SHIPPING_PRICE,
+          currency: CURRENCY,
+        }),
+      );
+  });
+  it("should apply the entity code metadata to the draft order", async () => {
+    await testCase
+      .step("Update draft order metadata")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(UpdateMetadata)
+      .withGraphQLVariables({
+        id: "$S{OrderID}",
+        input: metadata,
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJson("data.updateMetadata.item.metadata", metadata);
+  });
+  it("should update order to recalculate taxes after applying the metadata", async () => {
+    await testCase
+      .step("Update shipping method to recalculate taxes")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(DraftOrderUpdateShippingMethod)
+      .withGraphQLVariables({
+        "@DATA:TEMPLATE@": "DraftOrder:PricesWithTax:ShippingMethod",
+        "@OVERRIDES@": {
+          orderId: "$S{OrderID}",
+        },
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJson("data.orderUpdateShipping.order.id", "$S{OrderID}")
+      .expectJson(
+        "data.orderUpdateShipping.order.total",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          net: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      )
+      .expectJson(
+        "data.orderUpdateShipping.order.shippingPrice",
+        getCompleteMoney({
+          gross: TOTAL_GROSS_SHIPPING_PRICE,
+          net: TOTAL_GROSS_SHIPPING_PRICE,
+          tax: 0,
+          currency: CURRENCY,
+        }),
+      );
+  });
+  it("should complete draft order", async () => {
+    await testCase
+      .step("Complete draft order")
+      .spec()
+      .post("/graphql/")
+      .withGraphQLQuery(DraftOrderComplete)
+      .withGraphQLVariables({
+        id: "$S{OrderID}",
+      })
+      .withHeaders({
+        Authorization: "Bearer $S{StaffUserToken}",
+      })
+      .expectStatus(200)
+      .expectJson("data.draftOrderComplete.order.id", "$S{OrderID}");
+  });
+});


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Add new e2e:
- complete checkout with metadata avataxCustomerCode [AVATAX_15](https://saleor.testmo.net/repositories/6?group_id=139&case_id=16247)
- complete draft order with metadata avataxEntityCode [AVATAX_36](https://saleor.testmo.net/repositories/6?group_id=4846&case_id=24363)
- complete checkout with click and collect (warehouse) - shipping address changed to warehouse address [AVATAX_19](https://saleor.testmo.net/repositories/6?group_id=139&case_id=18383)
- complete checkout with digital-only products - only billing address needed [AVATAX_8](https://saleor.testmo.net/repositories/6?group_id=139&case_id=16239)

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
