### PR TITLE
Fix order of logs attributes

### DIFF
--- a/.changeset/eighty-brooms-help.md
+++ b/.changeset/eighty-brooms-help.md
@@ -1,0 +1,5 @@
+---
+"@saleor/apps-logger": patch
+---
+
+Fix Vercel runtime transport logs attribute order - attributes from logs context will be first so log attributes can override them.

--- a/packages/logger/src/logger-vercel-runtime-transport.ts
+++ b/packages/logger/src/logger-vercel-runtime-transport.ts
@@ -26,8 +26,8 @@ export const attachLoggerVercelRuntimeTransport = (
 
       const stringifiedMessage = JSON.stringify({
         message: bodyMessage,
-        ...attributes,
         ...(loggerContext?.getRawContext() ?? {}),
+        ...attributes,
         deployment: {
           environment: process.env.ENV,
         },


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Fix Vercel runtime transport logs attribute order - attributes from logs context will be first so log attributes can override them.


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
