### PR TITLE
Fix devcontainer setup

### DIFF
--- a/.devcontainer/avatax/Dockerfile
+++ b/.devcontainer/avatax/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-avatax

--- a/.devcontainer/avatax/devcontainer.json
+++ b/.devcontainer/avatax/devcontainer.json
@@ -12,7 +12,7 @@
       "label": "Local DynamoDB"
     }
   },
-  "postCreateCommand": "./scripts/setup-dynamodb.sh",
+  "postCreateCommand": "pnpm install --frozen-lockfile && ./scripts/setup-dynamodb.sh",
   "features": {
     "ghcr.io/devcontainers/features/aws-cli": {}
   },

--- a/.devcontainer/cms/Dockerfile
+++ b/.devcontainer/cms/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-cms

--- a/.devcontainer/cms/devcontainer.json
+++ b/.devcontainer/cms/devcontainer.json
@@ -9,6 +9,7 @@
       "label": "CMS app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/klaviyo/Dockerfile
+++ b/.devcontainer/klaviyo/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-klaviyo

--- a/.devcontainer/klaviyo/devcontainer.json
+++ b/.devcontainer/klaviyo/devcontainer.json
@@ -9,6 +9,7 @@
       "label": "Klaviyo app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/products-feed/Dockerfile
+++ b/.devcontainer/products-feed/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-products-feed

--- a/.devcontainer/products-feed/devcontainer.json
+++ b/.devcontainer/products-feed/devcontainer.json
@@ -9,6 +9,7 @@
       "label": "Products Feed app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/search/Dockerfile
+++ b/.devcontainer/search/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-search

--- a/.devcontainer/search/devcontainer.json
+++ b/.devcontainer/search/devcontainer.json
@@ -9,6 +9,7 @@
       "label": "Search app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/segment/Dockerfile
+++ b/.devcontainer/segment/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-segment

--- a/.devcontainer/segment/devcontainer.json
+++ b/.devcontainer/segment/devcontainer.json
@@ -12,7 +12,7 @@
       "label": "Local DynamoDB"
     }
   },
-  "postCreateCommand": "./scripts/setup-dynamodb.sh",
+  "postCreateCommand": "pnpm install --frozen-lockfile && ./scripts/setup-dynamodb.sh",
   "features": {
     "ghcr.io/devcontainers/features/aws-cli": {}
   },

--- a/.devcontainer/smtp/Dockerfile
+++ b/.devcontainer/smtp/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-smtp

--- a/.devcontainer/smtp/devcontainer.json
+++ b/.devcontainer/smtp/devcontainer.json
@@ -9,6 +9,7 @@
       "label": "SMTP app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/stripe/Dockerfile
+++ b/.devcontainer/stripe/Dockerfile
@@ -2,7 +2,6 @@ FROM mcr.microsoft.com/devcontainers/typescript-node:22
 
 ENV PNPM_HOME="/home/node/.pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN npm install --global corepack@latest
 RUN corepack enable
 
 WORKDIR /app
@@ -10,5 +9,3 @@ WORKDIR /app
 # This is needed so pnpm-store volume is created with correct permissions (see docker-compose.yml)
 RUN mkdir -p /app/.pnpm-store
 RUN chown -R node:node /app/.pnpm-store
-
-RUN pnpm install --frozen-lockfile --filter=saleor-app-stripe

--- a/.devcontainer/stripe/devcontainer.json
+++ b/.devcontainer/stripe/devcontainer.json
@@ -10,6 +10,7 @@
       "label": "Stripe app"
     }
   },
+  "postCreateCommand": "pnpm install --frozen-lockfile",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/apps/avatax/README.md
+++ b/apps/avatax/README.md
@@ -20,6 +20,9 @@
 
 ## Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` and `./scripts/setup-dynamodb.sh` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -33,6 +33,9 @@
 
 #### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/klaviyo/README.md
+++ b/apps/klaviyo/README.md
@@ -28,6 +28,9 @@
 
 #### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/products-feed/README.md
+++ b/apps/products-feed/README.md
@@ -25,6 +25,9 @@
 
 #### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/search/README.md
+++ b/apps/search/README.md
@@ -25,6 +25,9 @@
 
 #### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/segment/README.md
+++ b/apps/segment/README.md
@@ -15,10 +15,13 @@
 ### Prerequisites
 
 - [Node.js](https://nodejs.org) v22+
-- [PNPM](https://pnpm.io/) v9+
+- [PNPM](https://pnpm.io/) v10+
 - An account on [Twilio Segment](https://segment.com/) with configured [source](https://segment.com/docs/partners/sources/).
 
 ### Running app locally in development containers
+
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` and `./scripts/setup-dynamodb.sh` manually
 
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.

--- a/apps/smtp/README.md
+++ b/apps/smtp/README.md
@@ -25,6 +25,9 @@
 
 #### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 

--- a/apps/stripe/README.md
+++ b/apps/stripe/README.md
@@ -22,6 +22,9 @@
 
 ### Running app locally in development containers
 
+> [!IMPORTANT]
+> You can use devcontainer Dockerfile and docker-compose.yaml directly - but remember to run `pnpm install` manually
+
 The easiest way of running Saleor for local development is to use [development containers](https://containers.dev/).
 If you have Visual Studio Code follow their [guide](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-an-existing-folder-in-a-container) on how to open existing folder in container.
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
* Fixed when we install dependencies - after this change deps will be installed in devcontainer `postCreateCommand` instead in dockerfile. 
This is because in dockerfile there isn't volume with codebase connected yet - I will be connected in docker-compose. 
* Removed fix for corepack - it actually was causing docker builds to fail
* Removed `filter` from `pnpm install` - each app will have to have full deps in dev mode anyway

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
