### PR TITLE
Add compose function

### DIFF
--- a/apps/avatax/src/logger-context.ts
+++ b/apps/avatax/src/logger-context.ts
@@ -1,6 +1,11 @@
-import { LoggerContext } from "@saleor/apps-logger/node";
+import { LoggerContext, wrapWithLoggerContext } from "@saleor/apps-logger/node";
+import { NextApiHandler } from "next";
 
 /**
  * Server-side only
  */
 export const loggerContext = new LoggerContext();
+
+export const withLoggerContext = (handler: NextApiHandler) => {
+  return wrapWithLoggerContext(handler, loggerContext);
+};

--- a/apps/avatax/src/pages/api/manifest.ts
+++ b/apps/avatax/src/pages/api/manifest.ts
@@ -1,46 +1,43 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
-import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
+import { compose } from "@saleor/apps-shared";
 
 import { env } from "@/env";
-import { loggerContext } from "@/logger-context";
+import { withLoggerContext } from "@/logger-context";
 
 import packageJson from "../../../package.json";
 import { appWebhooks } from "../../../webhooks";
 
-export default wrapWithLoggerContext(
-  wrapWithSpanAttributes(
-    createManifestHandler({
-      async manifestFactory({ appBaseUrl }) {
-        const iframeBaseUrl = env.APP_IFRAME_BASE_URL ?? appBaseUrl;
-        const apiBaseURL = env.APP_API_BASE_URL ?? appBaseUrl;
+const handler = createManifestHandler({
+  async manifestFactory({ appBaseUrl }) {
+    const iframeBaseUrl = env.APP_IFRAME_BASE_URL ?? appBaseUrl;
+    const apiBaseURL = env.APP_API_BASE_URL ?? appBaseUrl;
 
-        const manifest: AppManifest = {
-          about: "App connects with AvaTax to dynamically calculate taxes",
-          appUrl: iframeBaseUrl,
-          author: "Saleor Commerce",
-          brand: {
-            logo: {
-              default: `${apiBaseURL}/logo.png`,
-            },
-          },
-          dataPrivacyUrl: "https://saleor.io/legal/privacy/",
-          extensions: [],
-          homepageUrl: "https://github.com/saleor/apps",
-          id: env.MANIFEST_APP_ID,
-          name: "AvaTax",
-          permissions: ["HANDLE_TAXES", "MANAGE_ORDERS"],
-          requiredSaleorVersion: ">=3.19 <4",
-          supportUrl: "https://github.com/saleor/apps/discussions",
-          tokenTargetUrl: `${apiBaseURL}/api/register`,
-          version: packageJson.version,
-          webhooks: appWebhooks.map((w) => w.getWebhookManifest(apiBaseURL)),
-        };
-
-        return manifest;
+    const manifest: AppManifest = {
+      about: "App connects with AvaTax to dynamically calculate taxes",
+      appUrl: iframeBaseUrl,
+      author: "Saleor Commerce",
+      brand: {
+        logo: {
+          default: `${apiBaseURL}/logo.png`,
+        },
       },
-    }),
-  ),
-  loggerContext,
-);
+      dataPrivacyUrl: "https://saleor.io/legal/privacy/",
+      extensions: [],
+      homepageUrl: "https://github.com/saleor/apps",
+      id: env.MANIFEST_APP_ID,
+      name: "AvaTax",
+      permissions: ["HANDLE_TAXES", "MANAGE_ORDERS"],
+      requiredSaleorVersion: ">=3.19 <4",
+      supportUrl: "https://github.com/saleor/apps/discussions",
+      tokenTargetUrl: `${apiBaseURL}/api/register`,
+      version: packageJson.version,
+      webhooks: appWebhooks.map((w) => w.getWebhookManifest(apiBaseURL)),
+    };
+
+    return manifest;
+  },
+});
+
+export default compose(withLoggerContext, withSpanAttributes)(handler);

--- a/apps/avatax/src/pages/api/register.ts
+++ b/apps/avatax/src/pages/api/register.ts
@@ -1,10 +1,10 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
-import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
+import { compose } from "@saleor/apps-shared";
 
 import { env } from "@/env";
 import { createLogger } from "@/logger";
-import { loggerContext } from "@/logger-context";
+import { withLoggerContext } from "@/logger-context";
 
 import { saleorApp } from "../../../saleor-app";
 
@@ -16,32 +16,29 @@ const allowedUrlsPattern = env.ALLOWED_DOMAIN_PATTERN;
  * Required endpoint, called by Saleor to install app.
  * It will exchange tokens with app, so saleorApp.apl will contain token
  */
-export default wrapWithLoggerContext(
-  wrapWithSpanAttributes(
-    createAppRegisterHandler({
-      apl: saleorApp.apl,
-      /**
-       * Prohibit installation from Saleor other than specified by the regex.
-       * Regex source is ENV so if ENV is not set, all installations will be allowed.
-       */
-      allowedSaleorUrls: [
-        (url) => {
-          if (allowedUrlsPattern) {
-            // we don't escape the pattern because it's not user input - it's an ENV variable controlled by us
-            const regex = new RegExp(allowedUrlsPattern);
+const handler = createAppRegisterHandler({
+  apl: saleorApp.apl,
+  /**
+   * Prohibit installation from Saleor other than specified by the regex.
+   * Regex source is ENV so if ENV is not set, all installations will be allowed.
+   */
+  allowedSaleorUrls: [
+    (url) => {
+      if (allowedUrlsPattern) {
+        // we don't escape the pattern because it's not user input - it's an ENV variable controlled by us
+        const regex = new RegExp(allowedUrlsPattern);
 
-            return regex.test(url);
-          }
+        return regex.test(url);
+      }
 
-          return true;
-        },
-      ],
-      onAuthAplSaved: async (_req, context) => {
-        logger.info("AvaTax app configuration set up successfully", {
-          saleorApiUrl: context.authData.saleorApiUrl,
-        });
-      },
-    }),
-  ),
-  loggerContext,
-);
+      return true;
+    },
+  ],
+  onAuthAplSaved: async (_req, context) => {
+    logger.info("AvaTax app configuration set up successfully", {
+      saleorApiUrl: context.authData.saleorApiUrl,
+    });
+  },
+});
+
+export default compose(withLoggerContext, withSpanAttributes)(handler);

--- a/apps/avatax/src/pages/api/trpc/[trpc].ts
+++ b/apps/avatax/src/pages/api/trpc/[trpc].ts
@@ -1,32 +1,29 @@
-import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
+import { compose } from "@saleor/apps-shared";
 import * as Sentry from "@sentry/nextjs";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { createLogger } from "../../../logger";
-import { loggerContext } from "../../../logger-context";
+import { withLoggerContext } from "../../../logger-context";
 import { appRouter } from "../../../modules/trpc/trpc-app-router";
 import { createTrpcContext } from "../../../modules/trpc/trpc-context";
 
 const logger = createLogger("tRPC error");
 
-export default wrapWithLoggerContext(
-  wrapWithSpanAttributes(
-    trpcNext.createNextApiHandler({
-      /**
-       * TODO: Add middleware that verifies permissions
-       */
-      router: appRouter,
-      createContext: createTrpcContext,
-      onError: ({ path, error }) => {
-        if (error.code === "INTERNAL_SERVER_ERROR") {
-          Sentry.captureException(error);
-          logger.error(`${path} returned error:`, error);
-          return;
-        }
-        logger.debug(`${path} returned error:`, error);
-      },
-    }),
-  ),
-  loggerContext,
-);
+const handler = trpcNext.createNextApiHandler({
+  /**
+   * TODO: Add middleware that verifies permissions
+   */
+  router: appRouter,
+  createContext: createTrpcContext,
+  onError: ({ path, error }) => {
+    if (error.code === "INTERNAL_SERVER_ERROR") {
+      Sentry.captureException(error);
+      logger.error(`${path} returned error:`, error);
+      return;
+    }
+    logger.debug(`${path} returned error:`, error);
+  },
+});
+
+export default compose(withLoggerContext, withSpanAttributes)(handler);

--- a/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
+++ b/apps/avatax/src/pages/api/webhooks/checkout-calculate-taxes.ts
@@ -1,6 +1,6 @@
-import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
+import { compose } from "@saleor/apps-shared";
 import * as Sentry from "@sentry/nextjs";
 import { captureException } from "@sentry/nextjs";
 
@@ -9,7 +9,7 @@ import { AppConfigurationLogger } from "@/lib/app-configuration-logger";
 import { metadataCache, wrapWithMetadataCache } from "@/lib/app-metadata-cache";
 import { SubscriptionPayloadErrorChecker } from "@/lib/error-utils";
 import { createLogger } from "@/logger";
-import { loggerContext } from "@/logger-context";
+import { loggerContext, withLoggerContext } from "@/logger-context";
 import { AvataxCalculateTaxesPayloadLinesTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-lines-transformer";
 import { AvataxCalculateTaxesResponseTransformer } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-response-transformer";
 import { AvataxCalculateTaxesTaxCodeMatcher } from "@/modules/avatax/calculate-taxes/avatax-calculate-taxes-tax-code-matcher";
@@ -151,7 +151,4 @@ const handler = checkoutCalculateTaxesSyncWebhook.createHandler(async (req, res,
 /**
  * TODO: Add tests to handler
  */
-export default wrapWithLoggerContext(
-  withMetadataCache(wrapWithSpanAttributes(handler)),
-  loggerContext,
-);
+export default compose(withLoggerContext, withMetadataCache, withSpanAttributes)(handler);

--- a/apps/cms/src/pages/api/manifest.ts
+++ b/apps/cms/src/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import packageJson from "../../../package.json";
 import { loggerContext } from "../../logger-context";

--- a/apps/cms/src/pages/api/register.ts
+++ b/apps/cms/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { saleorApp } from "@/saleor-app";
 

--- a/apps/cms/src/pages/api/trpc/[trpc].ts
+++ b/apps/cms/src/pages/api/trpc/[trpc].ts
@@ -1,5 +1,5 @@
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { createLogger } from "@/logger";

--- a/apps/cms/src/pages/api/webhooks/product-updated.ts
+++ b/apps/cms/src/pages/api/webhooks/product-updated.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as Sentry from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/cms/src/pages/api/webhooks/product-variant-created.ts
+++ b/apps/cms/src/pages/api/webhooks/product-variant-created.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as Sentry from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/cms/src/pages/api/webhooks/product-variant-deleted.ts
+++ b/apps/cms/src/pages/api/webhooks/product-variant-deleted.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as Sentry from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/cms/src/pages/api/webhooks/product-variant-updated.ts
+++ b/apps/cms/src/pages/api/webhooks/product-variant-updated.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as Sentry from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/klaviyo/src/pages/api/configuration.ts
+++ b/apps/klaviyo/src/pages/api/configuration.ts
@@ -2,7 +2,7 @@ import { createProtectedHandler, NextProtectedApiHandler } from "@saleor/app-sdk
 import { EncryptedMetadataManager } from "@saleor/app-sdk/settings-manager";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { createGraphQLClient } from "@saleor/apps-shared";
 
 import { saleorApp } from "../../../saleor-app";

--- a/apps/klaviyo/src/pages/api/manifest.ts
+++ b/apps/klaviyo/src/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import pkg from "../../../package.json";
 import { loggerContext } from "../../logger-context";

--- a/apps/klaviyo/src/pages/api/register.ts
+++ b/apps/klaviyo/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { saleorApp } from "../../../saleor-app";
 import { loggerContext } from "../../logger-context";

--- a/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { createGraphQLClient } from "@saleor/apps-shared";
 import { gql } from "urql";
 

--- a/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { createGraphQLClient } from "@saleor/apps-shared";
 import { gql } from "urql";
 

--- a/apps/klaviyo/src/pages/api/webhooks/order-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-created.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { createGraphQLClient } from "@saleor/apps-shared";
 import { gql } from "urql";
 

--- a/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { createGraphQLClient } from "@saleor/apps-shared";
 import { gql } from "urql";
 

--- a/apps/products-feed/src/pages/api/feed/[url]/[channel]/google.xml.ts
+++ b/apps/products-feed/src/pages/api/feed/[url]/[channel]/google.xml.ts
@@ -1,6 +1,6 @@
 import { SpanStatusCode } from "@opentelemetry/api";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z, ZodError } from "zod";
 

--- a/apps/products-feed/src/pages/api/manifest.ts
+++ b/apps/products-feed/src/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import packageJson from "../../../package.json";
 import { createLogger } from "../../logger";

--- a/apps/products-feed/src/pages/api/register.ts
+++ b/apps/products-feed/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { loggerContext } from "../../logger-context";
 import { saleorApp } from "../../saleor-app";

--- a/apps/products-feed/src/pages/api/trpc/[trpc].ts
+++ b/apps/products-feed/src/pages/api/trpc/[trpc].ts
@@ -1,6 +1,6 @@
 import { createProtectedHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { createLogger } from "../../../logger";

--- a/apps/search/src/pages/api/manifest.ts
+++ b/apps/search/src/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import packageJson from "../../../package.json";
 import { appWebhooks } from "../../../webhooks";

--- a/apps/search/src/pages/api/register.ts
+++ b/apps/search/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { saleorApp } from "../../../saleor-app";
 import { loggerContext } from "../../lib/logger-context";

--- a/apps/search/src/pages/api/setup-indices.ts
+++ b/apps/search/src/pages/api/setup-indices.ts
@@ -1,7 +1,7 @@
 import { createProtectedHandler, NextProtectedApiHandler } from "@saleor/app-sdk/handlers/next";
 import { SettingsManager } from "@saleor/app-sdk/settings-manager";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { Client } from "urql";
 
 import { ChannelsDocument } from "../../../generated/graphql";

--- a/apps/search/src/pages/api/trpc/[trpc].ts
+++ b/apps/search/src/pages/api/trpc/[trpc].ts
@@ -1,5 +1,5 @@
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { loggerContext } from "../../../lib/logger-context";

--- a/apps/search/src/pages/api/webhooks-status.ts
+++ b/apps/search/src/pages/api/webhooks-status.ts
@@ -1,6 +1,6 @@
 import { createProtectedHandler, NextProtectedApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { Client } from "urql";
 
 import { FetchOwnWebhooksDocument, OwnWebhookFragment } from "../../../generated/graphql";

--- a/apps/search/src/pages/api/webhooks/saleor/product_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_created.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductCreated } from "../../../../../generated/graphql";
 import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";

--- a/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductDeleted } from "../../../../../generated/graphql";
 import { createLogger } from "../../../../lib/logger";

--- a/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductUpdated } from "../../../../../generated/graphql";
 import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductVariantBackInStock } from "../../../../../generated/graphql";
 import { createLogger } from "../../../../lib/logger";

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductVariantCreated } from "../../../../../generated/graphql";
 import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_deleted.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductVariantDeleted } from "../../../../../generated/graphql";
 import { createLogger } from "../../../../lib/logger";

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductVariantOutOfStock } from "../../../../../generated/graphql";
 import { createLogger } from "../../../../lib/logger";

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { ProductVariantUpdated } from "../../../../../generated/graphql";
 import { AlgoliaErrorParser } from "../../../../lib/algolia/algolia-error-parser";

