### PR TITLE
Bring back lint:fix & test tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -54,8 +54,15 @@
     "lint": {
       "dependsOn": ["topo"]
     },
+    "lint:fix": {
+      "dependsOn": ["topo"]
+    },
     "start": {
       "dependsOn": ["^build", "^start"],
+      "cache": false,
+      "persistent": true
+    },
+    "test": {
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Brings back `lint:fix` task - currently it isn't possible to run it from root of monorepo
* Brings back `test` task but disables cache for it - by default test tasks are running vitest in watch mode so there is no reason to cache that

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
