### PR TITLE
Setup Segment API func memory & max duration

### DIFF
--- a/.changeset/silly-months-clean.md
+++ b/.changeset/silly-months-clean.md
@@ -1,0 +1,5 @@
+---
+"segment": patch
+---
+
+Set Vercel function memory allocation to 1024 and max duration to 15 seconds.

--- a/apps/segment/vercel.json
+++ b/apps/segment/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
     "src/pages/api/webhooks/*": {
-      "memory": 1024,
+      "memory": 256,
       "maxDuration": 15
     }
   },

--- a/apps/segment/vercel.json
+++ b/apps/segment/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "src/pages/api/webhooks/*": {
+      "memory": 1024,
+      "maxDuration": 15
+    }
+  },
   "regions": ["dub1", "iad1"]
 }


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Set Vercel function memory allocation to 1024 and max duration to 15 seconds.


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
