### PR TITLE
Fix e2e for AvaTax

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # TODO: https://linear.app/saleor/issue/EXT-1989
+        # Currently it says it will run on 3.19 & 3/20 but under the hood it will run on 3.19 and latest main.
         saleor: [319, 320]
     env:
       ACCESS_TOKEN: ${{ secrets.saleor-token }}

--- a/apps/avatax/e2e/tests/checkout_with_customer_metadata.spec.ts
+++ b/apps/avatax/e2e/tests/checkout_with_customer_metadata.spec.ts
@@ -25,13 +25,9 @@ describe("App should exempt taxes for checkout with metadata avataxCustomerCode 
   const TOTAL_NET_PRICE_BEFORE_SHIPPING = 15;
   const TOTAL_TAX_PRICE_BEFORE_SHIPPING = 1.33;
 
-  const SHIPPING_GROSS_PRICE = 75.45;
   const SHIPPING_NET_PRICE = 69.31;
-  const SHIPPING_TAX_PRICE = 6.14;
 
-  const TOTAL_GROSS_PRICE_AFTER_SHIPPING = 91.79;
   const TOTAL_NET_PRICE_AFTER_SHIPPING = 84.31;
-  const TOTAL_TAX_PRICE_AFTER_SHIPPING = 7.48;
 
   it("should have created a checkout", async () => {
     await testCase
@@ -58,35 +54,6 @@ describe("App should exempt taxes for checkout with metadata avataxCustomerCode 
       )
       .stores("CheckoutId", "data.checkoutCreate.checkout.id");
   });
-  it("should update delivery method and calculate shipping price", async () => {
-    await testCase
-      .step("Add delivery method")
-      .spec()
-      .post("/graphql/")
-      .withGraphQLQuery(CheckoutUpdateDeliveryMethod)
-      .withGraphQLVariables({
-        "@DATA:TEMPLATE@": "UpdateDeliveryMethod:USA",
-      })
-      .expectStatus(200)
-      .expectJson(
-        "data.checkoutDeliveryMethodUpdate.checkout.totalPrice",
-        getCompleteMoney({
-          gross: TOTAL_GROSS_PRICE_AFTER_SHIPPING,
-          net: TOTAL_NET_PRICE_AFTER_SHIPPING,
-          tax: TOTAL_TAX_PRICE_AFTER_SHIPPING,
-          currency: CURRENCY,
-        }),
-      )
-      .expectJson(
-        "data.checkoutDeliveryMethodUpdate.checkout.shippingPrice",
-        getCompleteMoney({
-          gross: SHIPPING_GROSS_PRICE,
-          net: SHIPPING_NET_PRICE,
-          tax: SHIPPING_TAX_PRICE,
-          currency: CURRENCY,
-        }),
-      );
-  });
   it("should apply the customer metadata to the checkout", async () => {
     await testCase
       .step("Update checkout with customer metadata")
@@ -100,9 +67,9 @@ describe("App should exempt taxes for checkout with metadata avataxCustomerCode 
       .expectStatus(200)
       .expectJson("data.updateMetadata.item.metadata", metadata);
   });
-  it("should update checkout to recalculate taxes after applying the metadata", async () => {
+  it("should update delivery method and calculate shipping price", async () => {
     await testCase
-      .step("Update shipping method to recalculate taxes")
+      .step("Add delivery method")
       .spec()
       .post("/graphql/")
       .withGraphQLQuery(CheckoutUpdateDeliveryMethod)

--- a/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
@@ -46,10 +46,6 @@ const handler = checkoutCalculateTaxesSyncWebhook.createHandler(async (req, res,
   try {
     const { payload, authData } = ctx;
 
-    logger.info("Received payload with taxBase", {
-      payload: payload.taxBase,
-    });
-
     subscriptionErrorChecker.checkPayload(payload);
 
     loggerContext.set(ObservabilityAttributes.CHANNEL_SLUG, ctx.payload.taxBase.channel.slug);


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
This PR fixes e2e for AvaTax to be in sync what we will recommend in docs:
* Update checkout metadata as early as possible in checkout flow as from 3.21 forcing recalculating of checkout by updating delivery method to the same that is on checkout won't trigger webhook to tax app

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
