### PR TITLE
Refactor logger

### DIFF
--- a/.changeset/healthy-pianos-marry.md
+++ b/.changeset/healthy-pianos-marry.md
@@ -1,0 +1,10 @@
+---
+"products-feed": patch
+"klaviyo": patch
+"app-avatax": patch
+"cms-v2": patch
+"search": patch
+"smtp": patch
+---
+
+Use new way of creating logger from `@saleor/apps-logger`

--- a/.changeset/violet-candles-hide.md
+++ b/.changeset/violet-candles-hide.md
@@ -1,0 +1,5 @@
+---
+"@saleor/apps-logger": minor
+---
+
+Renamed exported `logger` to `rootLogger` so we avoid collision of names when using `logger` in monorepo. Also `createLogger` function has been removed in favour of app defining it in their codebase.

--- a/apps/avatax/scripts/migration-logger.ts
+++ b/apps/avatax/scripts/migration-logger.ts
@@ -1,16 +1,22 @@
 // eslint-disable-next-line no-restricted-imports
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
 import { attachLoggerOtelTransport } from "@saleor/apps-logger/node";
 
 import packageJson from "../package.json";
 import { loggerContext } from "../src/logger-context";
 
-logger.settings.maskValuesOfKeys = ["username", "password", "token"];
+rootLogger.settings.maskValuesOfKeys = ["username", "password", "token"];
 
 if (process.env.ENABLE_MIGRATION_CONSOLE_LOGGER === "true") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
-attachLoggerOtelTransport(logger, packageJson.version, loggerContext);
+attachLoggerOtelTransport(rootLogger, packageJson.version, loggerContext);
 
-export { createLogger, logger };
+export const createMigrationScriptLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/avatax/scripts/run-webhooks-migration.ts
+++ b/apps/avatax/scripts/run-webhooks-migration.ts
@@ -6,7 +6,7 @@ import { WebhookMigrationRunner } from "@saleor/webhook-utils";
 import { createInstrumentedGraphqlClient } from "../src/lib/create-instrumented-graphql-client";
 import { loggerContext } from "../src/logger-context";
 import { appWebhooks } from "../webhooks";
-import { createLogger } from "./migration-logger";
+import { createMigrationScriptLogger } from "./migration-logger";
 
 const requiredEnvs = ["REST_APL_TOKEN", "REST_APL_ENDPOINT"];
 
@@ -17,7 +17,7 @@ if (process.env.OTEL_ENABLED === "true" && process.env.OTEL_SERVICE_NAME) {
   otelSdk.start();
 }
 