--- a/apps/segment/src/pages/api/manifest.ts
+++ b/apps/segment/src/pages/api/manifest.ts
@@ -1,7 +1,7 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { env } from "@/env";
 import { loggerContext } from "@/logger-context";

--- a/apps/segment/src/pages/api/register.ts
+++ b/apps/segment/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { env } from "@/env";
 import { loggerContext } from "@/logger-context";

--- a/apps/segment/src/pages/api/trpc/[trpc].ts
+++ b/apps/segment/src/pages/api/trpc/[trpc].ts
@@ -1,5 +1,5 @@
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as Sentry from "@sentry/nextjs";
 import * as trpcNext from "@trpc/server/adapters/next";
 

--- a/apps/segment/src/pages/api/webhooks/order-cancelled.ts
+++ b/apps/segment/src/pages/api/webhooks/order-cancelled.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { OrderUpdatedSubscriptionPayloadFragment } from "@/generated/graphql";
 import { createLogger } from "@/logger";

--- a/apps/segment/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/segment/src/pages/api/webhooks/order-confirmed.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { OrderConfirmedSubscriptionPayloadFragment } from "@/generated/graphql";
 import { createLogger } from "@/logger";

--- a/apps/segment/src/pages/api/webhooks/order-refunded.ts
+++ b/apps/segment/src/pages/api/webhooks/order-refunded.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { OrderRefundedSubscriptionPayloadFragment } from "@/generated/graphql";
 import { createLogger } from "@/logger";

