### PR TITLE
Fix vercel transport OTEL attrs

### DIFF
--- a/.changeset/weak-crabs-melt.md
+++ b/.changeset/weak-crabs-melt.md
@@ -1,0 +1,10 @@
+---
+"@saleor/apps-logger": patch
+---
+
+Added missing OTEL attributes to `loggerVercelTransport`. They will be visible under `otel` key in log collection service.
+
+Attributes:
+* `span_id`
+* `trace_id`
+* `timestamp`

--- a/packages/logger/src/logger-vercel-transport.ts
+++ b/packages/logger/src/logger-vercel-transport.ts
@@ -1,3 +1,4 @@
+import { trace } from "@opentelemetry/api";
 import * as Sentry from "@sentry/nextjs";
 import { ILogObj, Logger } from "tslog";
 
@@ -20,6 +21,11 @@ export const attachLoggerVercelTransport = (
         ...(loggerContext?.getRawContext() ?? {}),
         deployment: {
           environment: process.env.ENV,
+        },
+        otel: {
+          span_id: trace.getActiveSpan()?.spanContext().spanId,
+          trace_id: trace.getActiveSpan()?.spanContext().traceId,
+          timestamp: _meta.date.getTime(),
         },
         "commit-sha": process.env.VERCEL_GIT_COMMIT_SHA,
         service: {


### PR DESCRIPTION
## Scope of the PR

Added missing OTEL attributes to `loggerVercelTransport`. They will be visible under `otel` key in log collection service.

Attributes:
* `span_id`
* `trace_id`
* `timestamp`

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