-const logger = createLogger("RunWebhooksMigration");
+const logger = createMigrationScriptLogger("RunWebhooksMigration");
 
 const runMigrations = async () => {
   if (!requiredEnvs.every((env) => process.env[env])) {

--- a/apps/avatax/src/lib/app-configuration-logger.ts
+++ b/apps/avatax/src/lib/app-configuration-logger.ts
@@ -1,10 +1,10 @@
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/lib/observability-attributes";
 
-import { logger } from "../logger";
+import { createLogger } from "../logger";
 import { AppConfig } from "./app-config";
 
 export class AppConfigurationLogger {
-  constructor(private injectedLogger: Pick<typeof logger, "info" | "warn">) {}
+  constructor(private injectedLogger: Pick<ReturnType<typeof createLogger>, "info" | "warn">) {}
 
   logConfiguration(configuration: AppConfig, channelSlug: string) {
     const config = configuration.getConfigForChannelSlug(channelSlug);

--- a/apps/avatax/src/lib/error-utils.ts
+++ b/apps/avatax/src/lib/error-utils.ts
@@ -1,8 +1,9 @@
 import { TRPCClientError } from "@trpc/client";
 import { GraphQLError } from "graphql";
 
+import { createLogger } from "@/logger";
+
 import { BaseError } from "../error";
-import { logger } from "../logger";
 import { CalculateTaxesPayload } from "../modules/webhooks/payloads/calculate-taxes-payload";
 import { OrderCancelledPayload } from "../modules/webhooks/payloads/order-cancelled-payload";
 import { OrderConfirmedPayload } from "../modules/webhooks/payloads/order-confirmed-payload";
@@ -21,7 +22,7 @@ export class SubscriptionPayloadErrorChecker {
   private handledErrorPath = ["event", "taxBase", "sourceObject", "user"];
 
   constructor(
-    private injectedLogger: Pick<typeof logger, "error" | "info">,
+    private injectedLogger: Pick<ReturnType<typeof createLogger>, "error" | "info">,
     private injectedErrorCapture: (
       exception: InstanceType<typeof SubscriptionPayloadErrorChecker.SubscriptionPayloadError>,
     ) => void,

--- a/apps/avatax/src/logger.ts
+++ b/apps/avatax/src/logger.ts
@@ -1,11 +1,11 @@
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
 
 import packageJson from "../package.json";
 
-logger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
+rootLogger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
@@ -15,15 +15,21 @@ if (typeof window === "undefined") {
     attachLoggerVercelTransport,
   } = require("@saleor/apps-logger/node");
 
-  attachLoggerSentryTransport(logger);
+  attachLoggerSentryTransport(rootLogger);
 
   if (process.env.NODE_ENV === "production") {
     attachLoggerVercelTransport(
-      logger,
+      rootLogger,
       packageJson.version,
       require("./logger-context").loggerContext,
     );
   }
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/cms-v2/src/logger.ts
+++ b/apps/cms-v2/src/logger.ts
@@ -1,10 +1,11 @@
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
+
 import packageJson from "../package.json";
 
-logger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
+rootLogger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
@@ -12,10 +13,16 @@ if (typeof window === "undefined") {
     async ({ attachLoggerOtelTransport, attachLoggerSentryTransport, LoggerContext }) => {
       const loggerContext = await import("./logger-context").then((m) => m.loggerContext);
 
-      attachLoggerSentryTransport(logger);
-      attachLoggerOtelTransport(logger, packageJson.version, loggerContext);
+      attachLoggerSentryTransport(rootLogger);
+      attachLoggerOtelTransport(rootLogger, packageJson.version, loggerContext);
     },
   );
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/cms-v2/src/modules/providers/contentful/contentful-client.ts
+++ b/apps/cms-v2/src/modules/providers/contentful/contentful-client.ts
@@ -1,9 +1,10 @@
+import * as Sentry from "@sentry/nextjs";
 import { ClientAPI, createClient, Environment } from "contentful-management";
-import { WebhookProductVariantFragment } from "../../../../generated/graphql";
+
+import { createLogger } from "@/logger";
 import { ContentfulProviderConfig } from "@/modules/configuration";
 
-import * as Sentry from "@sentry/nextjs";
-import { createLogger, logger } from "@/logger";
+import { WebhookProductVariantFragment } from "../../../../generated/graphql";
 
 type ConstructorOptions = {
   space: string;
@@ -30,7 +31,7 @@ export class ContentfulClient {
   private client: ContentfulApiClientChunk;
   private space: string;
 
-  private logger: typeof logger;
+  private logger: ReturnType<typeof createLogger>;
 
   constructor(opts: ConstructorOptions, clientFactory: SdkClientFactory = defaultSdkClientFactory) {
     this.space = opts.space;
@@ -276,7 +277,7 @@ export class ContentfulClient {
         return this.uploadProductVariant({ configuration, variant });
       }
     } catch (err) {
-      logger.error("Error during the upsert", { error: err });
+      this.logger.error("Error during the upsert", { error: err });
       Sentry.captureException(err);
 
       throw err;

--- a/apps/cms-v2/src/modules/providers/payloadcms/payloadcms-bulk-sync-processor.ts
+++ b/apps/cms-v2/src/modules/providers/payloadcms/payloadcms-bulk-sync-processor.ts
@@ -1,9 +1,9 @@
+import { createLogger } from "@/logger";
+import { PayloadCmsProviderConfig } from "@/modules/configuration/schemas/payloadcms-provider.schema";
+
 import { BulkImportProductFragment } from "../../../../generated/graphql";
 import { BulkSyncProcessor, BulkSyncProcessorHooks } from "../../bulk-sync/bulk-sync-processor";
-
-import { PayloadCmsProviderConfig } from "@/modules/configuration/schemas/payloadcms-provider.schema";
 import { PayloadCMSClient } from "./payloadcms-client";
-import { createLogger, logger } from "@/logger";
 
 // todo CORS or proxy
 export class PayloadCmsBulkSyncProcessor implements BulkSyncProcessor {

--- a/apps/cms-v2/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/cms-v2/src/modules/trpc/protected-client-procedure.ts
@@ -1,11 +1,13 @@
-import { verifyJWT } from "@saleor/app-sdk/verify-jwt";
-import { middleware, procedure } from "./trpc-server";
-import { TRPCError } from "@trpc/server";
 import { ProtectedHandlerError } from "@saleor/app-sdk/handlers/next";
-import { saleorApp } from "../../saleor-app";
-import { createLogger, logger as appLogger } from "@/logger";
-import { createInstrumentedGraphqlClient } from "./create-instrumented-graphql-client";
+import { verifyJWT } from "@saleor/app-sdk/verify-jwt";
 import { REQUIRED_SALEOR_PERMISSIONS } from "@saleor/apps-shared";
+import { TRPCError } from "@trpc/server";
+
+import { createLogger } from "@/logger";
+
+import { saleorApp } from "../../saleor-app";
+import { createInstrumentedGraphqlClient } from "./create-instrumented-graphql-client";
+import { middleware, procedure } from "./trpc-server";
 
 const logger = createLogger("protectedClientProcedure");
 

--- a/apps/klaviyo/src/logger.ts
+++ b/apps/klaviyo/src/logger.ts
@@ -1,10 +1,11 @@
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
+
 import packageJson from "../package.json";
 
-logger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
+rootLogger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
@@ -12,10 +13,16 @@ if (typeof window === "undefined") {
     async ({ attachLoggerOtelTransport, attachLoggerSentryTransport }) => {
       const loggerContext = await import("./logger-context").then((m) => m.loggerContext);
 
-      attachLoggerSentryTransport(logger);
-      attachLoggerOtelTransport(logger, packageJson.version, loggerContext);
+      attachLoggerSentryTransport(rootLogger);
+      attachLoggerOtelTransport(rootLogger, packageJson.version, loggerContext);
     },
   );
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/products-feed/src/logger.ts
+++ b/apps/products-feed/src/logger.ts
@@ -1,21 +1,28 @@
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
+
 import packageJson from "../package.json";
 
-logger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
+rootLogger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
   import("@saleor/apps-logger/node").then(
-    async ({ attachLoggerOtelTransport, attachLoggerSentryTransport, LoggerContext }) => {
+    async ({ attachLoggerOtelTransport, attachLoggerSentryTransport }) => {
       const loggerContext = await import("./logger-context").then((m) => m.loggerContext);
 
-      attachLoggerSentryTransport(logger);
-      attachLoggerOtelTransport(logger, packageJson.version, loggerContext);
+      attachLoggerSentryTransport(rootLogger);
+      attachLoggerOtelTransport(rootLogger, packageJson.version, loggerContext);
     },
   );
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/search/src/lib/logger.ts
+++ b/apps/search/src/lib/logger.ts
@@ -1,20 +1,27 @@
 // eslint-disable-next-line no-restricted-imports
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
+
 import packageJson from "../../package.json";
 
-logger.settings.maskValuesOfKeys = ["token", "secretKey"];
+rootLogger.settings.maskValuesOfKeys = ["token", "secretKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
   import("@saleor/apps-logger/node").then(
     ({ attachLoggerOtelTransport, attachLoggerSentryTransport }) => {
-      attachLoggerSentryTransport(logger);
-      attachLoggerOtelTransport(logger, packageJson.version);
+      attachLoggerSentryTransport(rootLogger);
+      attachLoggerOtelTransport(rootLogger, packageJson.version);
     },
   );
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/apps/smtp/src/logger.ts
+++ b/apps/smtp/src/logger.ts
@@ -1,10 +1,11 @@
-import { attachLoggerConsoleTransport, createLogger, logger } from "@saleor/apps-logger";
+import { attachLoggerConsoleTransport, rootLogger } from "@saleor/apps-logger";
+
 import packageJson from "../package.json";
 
-logger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
+rootLogger.settings.maskValuesOfKeys = ["metadata", "username", "password", "apiKey"];
 
 if (process.env.NODE_ENV !== "production") {
-  attachLoggerConsoleTransport(logger);
+  attachLoggerConsoleTransport(rootLogger);
 }
 
 if (typeof window === "undefined") {
@@ -12,10 +13,16 @@ if (typeof window === "undefined") {
     async ({ attachLoggerOtelTransport, attachLoggerSentryTransport }) => {
       const loggerContext = await import("./logger-context").then((m) => m.loggerContext);
 
-      attachLoggerSentryTransport(logger);
-      attachLoggerOtelTransport(logger, packageJson.version, loggerContext);
+      attachLoggerSentryTransport(rootLogger);
+      attachLoggerOtelTransport(rootLogger, packageJson.version, loggerContext);
     },
   );
 }
 
-export { createLogger, logger };
+export const createLogger = (name: string, params?: Record<string, unknown>) =>
+  rootLogger.getSubLogger(
+    {
+      name: name,
+    },
+    params,
+  );

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,2 +1,2 @@
-export { createLogger, logger } from "./src/logger";
 export { attachLoggerConsoleTransport } from "./src/logger-console-transport";
+export { rootLogger } from "./src/root-logger";

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -2,9 +2,9 @@ import { logs } from "@opentelemetry/api-logs";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { describe, expect, it, vi } from "vitest";
 
-import { createLogger } from "./logger";
 import { attachLoggerConsoleTransport } from "./logger-console-transport";
 import { attachLoggerOtelTransport } from "./logger-otel-transport";
+import { rootLogger } from "./root-logger";
 
 vi.spyOn(console, "log");
 vi.setSystemTime(new Date(2024, 1, 1, 5, 15));
@@ -12,12 +12,15 @@ vi.setSystemTime(new Date(2024, 1, 1, 5, 15));
 describe("Logger", () => {
   describe("Console Transport", () => {
     it("Prints message and nested object to the console, including attributes passed from the parent scope", () => {
-      const logger = createLogger("Test Logger", {
-        rootScopePrimitiveArg: 1,
-        rootScopeObjectArg: {
-          objectKey: "objectValue",
+      const logger = rootLogger.getSubLogger(
+        { name: "Test Logger" },
+        {
+          rootScopePrimitiveArg: 1,
+          rootScopeObjectArg: {
+            objectKey: "objectValue",
+          },
         },
-      });
+      );
 
       attachLoggerConsoleTransport(logger);
 
@@ -46,12 +49,15 @@ describe("Logger", () => {
 
   describe("Otel Transport", () => {
     it("Calls Open Telemetry logger emit() function, passing there required attributes", () => {
-      const logger = createLogger("Test Logger", {
-        rootScopePrimitiveArg: 1,
-        rootScopeObjectArg: {
-          objectKey: "objectValue",
+      const logger = rootLogger.getSubLogger(
+        { name: "Test Logger" },
+        {
+          rootScopePrimitiveArg: 1,
+          rootScopeObjectArg: {
+            objectKey: "objectValue",
+          },
         },
-      });
+      );
 
       const mockOtelEmit = vi.fn();
 
@@ -96,15 +102,17 @@ describe("Logger", () => {
     });
 
     it("Calls Open Telemetry logger emit() function, passing there error attribute", () => {
-      expect.assertions(3);
-
-      const logger = createLogger("Test Logger", {
-        rootScopePrimitiveArg: 1,
-        rootScopeObjectArg: {
-          objectKey: "objectValue",
+      const logger = rootLogger.getSubLogger(
+        { name: "Test Logger" },
+        {
+          rootScopePrimitiveArg: 1,
+          rootScopeObjectArg: {
+            objectKey: "objectValue",
+          },
         },
-        error: new Error("Error Message"),
-      });
+      );
+
+      expect.assertions(3);
 
       const mockOtelEmit = vi.fn().mockImplementation((log) => {
         const error = log.attributes.error;

--- a/packages/logger/src/root-logger.test.ts
+++ b/packages/logger/src/root-logger.test.ts
@@ -109,6 +109,7 @@ describe("Logger", () => {
           rootScopeObjectArg: {
             objectKey: "objectValue",
           },
+          error: new Error("Error Message"),
         },
       );
 

--- a/packages/logger/src/root-logger.ts
+++ b/packages/logger/src/root-logger.ts
@@ -28,7 +28,7 @@ function getMinLevel() {
 /*
  * TODO: Add test
  */
-export const logger = new Logger<ILogObj>({
+export const rootLogger = new Logger<ILogObj>({
   minLevel: getMinLevel(),
   hideLogPositionForProduction: true,
   /**
@@ -56,10 +56,12 @@ export const logger = new Logger<ILogObj>({
   },
 });
 
-export const createLogger = (name: string, params?: Record<string, unknown>) =>
-  logger.getSubLogger(
-    {
-      name: name,
-    },
-    params,
-  );
+/*
+ * export const createLogger = (name: string, params?: Record<string, unknown>) =>
+ *   logger.getSubLogger(
+ *     {
+ *       name: name,
+ *     },
+ *     params,
+ *   );
+ */

--- a/packages/logger/src/root-logger.ts
+++ b/packages/logger/src/root-logger.ts
@@ -25,9 +25,6 @@ function getMinLevel() {
   }
 }
 
-/*
- * TODO: Add test
- */
 export const rootLogger = new Logger<ILogObj>({
   minLevel: getMinLevel(),
   hideLogPositionForProduction: true,
@@ -55,13 +52,3 @@ export const rootLogger = new Logger<ILogObj>({
     },
   },
 });
-
-/*
- * export const createLogger = (name: string, params?: Record<string, unknown>) =>
- *   logger.getSubLogger(
- *     {
- *       name: name,
- *     },
- *     params,
- *   );
- */


### PR DESCRIPTION
## Scope of the PR

Renamed exported `logger` to `rootLogger` so we avoid collision of names when using `logger` in monorepo. Also `createLogger` function has been removed in favour of app defining it in their codebase.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
