### PR TITLE
Add support for Vercel log limit

### DIFF
--- a/.changeset/rare-crews-end.md
+++ b/.changeset/rare-crews-end.md
@@ -1,0 +1,5 @@
+---
+"@saleor/apps-logger": minor
+---
+
+If Vercel runtime transport log is exceeding Vercel log limit (4kb) error to Sentry will be logged as it won't be visible in log drain.

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -17,7 +17,9 @@
     "@sentry/nextjs": "../../node_modules/@sentry/nextjs",
     "eslint-config-saleor": "workspace:*",
     "vite": "5.3.3",
-    "vitest": "1.6.0"
+    "vitest": "1.6.0",
+    "modern-errors": "7.0.1",
+    "modern-errors-serialize": "6.0.0"
   },
   "exports": {
     ".": {

--- a/packages/logger/src/errors.ts
+++ b/packages/logger/src/errors.ts
@@ -1,0 +1,8 @@
+import ModernError from "modern-errors";
+import modernErrorsSerialize from "modern-errors-serialize";
+
+export const BaseError = ModernError.subclass("BaseError", {
+  plugins: [modernErrorsSerialize],
+});
+
+export const UnknownError = BaseError.subclass("UnknownError");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1430,6 +1430,12 @@ importers:
       eslint-config-saleor:
         specifier: workspace:*
         version: link:../eslint-config-saleor
+      modern-errors:
+        specifier: 7.0.1
+        version: 7.0.1
+      modern-errors-serialize:
+        specifier: 6.0.0
+        version: 6.0.0(modern-errors@7.0.1)
       vite:
         specifier: 5.3.3
         version: 5.3.3(@types/node@20.12.3)(terser@5.18.0)


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
If Vercel runtime transport log is exceeding Vercel log limit (4kb) error to Sentry will be logged as it won't be visible in log drain.


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
