### PR TITLE
Add currency handling and validation for Stripe integration

### DIFF
--- a/apps/stripe/package.json
+++ b/apps/stripe/package.json
@@ -48,6 +48,8 @@
     "@trpc/react-query": "catalog:",
     "@trpc/server": "catalog:",
     "@vercel/otel": "catalog:",
+    "currency-codes": "2.2.0",
+    "currency.js": "2.0.4",
     "graphql-tag": "2.12.6",
     "modern-errors": "7.0.1",
     "modern-errors-serialize": "6.1.0",

--- a/apps/stripe/src/app/api/manifest/route.integration.test.ts
+++ b/apps/stripe/src/app/api/manifest/route.integration.test.ts
@@ -49,7 +49,7 @@ describe("Manifest handler", async () => {
             "version": Any<String>,
             "webhooks": [
               {
-                "isActive": false,
+                "isActive": true,
                 "name": "Stripe Payment Gateway Initialize",
                 "query": "subscription PaymentGatewayInitializeSession { event { ... on PaymentGatewayInitializeSession { ...PaymentGatewayInitializeSessionEvent } }}fragment Channel on Channel { id slug}fragment PaymentGatewayInitializeSessionEvent on PaymentGatewayInitializeSession { version sourceObject { ... on Checkout { channel { ...Channel } } ... on Order { channel { ...Channel } } }}",
                 "syncEvents": [

--- a/apps/stripe/src/app/api/saleor/payment-gateway-initialize-session/webhook-definition.ts
+++ b/apps/stripe/src/app/api/saleor/payment-gateway-initialize-session/webhook-definition.ts
@@ -11,7 +11,7 @@ export const paymentGatewayInitializeSessionWebhookDefinition =
     apl: saleorApp.apl,
     event: "PAYMENT_GATEWAY_INITIALIZE_SESSION",
     name: "Stripe Payment Gateway Initialize",
-    isActive: false,
+    isActive: true, // TODO: disable in production
     query: PaymentGatewayInitializeSessionDocument,
     webhookPath: "api/saleor/payment-gateway-initialize-session",
   });

--- a/apps/stripe/src/app/api/saleor/transaction-initialize-session/use-case.ts
+++ b/apps/stripe/src/app/api/saleor/transaction-initialize-session/use-case.ts
@@ -11,6 +11,10 @@ import { SaleorMoney } from "@/modules/saleor/saleor-money";
 import { StripeMoney } from "@/modules/stripe/stripe-money";
 import { IStripePaymentIntentsApiFactory } from "@/modules/stripe/types";
 
+type TransactionInitializeSessionResponseData = {
+  stripeClientSecret: string | null;
+};
+
 export class TransactionInitializeSessionUseCase {
   private logger = createLogger("TransactionInitializeSessionUseCase");
   private appConfigRepo: AppConfigRepo;
@@ -75,13 +79,15 @@ export class TransactionInitializeSessionUseCase {
       });
     }
 
+    const stripePaymentIntentAdditionalInformation: TransactionInitializeSessionResponseData = {
+      stripeClientSecret: stripePaymentIntentResponse.client_secret,
+    };
+
     return {
       result: "CHARGE_REQUESTED",
       amount: saleorMoneyResult.value.getAmount(),
       pspReference: stripePaymentIntentResponse.id,
-      data: {
-        stripeClientSecret: stripePaymentIntentResponse.client_secret,
-      },
+      data: stripePaymentIntentAdditionalInformation,
     } as const;
   }
 

--- a/apps/stripe/src/app/api/saleor/transaction-initialize-session/use-case.ts
+++ b/apps/stripe/src/app/api/saleor/transaction-initialize-session/use-case.ts
@@ -37,7 +37,7 @@ export class TransactionInitializeSessionUseCase {
 
     if (stripeMoneyResult.isErr()) {
       this.logger.error(
-        "Failed to convert amount / currency comming from Saleor to one used by Stripe - throwing",
+        "Failed to convert amount / currency coming from Saleor to one used by Stripe - throwing",
         {
           error: stripeMoneyResult.error,
         },
@@ -64,7 +64,7 @@ export class TransactionInitializeSessionUseCase {
 
     if (saleorMoneyResult.isErr()) {
       this.logger.error(
-        "Failed to convert amount / currency comming from Stripe to one used by Saleor - throwing",
+        "Failed to convert amount / currency coming from Stripe to one used by Saleor - throwing",
         {
           error: saleorMoneyResult.error,
         },

--- a/apps/stripe/src/modules/saleor/saleor-money.test.ts
+++ b/apps/stripe/src/modules/saleor/saleor-money.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { SaleorMoney } from "./saleor-money";
+
+describe("SaleorMoney", () => {
+  describe("createFromStripe", () => {
+    it("creates a valid money object for valid input", () => {
+      const result = SaleorMoney.createFromStripe({ amount: 1000, currency: "usd" });
+
+      expect(result.isOk()).toBe(true);
+      expect(result._unsafeUnwrap()).toBeInstanceOf(SaleorMoney);
+    });
+
+    it("rejects negative amounts", () => {
+      const result = SaleorMoney.createFromStripe({ amount: -100, currency: "usd" });
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(SaleorMoney.ValdationError);
+    });
+
+    it("rejects invalid currency code length", () => {
+      const result = SaleorMoney.createFromStripe({ amount: 100, currency: "usdd" });
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(SaleorMoney.ValdationError);
+    });
+
+    it("rejects unsupported currency codes", () => {
+      const result = SaleorMoney.createFromStripe({ amount: 100, currency: "abc" });
+
+      expect(result.isErr()).toBe(true);
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(SaleorMoney.ValdationError);
+    });
+  });
+
+  describe("getAmount", () => {
+    it("handles 0-digit currencies", () => {
+      const money = SaleorMoney.createFromStripe({
+        amount: 2137,
+        currency: "jpy",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(2137);
+    });
+
+    it("handles 2-digit currencies", () => {
+      const money = SaleorMoney.createFromStripe({
+        amount: 1099,
+        currency: "usd",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(10.99);
+    });
+
+    it("handles 3-digit currencies", () => {
+      const money = SaleorMoney.createFromStripe({
+        amount: 10123,
+        currency: "iqd",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(10.123);
+    });
+
+    it("handles 4-digit currencies", () => {
+      const money = SaleorMoney.createFromStripe({
+        amount: 101234,
+        currency: "uyw",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(10.1234);
+    });
+  });
+
+  describe("getCurrency", () => {
+    it("returns currency in uppercase", () => {
+      const result = SaleorMoney.createFromStripe({ amount: 1000, currency: "usd" });
+
+      expect(result._unsafeUnwrap().getCurrency()).toBe("USD");
+    });
+  });
+});

--- a/apps/stripe/src/modules/saleor/saleor-money.test.ts
+++ b/apps/stripe/src/modules/saleor/saleor-money.test.ts
@@ -33,14 +33,14 @@ describe("SaleorMoney", () => {
     });
   });
 
-  describe("getAmount", () => {
+  describe("amount", () => {
     it("handles 0-digit currencies", () => {
       const money = SaleorMoney.createFromStripe({
         amount: 2137,
         currency: "jpy",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(2137);
+      expect(money.amount).toBe(2137);
     });
 
     it("handles 2-digit currencies", () => {
@@ -49,7 +49,7 @@ describe("SaleorMoney", () => {
         currency: "usd",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(10.99);
+      expect(money.amount).toBe(10.99);
     });
 
     it("handles 3-digit currencies", () => {
@@ -58,7 +58,7 @@ describe("SaleorMoney", () => {
         currency: "iqd",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(10.123);
+      expect(money.amount).toBe(10.123);
     });
 
     it("handles 4-digit currencies", () => {
@@ -67,15 +67,15 @@ describe("SaleorMoney", () => {
         currency: "uyw",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(10.1234);
+      expect(money.amount).toBe(10.1234);
     });
   });
 
-  describe("getCurrency", () => {
+  describe("currency", () => {
     it("returns currency in uppercase", () => {
       const result = SaleorMoney.createFromStripe({ amount: 1000, currency: "usd" });
 
-      expect(result._unsafeUnwrap().getCurrency()).toBe("USD");
+      expect(result._unsafeUnwrap().currency).toBe("USD");
     });
   });
 });

--- a/apps/stripe/src/modules/saleor/saleor-money.ts
+++ b/apps/stripe/src/modules/saleor/saleor-money.ts
@@ -5,14 +5,14 @@ import { err, ok } from "neverthrow";
 import { BaseError } from "@/lib/errors";
 
 export class SaleorMoney {
-  private readonly stripeAmount: number;
-  private readonly stripeCurrency: string;
+  private readonly amount: number;
+  private readonly currency: string;
 
   static ValdationError = BaseError.subclass("ValidationError");
 
-  private constructor(args: { stripeAmount: number; stripeCurrency: string }) {
-    this.stripeAmount = args.stripeAmount;
-    this.stripeCurrency = args.stripeCurrency;
+  private constructor(args: { amount: number; currency: string }) {
+    this.amount = args.amount;
+    this.currency = args.currency;
   }
 
   static createFromStripe(args: { amount: number; currency: string }) {
@@ -30,8 +30,8 @@ export class SaleorMoney {
 
     return ok(
       new SaleorMoney({
-        stripeAmount: args.amount,
-        stripeCurrency: args.currency,
+        amount: args.amount,
+        currency: args.currency,
       }),
     );
   }
@@ -39,7 +39,7 @@ export class SaleorMoney {
   getAmount() {
     const currencyCodeData = currencyCodesData.code(this.getCurrency());
 
-    const amount = currencyJs(this.stripeAmount, {
+    const amount = currencyJs(this.amount, {
       fromCents: true,
       // currencyCodeData will be defined at this point
       precision: currencyCodeData!.digits,
@@ -49,6 +49,6 @@ export class SaleorMoney {
   }
 
   getCurrency() {
-    return this.stripeCurrency.toUpperCase();
+    return this.currency.toUpperCase();
   }
 }

--- a/apps/stripe/src/modules/saleor/saleor-money.ts
+++ b/apps/stripe/src/modules/saleor/saleor-money.ts
@@ -1,0 +1,54 @@
+import { default as currencyJs } from "currency.js";
+import { default as currencyCodesData } from "currency-codes";
+import { err, ok } from "neverthrow";
+
+import { BaseError } from "@/lib/errors";
+
+export class SaleorMoney {
+  private readonly stripeAmount: number;
+  private readonly stripeCurrency: string;
+
+  static ValdationError = BaseError.subclass("ValidationError");
+
+  private constructor(args: { stripeAmount: number; stripeCurrency: string }) {
+    this.stripeAmount = args.stripeAmount;
+    this.stripeCurrency = args.stripeCurrency;
+  }
+
+  static createFromStripe(args: { amount: number; currency: string }) {
+    if (args.amount < 0) {
+      return err(new SaleorMoney.ValdationError("Amount must be greater than 0"));
+    }
+
+    if (args.currency.length !== 3) {
+      return err(new SaleorMoney.ValdationError("Currency code must be 3 characters long"));
+    }
+
+    if (currencyCodesData.code(args.currency) === undefined) {
+      return err(new SaleorMoney.ValdationError("Currency code is not supported"));
+    }
+
+    return ok(
+      new SaleorMoney({
+        stripeAmount: args.amount,
+        stripeCurrency: args.currency,
+      }),
+    );
+  }
+
+  getAmount() {
+    const currencyCodeData = currencyCodesData.code(this.getCurrency());
+
+    const amount = currencyJs(this.stripeAmount, {
+      fromCents: true,
+      // currencyCodeData will be defined at this point
+      precision: currencyCodeData!.digits,
+    });
+
+    return amount.value;
+  }
+
+  getCurrency() {
+    return this.stripeCurrency.toUpperCase();
+  }
+}

--- a/apps/stripe/src/modules/saleor/saleor-money.ts
+++ b/apps/stripe/src/modules/saleor/saleor-money.ts
@@ -5,8 +5,8 @@ import { err, ok } from "neverthrow";
 import { BaseError } from "@/lib/errors";
 
 export class SaleorMoney {
-  private readonly amount: number;
-  private readonly currency: string;
+  public readonly amount: number;
+  public readonly currency: string;
 
   static ValdationError = BaseError.subclass("ValidationError");
 
@@ -24,31 +24,22 @@ export class SaleorMoney {
       return err(new SaleorMoney.ValdationError("Currency code must be 3 characters long"));
     }
 
-    if (currencyCodesData.code(args.currency) === undefined) {
+    const currencyCodeData = currencyCodesData.code(args.currency);
+
+    if (currencyCodeData === undefined) {
       return err(new SaleorMoney.ValdationError("Currency code is not supported"));
     }
 
-    return ok(
-      new SaleorMoney({
-        amount: args.amount,
-        currency: args.currency,
-      }),
-    );
-  }
-
-  getAmount() {
-    const currencyCodeData = currencyCodesData.code(this.getCurrency());
-
-    const amount = currencyJs(this.amount, {
+    const convertedAmount = currencyJs(args.amount, {
       fromCents: true,
-      // currencyCodeData will be defined at this point
-      precision: currencyCodeData!.digits,
+      precision: currencyCodeData.digits,
     });
 
-    return amount.value;
-  }
-
-  getCurrency() {
-    return this.currency.toUpperCase();
+    return ok(
+      new SaleorMoney({
+        amount: convertedAmount.value,
+        currency: args.currency.toUpperCase(),
+      }),
+    );
   }
 }

--- a/apps/stripe/src/modules/stripe/stripe-money.test.ts
+++ b/apps/stripe/src/modules/stripe/stripe-money.test.ts
@@ -10,8 +10,8 @@ describe("StripeMoney", () => {
         currency: "USD",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(1000);
-      expect(money.getCurrency()).toBe("usd");
+      expect(money.amount).toBe(1000);
+      expect(money.currency).toBe("usd");
     });
 
     it("handles different currency precisions correctly", () => {
@@ -20,8 +20,8 @@ describe("StripeMoney", () => {
         currency: "JPY",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(10);
-      expect(money.getCurrency()).toBe("jpy");
+      expect(money.amount).toBe(10);
+      expect(money.currency).toBe("jpy");
     });
 
     it("returns error for negative amount", () => {
@@ -59,7 +59,7 @@ describe("StripeMoney", () => {
         currency: "JPY",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(2137);
+      expect(money.amount).toBe(2137);
     });
 
     it("handles 2-digit currencies", () => {
@@ -68,7 +68,7 @@ describe("StripeMoney", () => {
         currency: "USD",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(1099);
+      expect(money.amount).toBe(1099);
     });
 
     it("handles 3-digit currencies", () => {
@@ -77,7 +77,7 @@ describe("StripeMoney", () => {
         currency: "IQD",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(10123);
+      expect(money.amount).toBe(10123);
     });
 
     it("handles 4-digit currencies", () => {
@@ -86,7 +86,7 @@ describe("StripeMoney", () => {
         currency: "UYW",
       })._unsafeUnwrap();
 
-      expect(money.getAmount()).toBe(101234);
+      expect(money.amount).toBe(101234);
     });
   });
 
@@ -97,7 +97,7 @@ describe("StripeMoney", () => {
         currency: "EUR",
       })._unsafeUnwrap();
 
-      expect(money.getCurrency()).toBe("eur");
+      expect(money.currency).toBe("eur");
     });
   });
 });

--- a/apps/stripe/src/modules/stripe/stripe-money.test.ts
+++ b/apps/stripe/src/modules/stripe/stripe-money.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { StripeMoney } from "./stripe-money";
+
+describe("StripeMoney", () => {
+  describe("createFromSaleorAmount", () => {
+    it("creates a valid StripeMoney instance", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 10.0,
+        currency: "USD",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(1000);
+      expect(money.getCurrency()).toBe("usd");
+    });
+
+    it("handles different currency precisions correctly", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 10.0,
+        currency: "JPY",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(10);
+      expect(money.getCurrency()).toBe("jpy");
+    });
+
+    it("returns error for negative amount", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: -10.0,
+        currency: "USD",
+      });
+
+      expect(money._unsafeUnwrapErr()).toBeInstanceOf(StripeMoney.ValdationError);
+    });
+
+    it("returns error for invalid currency code length", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 100.0,
+        currency: "USDD",
+      });
+
+      expect(money._unsafeUnwrapErr()).toBeInstanceOf(StripeMoney.ValdationError);
+    });
+
+    it("returns error for unsupported currency", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 100.0,
+        currency: "ABC",
+      });
+
+      expect(money._unsafeUnwrapErr()).toBeInstanceOf(StripeMoney.ValdationError);
+    });
+  });
+
+  describe("getAmount", () => {
+    it("handles 0-digit currencies", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 2137,
+        currency: "JPY",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(2137);
+    });
+
+    it("handles 2-digit currencies", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 10.99,
+        currency: "USD",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(1099);
+    });
+
+    it("handles 3-digit currencies", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 10.123,
+        currency: "IQD",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(10123);
+    });
+
+    it("handles 4-digit currencies", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 10.1234,
+        currency: "UYW",
+      })._unsafeUnwrap();
+
+      expect(money.getAmount()).toBe(101234);
+    });
+  });
+
+  describe("getCurrency", () => {
+    it("returns lowercase currency code", () => {
+      const money = StripeMoney.createFromSaleorAmount({
+        amount: 1000,
+        currency: "EUR",
+      })._unsafeUnwrap();
+
+      expect(money.getCurrency()).toBe("eur");
+    });
+  });
+});

--- a/apps/stripe/src/modules/stripe/stripe-money.ts
+++ b/apps/stripe/src/modules/stripe/stripe-money.ts
@@ -1,0 +1,53 @@
+import { default as currencyJs } from "currency.js";
+import { default as currencyCodesData } from "currency-codes";
+import { err, ok } from "neverthrow";
+
+import { BaseError } from "@/lib/errors";
+
+export class StripeMoney {
+  private readonly saleorAmount: number;
+  private readonly saleorCurrency: string;
+
+  static ValdationError = BaseError.subclass("ValidationError");
+
+  private constructor(args: { saleorAmount: number; saleorCurrency: string }) {
+    this.saleorAmount = args.saleorAmount;
+    this.saleorCurrency = args.saleorCurrency;
+  }
+
+  static createFromSaleorAmount(args: { amount: number; currency: string }) {
+    if (args.amount < 0) {
+      return err(new StripeMoney.ValdationError("Amount must be greater than 0"));
+    }
+
+    if (args.currency.length !== 3) {
+      return err(new StripeMoney.ValdationError("Currency code must be 3 characters long"));
+    }
+
+    if (currencyCodesData.code(args.currency) === undefined) {
+      return err(new StripeMoney.ValdationError("Currency code is not supported"));
+    }
+
+    return ok(
+      new StripeMoney({
+        saleorAmount: args.amount,
+        saleorCurrency: args.currency,
+      }),
+    );
+  }
+
+  getAmount() {
+    const currencyCodeData = currencyCodesData.code(this.saleorCurrency);
+
+    const amount = currencyJs(this.saleorAmount, {
+      // currencyCodeData will be defined at this point
+      precision: currencyCodeData!.digits,
+    });
+
+    return amount.intValue;
+  }
+
+  getCurrency() {
+    return this.saleorCurrency.toLowerCase();
+  }
+}

--- a/apps/stripe/src/modules/stripe/stripe-money.ts
+++ b/apps/stripe/src/modules/stripe/stripe-money.ts
@@ -5,14 +5,14 @@ import { err, ok } from "neverthrow";
 import { BaseError } from "@/lib/errors";
 
 export class StripeMoney {
-  private readonly saleorAmount: number;
-  private readonly saleorCurrency: string;
+  private readonly amount: number;
+  private readonly currency: string;
 
   static ValdationError = BaseError.subclass("ValidationError");
 
-  private constructor(args: { saleorAmount: number; saleorCurrency: string }) {
-    this.saleorAmount = args.saleorAmount;
-    this.saleorCurrency = args.saleorCurrency;
+  private constructor(args: { amount: number; currency: string }) {
+    this.amount = args.amount;
+    this.currency = args.currency;
   }
 
   static createFromSaleorAmount(args: { amount: number; currency: string }) {
@@ -30,16 +30,16 @@ export class StripeMoney {
 
     return ok(
       new StripeMoney({
-        saleorAmount: args.amount,
-        saleorCurrency: args.currency,
+        amount: args.amount,
+        currency: args.currency,
       }),
     );
   }
 
   getAmount() {
-    const currencyCodeData = currencyCodesData.code(this.saleorCurrency);
+    const currencyCodeData = currencyCodesData.code(this.currency);
 
-    const amount = currencyJs(this.saleorAmount, {
+    const amount = currencyJs(this.amount, {
       // currencyCodeData will be defined at this point
       precision: currencyCodeData!.digits,
     });
@@ -48,6 +48,6 @@ export class StripeMoney {
   }
 
   getCurrency() {
-    return this.saleorCurrency.toLowerCase();
+    return this.currency.toLowerCase();
   }
 }

--- a/apps/stripe/src/modules/stripe/stripe-money.ts
+++ b/apps/stripe/src/modules/stripe/stripe-money.ts
@@ -5,8 +5,8 @@ import { err, ok } from "neverthrow";
 import { BaseError } from "@/lib/errors";
 
 export class StripeMoney {
-  private readonly amount: number;
-  private readonly currency: string;
+  public readonly amount: number;
+  public readonly currency: string;
 
   static ValdationError = BaseError.subclass("ValidationError");
 
@@ -24,30 +24,20 @@ export class StripeMoney {
       return err(new StripeMoney.ValdationError("Currency code must be 3 characters long"));
     }
 
-    if (currencyCodesData.code(args.currency) === undefined) {
+    const currencyCodeData = currencyCodesData.code(args.currency);
+
+    if (currencyCodeData === undefined) {
       return err(new StripeMoney.ValdationError("Currency code is not supported"));
     }
+    const convertedAmount = currencyJs(args.amount, {
+      precision: currencyCodeData.digits,
+    });
 
     return ok(
       new StripeMoney({
-        amount: args.amount,
-        currency: args.currency,
+        amount: convertedAmount.intValue,
+        currency: args.currency.toLowerCase(),
       }),
     );
-  }
-
-  getAmount() {
-    const currencyCodeData = currencyCodesData.code(this.currency);
-
-    const amount = currencyJs(this.amount, {
-      // currencyCodeData will be defined at this point
-      precision: currencyCodeData!.digits,
-    });
-
-    return amount.intValue;
-  }
-
-  getCurrency() {
-    return this.currency.toLowerCase();
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1584,6 +1584,12 @@ importers:
       '@vercel/otel':
         specifier: 'catalog:'
         version: 1.10.1(@opentelemetry/api-logs@0.57.2)(@opentelemetry/api@1.9.0)(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))
+      currency-codes:
+        specifier: 2.2.0
+        version: 2.2.0
+      currency.js:
+        specifier: 2.0.4
+        version: 2.0.4
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.7.1)
@@ -6848,6 +6854,13 @@ packages:
     resolution: {integrity: sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==}
     engines: {node: '>= 0.1.90'}
 
+  currency-codes@2.2.0:
+    resolution: {integrity: sha512-vpbQc5sEYHGdTVAYUhHnKv0DWiYLRvzl/KKyqeHzBh7HD/j3UlWoScpZ9tN/jG6w2feddWoObsBbaNVu5yDapg==}
+
+  currency.js@2.0.4:
+    resolution: {integrity: sha512-6/OplJYgJ0RUlli74d93HJ/OsKVBi8lB1+Z6eJYS1YZzBuIp4qKKHpJ7ad+GvTlWmLR/hLJOWTykN5Nm8NJ7+w==}
+    engines: {node: '>=4'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -7590,6 +7603,9 @@ packages:
 
   find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
+
+  first-match@0.0.1:
+    resolution: {integrity: sha512-VvKbnaxrC0polTFDC+teKPTdl2mn6B/KUW+WB3C9RzKDeNwbzfLdnUz3FxC+tnjvus6bI0jWrWicQyVIPdS37A==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -9214,6 +9230,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nub@0.0.0:
+    resolution: {integrity: sha512-dK0Ss9C34R/vV0FfYJXuqDAqHlaW9fvWVufq9MmGF2umCuDbd5GRfRD9fpi/LiM0l4ZXf8IBB+RYmZExqCrf0w==}
 
   null-loader@4.0.1:
     resolution: {integrity: sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==}
@@ -17895,6 +17914,13 @@ snapshots:
       csv-stringify: 5.6.5
       stream-transform: 2.1.3
 
+  currency-codes@2.2.0:
+    dependencies:
+      first-match: 0.0.1
+      nub: 0.0.0
+
+  currency.js@2.0.4: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@3.0.2:
@@ -18784,6 +18810,8 @@ snapshots:
     dependencies:
       micromatch: 4.0.8
       pkg-dir: 4.2.0
+
+  first-match@0.0.1: {}
 
   flat-cache@4.0.1:
     dependencies:
@@ -20722,6 +20750,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nub@0.0.0: {}
 
   null-loader@4.0.1(webpack@5.82.1):
     dependencies:


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
- Introduced `SaleorMoney` and `StripeMoney` classes for currency conversion and validation.
- Updated `TransactionInitializeSessionUseCase` to utilize new money classes.
- Enhanced integration tests to cover currency validation scenarios.
- Added dependencies for currency handling in `package.json`.
## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
