### PR TITLE
Create github-releases-to-discord.yml

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,17 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Announce to Discord
+        uses: SethCohen/github-releases-to-discord@6ac5abea42b8cbac14316970819a8a535aab08ea # v1.16.2
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          color: "11155626"
+          content: "New Saleor Apps release!"


### PR DESCRIPTION
## Scope of the PR

I added the same workflow we use in saleor/saleor for announcing releases on Discord. It provides a nicely formatted message. 

TODO:
- Remove current #releases workflow for apps
