### PR TITLE
Fix lint-staged configs & introduce tool.config.js syntax

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,9 +1,0 @@
-/**
- * @type {import('lint-staged').Configuration}
- */
-export default {
-  "*.{jsx,tsx,js,ts,md,mdx}": "eslint --cache --fix",
-  "*.{jsx,tsx,js,ts,md,mdx}": "prettier --write",
-  "*.{jsx,tsx,js,ts,md,mdx}": "cspell --no-must-find-files",
-  "package.json": "sort-package-json",
-};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "singleQuote": false,
-  "printWidth": 100
-}

--- a/apps/avatax/.eslintrc.cjs
+++ b/apps/avatax/.eslintrc.cjs
@@ -17,5 +17,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/avatax/.lintstagedrc.js
+++ b/apps/avatax/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/avatax/lint-staged.config.js
+++ b/apps/avatax/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/cms/.eslintrc.cjs
+++ b/apps/cms/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/cms/.lintstagedrc.js
+++ b/apps/cms/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/cms/lint-staged.config.js
+++ b/apps/cms/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/klaviyo/.eslintrc.cjs
+++ b/apps/klaviyo/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/klaviyo/.lintstagedrc.js
+++ b/apps/klaviyo/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/klaviyo/lint-staged.config.js
+++ b/apps/klaviyo/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/products-feed/.eslintrc.cjs
+++ b/apps/products-feed/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/products-feed/.lintstagedrc.js
+++ b/apps/products-feed/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/products-feed/lint-staged.config.js
+++ b/apps/products-feed/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/search/.eslintrc.cjs
+++ b/apps/search/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/search/.lintstagedrc.js
+++ b/apps/search/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/search/lint-staged.config.js
+++ b/apps/search/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/segment/.eslintrc.cjs
+++ b/apps/segment/.eslintrc.cjs
@@ -34,5 +34,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/segment/.lintstagedrc.js
+++ b/apps/segment/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/segment/lint-staged.config.js
+++ b/apps/segment/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/apps/smtp/.eslintrc.cjs
+++ b/apps/smtp/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/apps/smtp/.lintstagedrc.js
+++ b/apps/smtp/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/apps/smtp/lint-staged.config.js
+++ b/apps/smtp/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,9 @@
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  "*.{jsx,tsx,js,ts,md}": "cspell --no-must-find-files",
+  // https://github.com/lint-staged/lint-staged#task-concurrency
+  "!(*.jsx|*.tsx|*.ts|*.js|*.cjs)": ["prettier --ignore-unknown --write"],
+  "package.json": "sort-package-json",
+};

--- a/packages/e2e/.eslintrc.cjs
+++ b/packages/e2e/.eslintrc.cjs
@@ -8,4 +8,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/e2e/.lintstagedrc.js
+++ b/packages/e2e/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/e2e/lint-staged.config.js
+++ b/packages/e2e/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/eslint-config/.lintstagedrc.js
+++ b/packages/eslint-config/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/eslint-config/lint-staged.config.js
+++ b/packages/eslint-config/lint-staged.config.js
@@ -1,0 +1,9 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  "*.cjs": ["prettier --write"],
+};

--- a/packages/logger/.eslintrc.cjs
+++ b/packages/logger/.eslintrc.cjs
@@ -9,4 +9,5 @@ module.exports = {
   rules: {
     "no-console": "off",
   },
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/logger/.lintstagedrc.js
+++ b/packages/logger/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/logger/lint-staged.config.js
+++ b/packages/logger/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/otel/.eslintrc.cjs
+++ b/packages/otel/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["coverage"],
+  ignorePatterns: ["coverage", "lint-staged.config.js"],
 };

--- a/packages/otel/.lintstagedrc.js
+++ b/packages/otel/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/otel/lint-staged.config.js
+++ b/packages/otel/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/react-hook-form-macaw/.eslintrc.cjs
+++ b/packages/react-hook-form-macaw/.eslintrc.cjs
@@ -16,4 +16,5 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/react-hook-form-macaw/.lintstagedrc.js
+++ b/packages/react-hook-form-macaw/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/react-hook-form-macaw/lint-staged.config.js
+++ b/packages/react-hook-form-macaw/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/sentry-utils/.eslintrc.cjs
+++ b/packages/sentry-utils/.eslintrc.cjs
@@ -8,4 +8,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/sentry-utils/.lintstagedrc.js
+++ b/packages/sentry-utils/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/sentry-utils/lint-staged.config.js
+++ b/packages/sentry-utils/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["coverage"],
+  ignorePatterns: ["coverage", "lint-staged.config.js"],
 };

--- a/packages/shared/.lintstagedrc.js
+++ b/packages/shared/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/shared/lint-staged.config.js
+++ b/packages/shared/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/trpc/.eslintrc.cjs
+++ b/packages/trpc/.eslintrc.cjs
@@ -5,4 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/trpc/.lintstagedrc.js
+++ b/packages/trpc/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/trpc/lint-staged.config.js
+++ b/packages/trpc/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/typescript-config/.lintstagedrc.js
+++ b/packages/typescript-config/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/typescript-config/lint-staged.config.js
+++ b/packages/typescript-config/lint-staged.config.js
@@ -1,0 +1,8 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+};

--- a/packages/ui/.eslintrc.cjs
+++ b/packages/ui/.eslintrc.cjs
@@ -5,4 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
+  ignorePatterns: ["lint-staged.config.js"],
 };

--- a/packages/ui/.lintstagedrc.js
+++ b/packages/ui/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/ui/lint-staged.config.js
+++ b/packages/ui/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/packages/webhook-utils/.eslintrc.cjs
+++ b/packages/webhook-utils/.eslintrc.cjs
@@ -5,5 +5,5 @@ module.exports = {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,
   },
-  ignorePatterns: ["generated", "coverage"],
+  ignorePatterns: ["generated", "coverage", "lint-staged.config.js"],
 };

--- a/packages/webhook-utils/.lintstagedrc.js
+++ b/packages/webhook-utils/.lintstagedrc.js
@@ -1,5 +1,0 @@
-import baseConfig from "../../.lintstagedrc.js";
-
-export default {
-  ...baseConfig,
-};

--- a/packages/webhook-utils/lint-staged.config.js
+++ b/packages/webhook-utils/lint-staged.config.js
@@ -1,0 +1,10 @@
+import baseConfig from "../../lint-staged.config.js";
+
+/**
+ * @type {import('lint-staged').Configuration}
+ */
+export default {
+  ...baseConfig,
+  // run eslint first & then format with prettier
+  "*.{jsx,tsx,ts,js}": ["eslint --cache --fix", "prettier --write"],
+};

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,7 @@
+/**
+ * @type {import("prettier").Config}
+ */
+export default {
+  singleQuote: false,
+  printWidth: 100,
+};


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Fixed lint-staged configs:
* Previously `lint-staged` tried to run `eslint` from root of monorepo where there is no `eslint` installed. Now each app & pkg will have its own `eslint` provided.
* Fixed issue where prettier & eslint will run concurrently on the same files - right now if file is `(*.jsx|*.tsx|*.ts|*.js|*.cjs)` it will first run `eslint` and then `pretter` - for other files `prettier` will be executed
* Introduced new format for config files - `lint-staged.config.js` & `pretter.config.js` - more readable and in sync with eslint config file in version 9 (`eslint.config.js`)

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
