### PR TITLE
Refactor AvaTax client to use nevethrow

### DIFF
--- a/.changeset/small-moles-tell.md
+++ b/.changeset/small-moles-tell.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": minor
+---
+
+Refactor AvaTax client to use neverthrow library. No visible changes to the end user.

--- a/apps/avatax/src/modules/avatax/avatax-client-tax-code.service.test.ts
+++ b/apps/avatax/src/modules/avatax/avatax-client-tax-code.service.test.ts
@@ -1,18 +1,16 @@
+import { err } from "neverthrow";
 import { describe, expect, it } from "vitest";
 
 import { AvataxClientTaxCodeService } from "@/modules/avatax/avatax-client-tax-code.service";
 
+import { AvataxForbiddenAccessError } from "../taxes/tax-error";
+
 describe("AvataxClientTaxCodeService", () => {
   describe("getFilteredTaxCodes", () => {
-    it("Throws ForbiddenAccessError error if Avatax returns error.code 'PermissionRequired'", () => {
+    it("Throws ForbiddenAccessError error if Avatax returns AvataxForbiddenAccessError", () => {
       const service = new AvataxClientTaxCodeService({
         listTaxCodes() {
-          return Promise.reject({
-            code: "PermissionRequired",
-            message: "Not permitted",
-            name: "Error",
-            target: "CustomerAccountSetup",
-          });
+          return Promise.resolve(err(new AvataxForbiddenAccessError("Not permitted")));
         },
       });
 

--- a/apps/avatax/src/modules/avatax/avatax-client-tax-code.service.ts
+++ b/apps/avatax/src/modules/avatax/avatax-client-tax-code.service.ts
@@ -1,15 +1,10 @@
-import Avatax from "avatax";
 import { TaxCodeModel } from "avatax/lib/models/TaxCodeModel";
 import { FetchResult } from "avatax/lib/utils/fetch_result";
-import { z } from "zod";
 
 import { BaseError } from "@/error";
 
-import { createLogger } from "../../logger";
-
-const AvataxErrorShape = z.object({
-  code: z.string(),
-});
+import { AvataxForbiddenAccessError } from "../taxes/tax-error";
+import { AvataxClient } from "./avatax-client";
 
 export class AvataxClientTaxCodeService {
   static AvataxClientTaxCodeServiceError = BaseError.subclass("AvataxClientTaxCodeServiceError");
@@ -18,9 +13,8 @@ export class AvataxClientTaxCodeService {
 
   // * These are the tax codes that we don't want to show to the user. For some reason, Avatax has them as active.
   private readonly notSuitableKeys = ["Expired Tax Code - Do Not Use"];
-  private logger = createLogger("AvataxClientTaxCodeService");
 
-  constructor(private client: Pick<Avatax, "listTaxCodes">) {}
+  constructor(private client: Pick<AvataxClient, "listTaxCodes">) {}
 
   private filterOutInvalid(response: FetchResult<TaxCodeModel>) {
     return response.value.filter((taxCode) => {
@@ -33,39 +27,20 @@ export class AvataxClientTaxCodeService {
   }
 
   async getFilteredTaxCodes({ filter }: { filter: string | null }) {
-    const result = await this.client
-      .listTaxCodes({
-        ...(filter ? { filter: `taxCode contains "${filter}"` } : {}),
-        top: 50,
-      })
-      .catch((error) => {
-        this.logger.error("Failed to call listTaxCodes on Avatax client", {
-          error,
-        });
+    const listTaxCodesResult = await this.client.listTaxCodes({ filter });
 
-        try {
-          const parsedError = AvataxErrorShape.parse(error);
+    if (listTaxCodesResult.isErr()) {
+      if (listTaxCodesResult.error instanceof AvataxForbiddenAccessError) {
+        throw new AvataxClientTaxCodeService.ForbiddenAccessError(
+          "PermissionRequired error was returned from Avatax",
+          {
+            cause: listTaxCodesResult.error,
+          },
+        );
+      }
+      throw listTaxCodesResult.error;
+    }
 
-          /*
-           * Catch specific client error so it's returned to the frontend
-           * https://linear.app/saleor/issue/SHOPX-1189/
-           */
-          if (parsedError.code === "PermissionRequired") {
-            throw new AvataxClientTaxCodeService.ForbiddenAccessError(
-              "PermissionRequired error was returned from Avatax",
-              {
-                cause: error,
-              },
-            );
-          }
-
-          // Throw other errors like usual
-          throw error;
-        } catch (outerError) {
-          throw outerError;
-        }
-      });
-
-    return this.filterOutInvalid(result);
+    return this.filterOutInvalid(listTaxCodesResult.value);
   }
 }

--- a/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.test.ts
+++ b/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.test.ts
@@ -1,3 +1,4 @@
+import { ok } from "neverthrow";
 import { describe, expect, it, vi } from "vitest";
 
 import { AvataxClient } from "./avatax-client";
@@ -9,7 +10,7 @@ describe("AvataxEntityTypeMatcher", () => {
   it("returns empty string when no entity code", async () => {
     const mockAvataxClient = {
       getEntityUseCode: mockGetEntityUseCode.mockReturnValue(
-        Promise.resolve({ value: [{ code: "entityCode" }] }),
+        Promise.resolve(ok({ value: [{ code: "entityCode" }] })),
       ),
     } as any as AvataxClient;
 
@@ -20,7 +21,7 @@ describe("AvataxEntityTypeMatcher", () => {
   });
   it("returns empty string when entity code is present in metadata but not in avatax", async () => {
     const mockAvataxClient = {
-      getEntityUseCode: mockGetEntityUseCode.mockReturnValue(Promise.resolve({})),
+      getEntityUseCode: mockGetEntityUseCode.mockReturnValue(Promise.resolve(ok({}))),
     } as any as AvataxClient;
 
     const matcher = new AvataxEntityTypeMatcher(mockAvataxClient);
@@ -32,7 +33,7 @@ describe("AvataxEntityTypeMatcher", () => {
   it("returns entity code when entity code is present in metadata and in avatax", async () => {
     const mockAvataxClient = {
       getEntityUseCode: mockGetEntityUseCode.mockReturnValue(
-        Promise.resolve({ value: [{ code: "entityCode" }] }),
+        Promise.resolve(ok({ value: [{ code: "entityCode" }] })),
       ),
     } as any as AvataxClient;
 

--- a/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
+++ b/apps/avatax/src/modules/avatax/avatax-entity-type-matcher.ts
@@ -12,10 +12,14 @@ export class AvataxEntityTypeMatcher {
   }
 
   private async validateEntityCode(entityCode: string) {
-    const result = await this.avataxClient.getEntityUseCode(entityCode);
+    const entityUseCodeResult = await this.avataxClient.getEntityUseCode(entityCode);
+
+    if (entityUseCodeResult.isErr()) {
+      throw entityUseCodeResult.error;
+    }
 
     // If verified, return the entity code. If not, return empty string.
-    return result.value?.[0].code || this.returnFallback();
+    return entityUseCodeResult.value.value?.[0].code || this.returnFallback();
   }
 
   // TODO: Now that we get the customer code from user metadata, maybe we should get the entity code from the same place?

--- a/apps/avatax/src/modules/avatax/avatax-errors-parser.ts
+++ b/apps/avatax/src/modules/avatax/avatax-errors-parser.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { BaseError } from "../../error";
 import {
   AvataxEntityNotFoundError,
+  AvataxForbiddenAccessError,
   AvataxGetTaxError,
   AvataxInvalidAddressError,
   AvataxInvalidCredentialsError,
@@ -25,6 +26,7 @@ export class AvataxErrorsParser {
       "StringLengthError",
       "EntityNotFoundError",
       "TransactionAlreadyCancelled",
+      "PermissionRequired",
     ]),
     details: z.array(
       z.object({
@@ -78,6 +80,13 @@ export class AvataxErrorsParser {
       }
       case "TransactionAlreadyCancelled": {
         return new AvataxTransactionAlreadyCancelledError(parsedError.data.code, {
+          props: {
+            description: parsedError.data.details[0].description,
+          },
+        });
+      }
+      case "PermissionRequired": {
+        return new AvataxForbiddenAccessError(parsedError.data.code, {
           props: {
             description: parsedError.data.details[0].description,
           },

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-payload-transformer.test.ts
@@ -1,4 +1,5 @@
 import { DocumentType } from "avatax/lib/enums/DocumentType";
+import { ok } from "neverthrow";
 import { describe, expect, it, test } from "vitest";
 
 import { AvataxEntityTypeMatcher } from "@/modules/avatax/avatax-entity-type-matcher";
@@ -16,7 +17,7 @@ describe("AvataxCalculateTaxesPayloadTransformer", () => {
     new AvataxCalculateTaxesPayloadLinesTransformer(new AvataxCalculateTaxesTaxCodeMatcher()),
     new AvataxEntityTypeMatcher({
       getEntityUseCode() {
-        return Promise.resolve({ "@recordsetCount": 1, value: [{ code: "entityCode" }] });
+        return Promise.resolve(ok({ "@recordsetCount": 1, value: [{ code: "entityCode" }] }));
       },
     }),
   );

--- a/apps/avatax/src/modules/avatax/configuration/avatax-address-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-address-validation.service.ts
@@ -1,11 +1,6 @@
-import { fromPromise } from "neverthrow";
-
 import { avataxAddressFactory } from "../address-factory";
 import { AvataxClient } from "../avatax-client";
 import { AvataxConfig } from "../avatax-connection-schema";
-import { AvataxErrorsParser } from "../avatax-errors-parser";
-
-const errorParser = new AvataxErrorsParser();
 
 export class AvataxAddressValidationService {
   constructor(private avataxClient: AvataxClient) {}
@@ -13,9 +8,6 @@ export class AvataxAddressValidationService {
   async validate(address: AvataxConfig["address"]) {
     const formattedAddress = avataxAddressFactory.fromChannelAddress(address);
 
-    return fromPromise(
-      this.avataxClient.validateAddress({ address: formattedAddress }),
-      errorParser.parse,
-    );
+    return this.avataxClient.validateAddress({ address: formattedAddress });
   }
 }

--- a/apps/avatax/src/modules/avatax/configuration/avatax-auth-validation.service.ts
+++ b/apps/avatax/src/modules/avatax/configuration/avatax-auth-validation.service.ts
@@ -7,9 +7,13 @@ export class AvataxAuthValidationService {
   constructor(private avataxClient: AvataxClient) {}
 
   async testConnection() {
-    const result = await this.avataxClient.ping();
+    const pingResult = await this.avataxClient.ping();
 
-    if (!result.authenticated) {
+    if (pingResult.isErr()) {
+      return errAsync(pingResult.error);
+    }
+
+    if (!pingResult.value.authenticated) {
       return errAsync(new AvataxInvalidCredentialsError("Invalid AvaTax credentials"));
     }
     return okAsync({});

--- a/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.test.ts
+++ b/apps/avatax/src/modules/avatax/order-cancelled/avatax-order-cancelled-adapter.test.ts
@@ -1,18 +1,19 @@
+import { err } from "neverthrow";
 import { describe, expect, it } from "vitest";
 
 import { AvataxConfigMockGenerator } from "@/modules/avatax/avatax-config-mock-generator";
 import { AvataxOrderCancelledAdapter } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-adapter";
 import { AvataxOrderCancelledPayloadTransformer } from "@/modules/avatax/order-cancelled/avatax-order-cancelled-payload-transformer";
+import { AvataxEntityNotFoundError } from "@/modules/taxes/tax-error";
 
 describe("AvataxOrderCancelledAdapter", () => {
-  it("Throws DocumentNotFoundError if Avatax returns DocumentNotFoundError from the response of transaction void", async () => {
+  it("Throws DocumentNotFoundError if Avatax returns AvataxEntityNotFoundError from the response of transaction void", async () => {
     const adapter = new AvataxOrderCancelledAdapter(
       {
         async voidTransaction() {
-          throw {
-            code: "EntityNotFoundError",
-            details: [{}],
-          };
+          return Promise.resolve(
+            err(new AvataxEntityNotFoundError("AvaTax didnt find the document to void")),
+          );
         },
       },
       new AvataxOrderCancelledPayloadTransformer(),
@@ -21,6 +22,7 @@ describe("AvataxOrderCancelledAdapter", () => {
     try {
       await adapter.send({ avataxId: "1" }, new AvataxConfigMockGenerator().generateAvataxConfig());
     } catch (e) {
+      // console.log("Error", e);
       return expect(e).toBeInstanceOf(AvataxOrderCancelledAdapter.DocumentNotFoundError);
     }
   });

--- a/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.service.ts
+++ b/apps/avatax/src/modules/avatax/tax-code/avatax-tax-codes.service.ts
@@ -6,11 +6,12 @@ import type { TaxCode } from "../../taxes/tax-code";
 import { TaxBadProviderResponseError } from "../../taxes/tax-error";
 import { taxProviderUtils } from "../../taxes/tax-provider-utils";
 import { AvataxClient } from "../avatax-client";
+import { AvataxClientTaxCodeService } from "../avatax-client-tax-code.service";
 
 export class AvataxTaxCodesService {
   private logger = createLogger("AvataxTaxCodesService");
 
-  constructor(private client: Pick<AvataxClient, "getFilteredTaxCodes">) {}
+  constructor(private client: Pick<AvataxClient, "listTaxCodes">) {}
 
   private adapt(taxCodes: TaxCodeModel[]): TaxCode[] {
     return taxCodes.map((item) => ({
@@ -23,7 +24,8 @@ export class AvataxTaxCodesService {
   }
 
   async getAllFiltered({ filter }: { filter: string | null }): Promise<TaxCode[]> {
-    const response = await this.client.getFilteredTaxCodes({ filter }).catch((error) => {
+    const clientTaxCodeService = new AvataxClientTaxCodeService(this.client);
+    const response = await clientTaxCodeService.getFilteredTaxCodes({ filter }).catch((error) => {
       this.logger.error("Failed to fetch filtered tax codes", { error });
 
       throw error;

--- a/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.test.ts
+++ b/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.test.ts
@@ -236,7 +236,7 @@ describe("CalculateTaxesUseCase", () => {
   it("Calculates proper discount (extra field with sum of SUBTOTAL-type amounts) and properly reduces price of shipping line", async () => {
     mockGetAppConfig.mockImplementationOnce(() => ok(getMockedAppConfig()));
 
-    mockedAvataxClient.createTransaction.mockResolvedValueOnce({ lines: [] });
+    mockedAvataxClient.createTransaction.mockResolvedValueOnce(Promise.resolve(ok({ lines: [] })));
 
     const payload = getPayloadWithDiscounts();
 
@@ -265,7 +265,7 @@ describe("CalculateTaxesUseCase", () => {
   it("Writes successful log if taxes calculated to Log Writer", async () => {
     mockGetAppConfig.mockImplementationOnce(() => ok(getMockedAppConfig()));
 
-    mockedAvataxClient.createTransaction.mockResolvedValueOnce({ lines: [] });
+    mockedAvataxClient.createTransaction.mockResolvedValueOnce(Promise.resolve(ok({ lines: [] })));
 
     const payload = getPayloadWithDiscounts();
 

--- a/apps/avatax/src/modules/taxes/tax-error.ts
+++ b/apps/avatax/src/modules/taxes/tax-error.ts
@@ -53,3 +53,9 @@ export const AvataxTransactionAlreadyCancelledError = ExpectedError.subclass(
     },
   },
 );
+
+export const AvataxForbiddenAccessError = ExpectedError.subclass("AvataxForbiddenAccessError", {
+  props: {
+    description: "",
+  },
+});


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Refactored AvaTax client to use `nevethrow` - thanks to that it will be easier to wrap AvaTax methods with custom spans and set span statuses based on response.


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
