### PR TITLE
Cache TRPC query for logs & implement logs pagination

### DIFF
--- a/.changeset/honest-sheep-happen.md
+++ b/.changeset/honest-sheep-happen.md
@@ -3,3 +3,4 @@
 ---
 
 Implement client logs cache. Right now app will cache request for 1 day and revalidate the cache every 60 seconds.
+Added forward / backward pagination to client logs. After this change end user can browse logs that exceeds current pagination limit (first 100).

--- a/.changeset/honest-sheep-happen.md
+++ b/.changeset/honest-sheep-happen.md
@@ -1,0 +1,5 @@
+---
+"app-avatax": patch
+---
+
+Implement client logs cache. Right now app will cache request for 1 day and revalidate the cache every 60 seconds.

--- a/apps/avatax/next.config.js
+++ b/apps/avatax/next.config.js
@@ -4,8 +4,42 @@
 import withBundleAnalyzerConfig from "@next/bundle-analyzer";
 import { withSentryConfig } from "@sentry/nextjs";
 
+// cache request for 1 day (in seconds) + revalidate once 60 seconds
+const cacheValue = "private,s-maxage=60,stale-while-revalidate=86400";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/api/trpc/clientLogs.getByCheckoutOrOrderId",
+        // Keys based on https://vercel.com/docs/edge-network/headers/cache-control-headers
+        headers: [
+          {
+            key: "CDN-Cache-Control",
+            value: cacheValue,
+          },
+          {
+            key: "Cache-Control",
+            value: cacheValue,
+          },
+        ],
+      },
+      {
+        source: "/api/trpc/clientLogs.getByDate",
+        headers: [
+          {
+            key: "CDN-Cache-Control",
+            value: cacheValue,
+          },
+          {
+            key: "Cache-Control",
+            value: cacheValue,
+          },
+        ],
+      },
+    ];
+  },
   reactStrictMode: true,
   transpilePackages: [
     "@saleor/apps-otel",

--- a/apps/avatax/package.json
+++ b/apps/avatax/package.json
@@ -89,6 +89,7 @@
     "@graphql-codegen/typescript-urql": "4.0.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@next/bundle-analyzer": "14.1.4",
+    "@testing-library/react": "14.0.0",
     "@total-typescript/ts-reset": "0.6.1",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/avatax/package.json
+++ b/apps/avatax/package.json
@@ -89,7 +89,7 @@
     "@graphql-codegen/typescript-urql": "4.0.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@next/bundle-analyzer": "14.1.4",
-    "@testing-library/react": "14.0.0",
+    "@testing-library/react": "^14.0.0",
     "@total-typescript/ts-reset": "0.6.1",
     "@types/react": "18.2.5",
     "@types/react-dom": "18.2.5",

--- a/apps/avatax/src/modules/client-logs/logs-repository.test.ts
+++ b/apps/avatax/src/modules/client-logs/logs-repository.test.ts
@@ -1,7 +1,7 @@
 import { BatchWriteCommand, DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import { mockClient } from "aws-sdk-client-mock";
 import { type SavedItem } from "dynamodb-toolbox";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { ClientLog, ClientLogStoreRequest } from "@/modules/client-logs/client-log";
 
@@ -203,13 +203,14 @@ describe("LogsRepositoryDynamodb", () => {
         startDate: new Date("2023-01-01T00:00:00Z"),
         endDate: new Date("2023-01-02T00:00:00Z"),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isOk()).toBe(true);
 
-      expect(result._unsafeUnwrap()).toHaveLength(1);
+      expect(result._unsafeUnwrap().clientLogs).toHaveLength(1);
 
-      expect(result._unsafeUnwrap()[0]).toBeInstanceOf(ClientLog);
+      expect(result._unsafeUnwrap().clientLogs[0]).toBeInstanceOf(ClientLog);
     });
 
     it("should return an empty array when no items are found in the database", async () => {
@@ -230,11 +231,12 @@ describe("LogsRepositoryDynamodb", () => {
         startDate: new Date("2023-01-01T00:00:00Z"),
         endDate: new Date("2023-01-02T00:00:00Z"),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isOk()).toBe(true);
 
-      expect(result._unsafeUnwrap()).toEqual([]);
+      expect(result._unsafeUnwrap()).toStrictEqual({ clientLogs: [], lastEvaluatedKey: undefined });
     });
 
     it("should return an error when data cannot be mapped to ClientLog", async () => {
@@ -289,6 +291,7 @@ describe("LogsRepositoryDynamodb", () => {
         startDate: new Date("2023-01-01T00:00:00Z"),
         endDate: new Date("2023-01-02T00:00:00Z"),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -323,6 +326,7 @@ describe("LogsRepositoryDynamodb", () => {
         startDate: new Date("2023-01-01T00:00:00Z"),
         endDate: new Date("2023-01-02T00:00:00Z"),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -344,6 +348,7 @@ describe("LogsRepositoryDynamodb", () => {
         startDate: new Date("2023-01-01T00:00:00Z"),
         endDate: new Date("2023-01-02T00:00:00Z"),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -387,13 +392,14 @@ describe("LogsRepositoryDynamodb", () => {
         saleorApiUrl,
         checkoutOrOrderId: "test-order-id",
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isOk()).toBe(true);
 
-      expect(result._unsafeUnwrap()).toHaveLength(1);
+      expect(result._unsafeUnwrap().clientLogs).toHaveLength(1);
 
-      expect(result._unsafeUnwrap()[0]).toBeInstanceOf(ClientLog);
+      expect(result._unsafeUnwrap().clientLogs[0]).toBeInstanceOf(ClientLog);
     });
 
     it("should return an empty array when no items are found in the database", async () => {
@@ -413,11 +419,12 @@ describe("LogsRepositoryDynamodb", () => {
         saleorApiUrl,
         checkoutOrOrderId: "test-order-id",
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isOk()).toBe(true);
 
-      expect(result._unsafeUnwrap()).toEqual([]);
+      expect(result._unsafeUnwrap()).toStrictEqual({ clientLogs: [], lastEvaluatedKey: undefined });
     });
 
     it("should return an error when data cannot be mapped to ClientLog", async () => {
@@ -473,6 +480,7 @@ describe("LogsRepositoryDynamodb", () => {
         saleorApiUrl,
         checkoutOrOrderId: "test-order-id",
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -506,6 +514,7 @@ describe("LogsRepositoryDynamodb", () => {
         saleorApiUrl,
         checkoutOrOrderId: "test-order-id",
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -526,6 +535,7 @@ describe("LogsRepositoryDynamodb", () => {
         saleorApiUrl,
         checkoutOrOrderId: "test-order-id",
         appId,
+        lastEvaluatedKey: undefined,
       });
 
       expect(result.isErr()).toBe(true);
@@ -560,9 +570,13 @@ describe("LogsRepositoryMemory", () => {
         // endDate = startDate + 1h
         endDate: new Date(new Date().getTime() + 60 * 60 * 1000),
         appId,
+        lastEvaluatedKey: undefined,
       });
 
-      expect(result._unsafeUnwrap()).toEqual([testLog]);
+      expect(result._unsafeUnwrap()).toStrictEqual({
+        clientLogs: [testLog],
+        lastEvaluatedKey: undefined,
+      });
     });
   });
 
@@ -611,9 +625,13 @@ describe("LogsRepositoryMemory", () => {
         saleorApiUrl,
         appId,
         checkoutOrOrderId: "test-order-id",
+        lastEvaluatedKey: undefined,
       });
 
-      expect(result._unsafeUnwrap()).toEqual([testLog]);
+      expect(result._unsafeUnwrap()).toStrictEqual({
+        clientLogs: [testLog],
+        lastEvaluatedKey: undefined,
+      });
     });
   });
 });

--- a/apps/avatax/src/modules/client-logs/ui/format-date.ts
+++ b/apps/avatax/src/modules/client-logs/ui/format-date.ts
@@ -1,0 +1,41 @@
+/**
+ * Format date to display in logs table (e.g: 12/3/24, 11:09:56 AM)
+ */
+export const formatUserFriendlyDate = (date: Date): string => {
+  const lang = navigator.language ?? "en-GB";
+
+  return Intl.DateTimeFormat(lang, {
+    day: "numeric",
+    month: "numeric",
+    year: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+};
+
+/**
+ * Format date for format yyyy-mm-dd T hh:mm -> required by RangePicker
+ */
+export const formatDateForInput = (d: Date): string => {
+  const pad = (n: number): string => n.toString().padStart(2, "0");
+
+  const yyyy = d.getFullYear();
+  const MM = pad(d.getMonth() + 1);
+  const hh = pad(d.getHours());
+  const mm = pad(d.getMinutes());
+
+  return `${yyyy}-${MM}-${pad(d.getDate())}T${hh}:${mm}`;
+};
+
+/**
+ * Format date for ISO format with seconds & milliseconds set to 00 -> required by clientLogsRouter.getByDate.
+ * It allows us to cache the query as seconds won't change between UI changes.
+ */
+export const formatDateForQuery = (d: Date): string => {
+  d.setSeconds(0);
+
+  d.setMilliseconds(0);
+
+  return d.toISOString();
+};

--- a/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
+++ b/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
@@ -92,6 +92,18 @@ const formatDateForInput = (d: Date) => {
   return `${yyyy}-${MM}-${pad(d.getDate())}T${hh}:${mm}`;
 };
 
+/**
+ * Format date for ISO format with seconds & milliseconds set to 00 -> required by clientLogsRouter.getByDate.
+ * It allows us to cache the query as seconds won't change between UI changes.
+ */
+const formatDateForQuery = (d: Date): string => {
+  d.setSeconds(0);
+
+  d.setMilliseconds(0);
+
+  return d.toISOString();
+};
+
 const LogsByDate = () => {
   const [rangeDates, setRangeDates] = useState<{ start: Date; end: Date }>(() => {
     const now = Date.now();
@@ -109,8 +121,8 @@ const LogsByDate = () => {
     error,
     isLoading,
   } = trpcClient.clientLogs.getByDate.useQuery({
-    startDate: rangeDates.start.toISOString(),
-    endDate: rangeDates.end.toISOString(),
+    startDate: formatDateForQuery(rangeDates.start),
+    endDate: formatDateForQuery(rangeDates.end),
   });
 
   const isEmpty = !isLoading && logs && logs.length === 0;

--- a/apps/avatax/src/modules/client-logs/ui/use-client-logs-pagination.test.tsx
+++ b/apps/avatax/src/modules/client-logs/ui/use-client-logs-pagination.test.tsx
@@ -1,0 +1,54 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useClientLogsPagination } from "./use-client-logs-pagination";
+
+describe("useClientLogsPagination", () => {
+  it("should allow to go to the next evaluated key", () => {
+    const { result } = renderHook(() => useClientLogsPagination());
+
+    act(() => {
+      result.current.goToNextEvaluatedKey({ key: "value" });
+    });
+
+    expect(result.current.currentEvaluatedKey).toStrictEqual({ key: "value" });
+  });
+
+  it("should allow to go to the previous evaluated key", () => {
+    const { result } = renderHook(() => useClientLogsPagination());
+
+    act(() => {
+      result.current.goToNextEvaluatedKey({ key: "value1" });
+
+      result.current.goToNextEvaluatedKey({ key: "value2" });
+
+      result.current.goToPreviousEvaluatedKey();
+    });
+
+    expect(result.current.currentEvaluatedKey).toStrictEqual({ key: "value1" });
+  });
+
+  it("should disable previous button when there are no previous keys", () => {
+    const { result } = renderHook(() => useClientLogsPagination());
+
+    expect(result.current.isPreviousButtonDisabled()).toBe(true);
+
+    act(() => {
+      result.current.goToNextEvaluatedKey({ key: "value" });
+    });
+
+    expect(result.current.isPreviousButtonDisabled()).toBe(false);
+  });
+
+  it("should disable next button when next key is undefined", () => {
+    const { result } = renderHook(() => useClientLogsPagination());
+
+    expect(result.current.isNextButtonDisabled(undefined)).toBe(true);
+
+    act(() => {
+      result.current.goToNextEvaluatedKey({ key: "value" });
+    });
+
+    expect(result.current.isNextButtonDisabled(undefined)).toBe(true);
+  });
+});

--- a/apps/avatax/src/modules/client-logs/ui/use-client-logs-pagination.tsx
+++ b/apps/avatax/src/modules/client-logs/ui/use-client-logs-pagination.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+
+import { type LastEvaluatedKey } from "../logs-repository";
+
+export const useClientLogsPagination = (): {
+  currentEvaluatedKey: LastEvaluatedKey | undefined;
+  goToPreviousEvaluatedKey: () => void;
+  goToNextEvaluatedKey: (nextKey: LastEvaluatedKey) => void;
+  isPreviousButtonDisabled: () => boolean;
+  isNextButtonDisabled: (nextKey: LastEvaluatedKey) => boolean;
+} => {
+  const [lastEvaluatedKeys, setLastEvaluatedKeys] = useState<Array<LastEvaluatedKey>>([]);
+
+  const goToPreviousEvaluatedKey = (): void => {
+    setLastEvaluatedKeys((prev) => prev.slice(0, -1));
+  };
+
+  const goToNextEvaluatedKey = (nextKey: LastEvaluatedKey): void => {
+    setLastEvaluatedKeys((prev) => [...prev, nextKey]);
+  };
+
+  const isPreviousButtonDisabled = (): boolean => {
+    return lastEvaluatedKeys.length === 0;
+  };
+
+  const isNextButtonDisabled = (nextKey: LastEvaluatedKey): boolean => {
+    return nextKey === undefined;
+  };
+
+  return {
+    currentEvaluatedKey: lastEvaluatedKeys.at(-1),
+    goToPreviousEvaluatedKey,
+    goToNextEvaluatedKey,
+    isPreviousButtonDisabled,
+    isNextButtonDisabled,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         specifier: 14.1.4
         version: 14.1.4
       '@testing-library/react':
-        specifier: 14.0.0
+        specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@total-typescript/ts-reset':
         specifier: 0.6.1
@@ -2583,10 +2583,6 @@ packages:
     resolution: {integrity: sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==}
     engines: {node: '>=14.0.0'}
 
-  '@babel/code-frame@7.22.13':
-    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.22.5':
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
@@ -2903,10 +2899,6 @@ packages:
 
   '@babel/helpers@7.24.7':
     resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/highlight@7.22.13':
-    resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
@@ -14733,14 +14725,9 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@babel/code-frame@7.22.13':
-    dependencies:
-      '@babel/highlight': 7.24.7
-      chalk: 2.4.2
-
   '@babel/code-frame@7.22.5':
     dependencies:
-      '@babel/highlight': 7.22.13
+      '@babel/highlight': 7.24.7
 
   '@babel/code-frame@7.24.2':
     dependencies:
@@ -15355,12 +15342,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.24.7
       '@babel/types': 7.24.7
-
-  '@babel/highlight@7.22.13':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -16729,7 +16710,7 @@ snapshots:
 
   '@babel/template@7.22.5':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/parser': 7.22.16
       '@babel/types': 7.22.17
 
@@ -16777,7 +16758,7 @@ snapshots:
 
   '@babel/traverse@7.22.5':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.22.15
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: 14.1.4
         version: 14.1.4
+      '@testing-library/react':
+        specifier: 14.0.0
+        version: 14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@total-typescript/ts-reset':
         specifier: 0.6.1
         version: 0.6.1
@@ -738,7 +741,7 @@ importers:
         version: 3.3.1(react-hook-form@7.44.3(react@18.2.0))
       '@opentelemetry/api':
         specifier: ../../node_modules/@opentelemetry/api
-        version: 1.9.0
+        version: link:../../node_modules/@opentelemetry/api
       '@opentelemetry/api-logs':
         specifier: ../../node_modules/@opentelemetry/api-logs
         version: link:../../node_modules/@opentelemetry/api-logs
@@ -816,7 +819,7 @@ importers:
         version: 10.43.1(@trpc/server@10.43.1)
       '@trpc/next':
         specifier: 10.43.1
-        version: 10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/react-query@10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.43.1)(next@14.2.3(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/react-query@10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.43.1)(next@14.2.3(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/react-query':
         specifier: 10.43.1
         version: 10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -849,7 +852,7 @@ importers:
         version: 20.0.3
       next:
         specifier: 14.2.3
-        version: 14.2.3(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 14.2.3(@babel/core@7.24.7)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -2580,10 +2583,6 @@ packages:
     resolution: {integrity: sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==}
     engines: {node: '>=14.0.0'}
 
-  '@babel/code-frame@7.22.10':
-    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.22.13':
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
@@ -2908,10 +2907,6 @@ packages:
 
   '@babel/highlight@7.22.13':
     resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/highlight@7.24.2':
-    resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.7':
@@ -3695,10 +3690,6 @@ packages:
 
   '@babel/regjsgen@0.8.0':
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
-
-  '@babel/runtime@7.22.11':
-    resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.22.6':
     resolution: {integrity: sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==}
@@ -9680,10 +9671,6 @@ packages:
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
-  has-proto@1.0.1:
-    resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
-    engines: {node: '>= 0.4'}
-
   has-proto@1.0.3:
     resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
     engines: {node: '>= 0.4'}
@@ -14746,14 +14733,9 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@babel/code-frame@7.22.10':
-    dependencies:
-      '@babel/highlight': 7.22.13
-      chalk: 2.4.2
-
   '@babel/code-frame@7.22.13':
     dependencies:
-      '@babel/highlight': 7.22.13
+      '@babel/highlight': 7.24.7
       chalk: 2.4.2
 
   '@babel/code-frame@7.22.5':
@@ -14762,7 +14744,7 @@ snapshots:
 
   '@babel/code-frame@7.24.2':
     dependencies:
-      '@babel/highlight': 7.24.2
+      '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
   '@babel/code-frame@7.24.7':
@@ -14781,7 +14763,7 @@ snapshots:
   '@babel/core@7.21.8':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.21.8)
@@ -14801,7 +14783,7 @@ snapshots:
   '@babel/core@7.22.11':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-compilation-targets': 7.22.10
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.11)
@@ -14841,7 +14823,7 @@ snapshots:
   '@babel/core@7.23.3':
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.23.3
       '@babel/helper-compilation-targets': 7.22.15
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.3)
@@ -14861,7 +14843,7 @@ snapshots:
   '@babel/core@7.23.9':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
@@ -14881,7 +14863,7 @@ snapshots:
   '@babel/core@7.24.3':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.3)
@@ -15181,7 +15163,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.21.8)':
     dependencies:
@@ -15190,7 +15172,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.22.11)':
     dependencies:
@@ -15199,7 +15181,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.3)':
     dependencies:
@@ -15208,7 +15190,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
     dependencies:
@@ -15217,7 +15199,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.24.3)':
     dependencies:
@@ -15226,7 +15208,7 @@ snapshots:
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/helper-module-transforms@7.24.7(@babel/core@7.24.7)':
     dependencies:
@@ -15376,16 +15358,9 @@ snapshots:
 
   '@babel/highlight@7.22.13':
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-
-  '@babel/highlight@7.24.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-      picocolors: 1.0.1
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -16182,7 +16157,7 @@ snapshots:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.21.8)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.22.11)':
     dependencies:
@@ -16190,7 +16165,7 @@ snapshots:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.22.11)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
 
   '@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.21.8)':
     dependencies:
@@ -16734,10 +16709,6 @@ snapshots:
 
   '@babel/regjsgen@0.8.0': {}
 
-  '@babel/runtime@7.22.11':
-    dependencies:
-      regenerator-runtime: 0.14.1
-
   '@babel/runtime@7.22.6':
     dependencies:
       regenerator-runtime: 0.13.11
@@ -16752,7 +16723,7 @@ snapshots:
 
   '@babel/template@7.22.15':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/parser': 7.23.3
       '@babel/types': 7.24.0
 
@@ -16776,7 +16747,7 @@ snapshots:
 
   '@babel/traverse@7.21.5':
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
@@ -16791,7 +16762,7 @@ snapshots:
 
   '@babel/traverse@7.22.17':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-environment-visitor': 7.22.5
       '@babel/helper-function-name': 7.22.5
@@ -16821,7 +16792,7 @@ snapshots:
 
   '@babel/traverse@7.23.3':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -16836,7 +16807,7 @@ snapshots:
 
   '@babel/traverse@7.23.9':
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -16851,7 +16822,7 @@ snapshots:
 
   '@babel/traverse@7.24.1':
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       '@babel/generator': 7.24.1
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -16882,13 +16853,13 @@ snapshots:
   '@babel/types@7.21.5':
     dependencies:
       '@babel/helper-string-parser': 7.24.1
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
   '@babel/types@7.22.17':
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.15
+      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
   '@babel/types@7.22.5':
@@ -16900,7 +16871,7 @@ snapshots:
   '@babel/types@7.23.3':
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
   '@babel/types@7.24.0':
@@ -18487,7 +18458,8 @@ snapshots:
 
   '@opentelemetry/api@1.7.0': {}
 
-  '@opentelemetry/api@1.9.0': {}
+  '@opentelemetry/api@1.9.0':
+    optional: true
 
   '@opentelemetry/context-async-hooks@1.18.1(@opentelemetry/api@1.7.0)':
     dependencies:
@@ -20612,7 +20584,7 @@ snapshots:
 
   '@testing-library/dom@8.20.0':
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.25.6
       '@types/aria-query': 5.0.1
       aria-query: 5.2.1
@@ -20623,7 +20595,7 @@ snapshots:
 
   '@testing-library/dom@9.3.1':
     dependencies:
-      '@babel/code-frame': 7.22.10
+      '@babel/code-frame': 7.24.7
       '@babel/runtime': 7.25.6
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
@@ -20643,7 +20615,7 @@ snapshots:
 
   '@testing-library/react@14.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@babel/runtime': 7.22.11
+      '@babel/runtime': 7.25.6
       '@testing-library/dom': 9.3.1
       '@types/react-dom': 18.2.5
       react: 18.2.0
@@ -20684,17 +20656,6 @@ snapshots:
       '@trpc/react-query': 10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@trpc/server': 10.43.1
       next: 14.2.3(@babel/core@7.24.7)(@opentelemetry/api@node_modules+@opentelemetry+api)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-ssr-prepass: 1.5.0(react@18.2.0)
-
-  '@trpc/next@10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/react-query@10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/server@10.43.1)(next@14.2.3(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      '@tanstack/react-query': 4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@trpc/client': 10.43.1(@trpc/server@10.43.1)
-      '@trpc/react-query': 10.43.1(@tanstack/react-query@4.29.19(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@trpc/client@10.43.1(@trpc/server@10.43.1))(@trpc/server@10.43.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@trpc/server': 10.43.1
-      next: 14.2.3(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-ssr-prepass: 1.5.0(react@18.2.0)
@@ -22910,7 +22871,7 @@ snapshots:
       object-keys: 1.1.1
       object.assign: 4.1.5
       regexp.prototype.flags: 1.5.2
-      side-channel: 1.0.4
+      side-channel: 1.0.6
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
       which-typed-array: 1.1.15
@@ -24250,7 +24211,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
       has: 1.0.3
-      has-proto: 1.0.1
+      has-proto: 1.0.3
       has-symbols: 1.0.3
 
   get-intrinsic@1.2.4:
@@ -24521,8 +24482,6 @@ snapshots:
     dependencies:
       es-define-property: 1.0.0
 
-  has-proto@1.0.1: {}
-
   has-proto@1.0.3: {}
 
   has-symbols@1.0.3: {}
@@ -24784,7 +24743,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
-      side-channel: 1.0.4
+      side-channel: 1.0.6
 
   interpret@1.4.0: {}
 
@@ -26629,7 +26588,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.22.13
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -26938,7 +26897,7 @@ snapshots:
 
   qs@6.11.0:
     dependencies:
-      side-channel: 1.0.4
+      side-channel: 1.0.6
 
   qs@6.11.2:
     dependencies:


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Implemented client logs cache. Right now app will cache request for 1 day and revalidate the cache every 60 seconds.
* Added forward / backward pagination to client logs. After this change end user can browse logs that exceeds current pagination limit (first 100).

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
