### PR TITLE
Add missing env vars to turbo configuration

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,18 +2,24 @@
   "$schema": "https://turbo.build/schema.v2.json",
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": [
-    "VERCEL_ENV",
     "APP_LOG_LEVEL",
-    "NODE_ENV",
     "CI",
-    "OTEL_SERVICE_NAME",
-    "OTEL_ENABLED",
+    "ENABLE_EXPERIMENTAL_COREPACK",
     "ENV",
     "GITHUB_SHA",
+    "NEXT_RUNTIME",
+    "NODE_ENV",
+    "OTEL_ENABLED",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_LOG_LEVEL",
+    "OTEL_SERVICE_NAME",
+    "OTEL_TRACES_SAMPLER_ARG",
+    "OTEL_TRACES_SAMPLER",
+    "REPOSITORY_URL",
+    "VERCEL_ENV",
     "VERCEL_GIT_COMMIT_SHA",
     "VERCEL_URL",
-    "VERCEL",
-    "NEXT_RUNTIME"
+    "VERCEL"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Solves warnings during Vercel deployments:
```
Warning - the following environment variables are set on your Vercel project, but missing from "turbo.json". These variables WILL NOT be available to your application and may cause your build to fail. Learn more at https://turbo.build/repo/docs/platform-environment-variables
[warn] saleor-app-avatax#deploy
[warn]   - OTEL_EXPORTER_OTLP_ENDPOINT 
[warn]   - OTEL_TRACES_SAMPLER_ARG 
[warn]   - OTEL_TRACES_SAMPLER 
[warn]   - ENABLE_EXPERIMENTAL_COREPACK 
[warn]   - OTEL_LOG_LEVEL 
[warn]   - REPOSITORY_URL 
```

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