--- a/apps/segment/src/pages/api/webhooks/order-updated.ts
+++ b/apps/segment/src/pages/api/webhooks/order-updated.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import { OrderUpdatedSubscriptionPayloadFragment } from "@/generated/graphql";
 import { createLogger } from "@/logger";

--- a/apps/smtp/src/pages/api/manifest.ts
+++ b/apps/smtp/src/pages/api/manifest.ts
@@ -1,6 +1,6 @@
 import { createManifestHandler } from "@saleor/app-sdk/handlers/next";
 import { AppManifest } from "@saleor/app-sdk/types";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 
 import packageJson from "../../../package.json";
 

--- a/apps/smtp/src/pages/api/register.ts
+++ b/apps/smtp/src/pages/api/register.ts
@@ -1,6 +1,6 @@
 import { createAppRegisterHandler } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { SaleorVersionCompatibilityValidator } from "@saleor/apps-shared";
 
 import { createInstrumentedGraphqlClient } from "../../lib/create-instrumented-graphql-client";

--- a/apps/smtp/src/pages/api/trpc/[trpc].ts
+++ b/apps/smtp/src/pages/api/trpc/[trpc].ts
@@ -1,5 +1,5 @@
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { createLogger } from "../../../logger";

--- a/apps/smtp/src/pages/api/webhooks/gift-card-sent.ts
+++ b/apps/smtp/src/pages/api/webhooks/gift-card-sent.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/invoice-sent.ts
+++ b/apps/smtp/src/pages/api/webhooks/invoice-sent.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/notify.ts
+++ b/apps/smtp/src/pages/api/webhooks/notify.ts
@@ -1,6 +1,6 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 
 import { notifyEventMapping, NotifySubscriptionPayload } from "../../../lib/notify-event-types";

