### PR TITLE
Fix TTL for AvaTax client logs

### DIFF
--- a/.changeset/big-chicken-play.md
+++ b/.changeset/big-chicken-play.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Fix time to live of client logs. After this change logs will be deleted after 14 days by default.

--- a/apps/avatax/src/modules/client-logs/dynamo-schema.test.ts
+++ b/apps/avatax/src/modules/client-logs/dynamo-schema.test.ts
@@ -119,10 +119,9 @@ describe("LogsTable", () => {
 
       const result = LogsTable.getDefaultTTL();
 
-      const expectedDate = new Date("2023-01-08T00:00:00Z");
-      const expected = expectedDate.getTime();
+      const expectedDateInSeconds = 1673136000; // 2023-01-08T00:00:00Z;
 
-      expect(result).toBe(expected);
+      expect(result).toBe(expectedDateInSeconds);
     });
   });
 });

--- a/apps/avatax/src/modules/client-logs/dynamo-schema.ts
+++ b/apps/avatax/src/modules/client-logs/dynamo-schema.ts
@@ -62,10 +62,11 @@ export class LogsTable extends Table<
 
   static getDefaultTTL() {
     const daysUntilExpire = env.DYNAMODB_LOGS_ITEM_TTL_IN_DAYS;
-    const today = new Date();
+    const now = new Date();
+    const expireDate = new Date(now.getTime() + daysUntilExpire * 24 * 60 * 60 * 1000);
 
-    // Add today + days until expire, export to UNIX epoch timestamp
-    return new Date(today.setDate(today.getDate() + daysUntilExpire)).getTime();
+    // Export to UNIX epoch timestamp in seconds
+    return Math.floor(expireDate.getTime() / 1000);
   }
 }
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
After this change we will send TTL as seconds instead of milliseconds.


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
