### PR TITLE
Fix deprecated span attr for `urqlExchange`

### DIFF
--- a/.changeset/neat-cherries-check.md
+++ b/.changeset/neat-cherries-check.md
@@ -1,0 +1,5 @@
+---
+"@saleor/apps-otel": patch
+---
+
+Remove deprecated `SemanticAttributes.HTTP_URL` from `otelUrqlExchangeFactory` and use `ATTR_URL_FULL` instead

--- a/packages/otel/src/otel-urql-exchange-factory.ts
+++ b/packages/otel/src/otel-urql-exchange-factory.ts
@@ -1,5 +1,5 @@
 import { context, Span, SpanKind, SpanStatusCode, Tracer } from "@opentelemetry/api";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+import { ATTR_URL_FULL } from "@opentelemetry/semantic-conventions/incubating";
 import { type CombinedError, makeOperation, mapExchange, Operation } from "urql";
 
 type Definition = {
@@ -56,7 +56,7 @@ export const createOtelUrqlExchange = (args: { tracer: Tracer }) => {
 
       span.setAttribute("saleorApiUrl", operation.context.url);
 
-      span.setAttribute(SemanticAttributes.HTTP_URL, operation.context.url);
+      span.setAttribute(ATTR_URL_FULL, operation.context.url);
 
       addRequestHeaderAttributes(span, operation.context.fetchOptions?.headers);
       if (operation.variables) {

--- a/packages/otel/tsconfig.json
+++ b/packages/otel/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Remove deprecated `SemanticAttributes.HTTP_URL` from `otelUrqlExchangeFactory` and use `ATTR_URL_FULL` instead

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
