### PR TITLE
Add GitHub Action to notify Discord on "Help Wanted" issues

### DIFF
--- a/.github/workflows/help-wanted-issues-to-discord.yml
+++ b/.github/workflows/help-wanted-issues-to-discord.yml
@@ -1,0 +1,24 @@
+name: Notify Discord on Help Wanted Issue
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    if: github.event.label.name == 'help wanted'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: appleboy/discord-action@6047e1fe519c24dbf2865cf0557f20f51f075b3e # v1.2.0
+        with:
+          webhook_url: ${{ secrets.DISCORD_GFI_WEBHOOK_URL }}
+          message: |
+            🎉 New Issue Labeled with "Help Wanted" in Saleor Apps
+
+            **Issue Details:**
+            - Title: ${{ github.event.issue.title }}
+            - Number: #${{ github.event.issue.number }}
+            - URL: ${{ github.event.issue.html_url }}
+
+            Please take a look and help if you can! 🙏


### PR DESCRIPTION
## Scope of the PR

Add GitHub Action to notify Discord on "Help Wanted" issues the same way we do in saleor/saleor

