### PR TITLE
Add logs when we found `isFee` from Avalara response

### DIFF
--- a/.changeset/dull-chairs-breathe.md
+++ b/.changeset/dull-chairs-breathe.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Added warning logs when Avalara returns `isFee` in product or shipping line details.

--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
   ],
   "words": [
     "avatax",
+    "avalara",
     "bruno",
     "codegen",
     "contentful",

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
@@ -48,6 +48,14 @@ export class AvataxCalculateTaxesResponseLinesTransformer {
           line.details?.map((details) => details.rate),
         );
 
+        const hasFee = line.details?.some((details) => details.isFee);
+
+        if (hasFee) {
+          this.logger.warn("Product line has a fee. App will report this fee as tax_rate", {
+            details: line.details,
+          });
+        }
+
         const lineTaxCalculated = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
           line.taxCalculated,
           new TaxBadPayloadError("line.taxCalculated is undefined"),

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-lines-transformer.ts
@@ -51,7 +51,7 @@ export class AvataxCalculateTaxesResponseLinesTransformer {
         const hasFee = line.details?.some((details) => details.isFee);
 
         if (hasFee) {
-          this.logger.warn("Product line has a fee. App will report this fee as tax_rate", {
+          this.logger.info("Product line has a fee. App will report this fee as tax_rate", {
             details: line.details,
           });
         }

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
@@ -62,6 +62,14 @@ export function transformAvataxTransactionModelIntoShipping(
     shippingLine.details?.map((details) => details.rate),
   );
 
+  const hasFee = shippingLine.details?.some((details) => details.isFee);
+
+  if (hasFee) {
+    logger.warn("Shipping line has a fee. App will report this fee as shipping_tax_rate", {
+      details: shippingLine.details,
+    });
+  }
+
   const shippingTaxCalculated = taxProviderUtils.resolveOptionalOrThrowUnexpectedError(
     shippingLine.taxCalculated,
     new TaxBadProviderResponseError("shippingLine.taxCalculated is undefined"),

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-shipping-transformer.ts
@@ -65,7 +65,7 @@ export function transformAvataxTransactionModelIntoShipping(
   const hasFee = shippingLine.details?.some((details) => details.isFee);
 
   if (hasFee) {
-    logger.warn("Shipping line has a fee. App will report this fee as shipping_tax_rate", {
+    logger.info("Shipping line has a fee. App will report this fee as shipping_tax_rate", {
       details: shippingLine.details,
     });
   }


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Added warning logs when Avalara returns `isFee` in product or shipping line details.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
