### PR TITLE
Add eslint rule for unused vars

### DIFF
--- a/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
@@ -67,7 +67,7 @@ export const customerCreatedWebhook = new SaleorAsyncWebhook<CustomerCreatedWebh
 );
 
 const handler: NextJsWebhookHandler<CustomerCreatedWebhookPayloadFragment> = async (
-  req,
+  _req,
   res,
   context,
 ) => {

--- a/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
@@ -73,7 +73,7 @@ export const fulfillmentCreatedWebhook =
   });
 
 const handler: NextJsWebhookHandler<FulfillmentCreatedWebhookPayloadFragment> = async (
-  req,
+  _req,
   res,
   context,
 ) => {

--- a/apps/klaviyo/src/pages/api/webhooks/order-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-created.ts
@@ -43,7 +43,7 @@ export const orderCreatedWebhook = new SaleorAsyncWebhook<OrderCreatedWebhookPay
 });
 
 const handler: NextJsWebhookHandler<OrderCreatedWebhookPayloadFragment> = async (
-  req,
+  _req,
   res,
   context,
 ) => {

--- a/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
@@ -43,7 +43,7 @@ export const orderFullyPaidWebhook = new SaleorAsyncWebhook<OrderFullyPaidWebhoo
 });
 
 const handler: NextJsWebhookHandler<OrderFullyPaidWebhookPayloadFragment> = async (
-  req,
+  _req,
   res,
   context,
 ) => {

--- a/apps/stripe/package.json
+++ b/apps/stripe/package.json
@@ -27,9 +27,7 @@
     }
   },
   "dependencies": {
-    "react-hook-form": "^7.43.9",
     "@hookform/resolvers": "^3.3.1",
-    "@saleor/react-hook-form-macaw": "workspace:*",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/api-logs": "catalog:",
     "@opentelemetry/instrumentation": "catalog:",
@@ -44,6 +42,7 @@
     "@saleor/apps-trpc": "workspace:*",
     "@saleor/apps-ui": "workspace:*",
     "@saleor/macaw-ui": "catalog:",
+    "@saleor/react-hook-form-macaw": "workspace:*",
     "@sentry/cli": "catalog:",
     "@sentry/nextjs": "catalog:",
     "@t3-oss/env-nextjs": "0.11.1",
@@ -61,6 +60,7 @@
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-hook-form": "^7.43.9",
     "stripe": "18.0.0",
     "urql": "catalog:",
     "usehooks-ts": "^2.9.1",

--- a/apps/stripe/src/app/api/saleor/transaction-initialize-session/route.ts
+++ b/apps/stripe/src/app/api/saleor/transaction-initialize-session/route.ts
@@ -19,7 +19,7 @@ const useCase = new TransactionInitializeSessionUseCase({
   stripePaymentIntentsApiFactory: new StripePaymentIntentsApiFactory(),
 });
 
-const handler = transactionInitializeSessionWebhookDefinition.createHandler(async (req, ctx) => {
+const handler = transactionInitializeSessionWebhookDefinition.createHandler(async (_req, ctx) => {
   try {
     const saleorApiUrlResult = createSaleorApiUrl(ctx.authData.saleorApiUrl);
 

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -90,6 +90,18 @@ export const config = [
       "no-console": "error",
       "@saleor/saleor-app/logger-leak": "error",
       "react-naming-convention/filename": ["error", { rule: "kebab-case" }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Based on https://typescript-eslint.io/rules/no-unused-vars/#what-benefits-does-this-rule-have-over-typescript so unused vars can be renamed to `_VARNAME`

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