--- a/apps/smtp/src/pages/api/webhooks/order-cancelled.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-cancelled.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/order-confirmed.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-confirmed.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/order-created.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-created.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/order-fulfilled.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-fulfilled.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/order-fully-paid.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-fully-paid.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/apps/smtp/src/pages/api/webhooks/order-refunded.ts
+++ b/apps/smtp/src/pages/api/webhooks/order-refunded.ts
@@ -1,7 +1,7 @@
 import { NextWebhookApiHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/handlers/next";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
-import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/wrap-with-span-attributes";
+import { wrapWithSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
 import { captureException } from "@sentry/nextjs";
 import { gql } from "urql";
 

--- a/packages/otel/src/with-span-attributes.ts
+++ b/packages/otel/src/with-span-attributes.ts
@@ -4,7 +4,7 @@ import { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 
 import { ObservabilityAttributes } from "./observability-attributes";
 
-export const wrapWithSpanAttributes = (handler: NextApiHandler) => {
+export const withSpanAttributes = (handler: NextApiHandler) => {
   return (req: NextApiRequest, res: NextApiResponse) => {
     const span = trace.getActiveSpan();
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,3 +1,4 @@
+export * from "./src/compose";
 export * from "./src/create-graphql-client";
 export * from "./src/editor-js/editor-js-plaintext-renderer";
 export * from "./src/get-app-base-url";

--- a/packages/shared/src/compose.ts
+++ b/packages/shared/src/compose.ts
@@ -1,0 +1,2 @@
+export const compose = <T>(...fns: Array<(arg: T) => T>) =>
+  fns.reduce((prevFn, nextFn) => (value: T) => prevFn(nextFn(value)));


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Added `compose` function that can be used e.g to compose multiple wrappers around handler:
```ts
// before
export default wrapWithLoggerContext(withSpanAttributes(handler));
// after
export default compose(withLoggerContext, withSpanAttributes)(handler)
```
* Renamed `wrapWithSpanAttributes` to `withSpanAttributes` to be in sync with other wrappers.
* For testing migrated AvaTax app

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
