### PR TITLE
Improve Stripe webhook error handling with error cause

### DIFF
--- a/apps/stripe/src/modules/saleor/transaction-event-reporter.test.ts
+++ b/apps/stripe/src/modules/saleor/transaction-event-reporter.test.ts
@@ -42,7 +42,10 @@ describe("TransactionEventReporter", () => {
     });
 
     expect(result._unsafeUnwrapErr()).toMatchInlineSnapshot(
-      `[TransactionEventReporter.AlreadyReportedError: Event already reported]`,
+      `
+      [TransactionEventReporter.AlreadyReportedError: Transaction with this pspReference already exists
+      Event already reported]
+    `,
     );
   });
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly changed made in this PR -->
Instead of passing server error from urql as a cause I changed and pass graphql error from mutation as cause

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
