### PR TITLE
Add bulk processing for Strapi CMS provider

### DIFF
--- a/.changeset/angry-dots-jog.md
+++ b/.changeset/angry-dots-jog.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-cms": minor
+---
+
+Added bulk processing of uploading products to Strapi CMS. After this change you can use `STRAPI_BATCH_SIZE` to control number to request send in the same batch to Strapi API with `STRAPI_MILIS_DELAY_BETWEEN_BATCHES` controlling how frequent those batches are send to Strapi API.

--- a/apps/cms/src/modules/bulk-sync/bulk-sync-view.tsx
+++ b/apps/cms/src/modules/bulk-sync/bulk-sync-view.tsx
@@ -100,7 +100,7 @@ export const BulkSyncView = ({
       onUploadSuccess({ variantId }) {
         setItemStatus(variantId, "success");
       },
-      onUploadError({ error, variantId }) {
+      onUploadError({ variantId }) {
         // User will be notified about the error in the UI
         setItemStatus(variantId, "error");
       },
@@ -146,7 +146,6 @@ export const BulkSyncView = ({
             }
 
             case "fetched":
-
             case "uploading": {
               return (
                 <SaleorProductsFetchedStep

--- a/apps/cms/src/modules/providers/strapi/strapi-bulk-sync-processor.ts
+++ b/apps/cms/src/modules/providers/strapi/strapi-bulk-sync-processor.ts
@@ -11,7 +11,7 @@ type VariantToProcess = {
 export class StrapiBulkSyncProcessor implements BulkSyncProcessor {
   private batchSize = process.env.STRAPI_BATCH_SIZE
     ? parseInt(process.env.STRAPI_BATCH_SIZE, 10)
-    : 10;
+    : 50;
   private delayBetweenBatches = process.env.STRAPI_MILIS_DELAY_BETWEEN_BATCHES
     ? parseInt(process.env.STRAPI_MILIS_DELAY_BETWEEN_BATCHES, 10)
     : 1_000;

--- a/apps/cms/src/modules/providers/strapi/strapi-bulk-sync-processor.ts
+++ b/apps/cms/src/modules/providers/strapi/strapi-bulk-sync-processor.ts
@@ -3,8 +3,30 @@ import { BulkSyncProcessor, BulkSyncProcessorHooks } from "../../bulk-sync/bulk-
 import { StrapiProviderConfig } from "../../configuration";
 import { StrapiClient } from "./strapi-client";
 
+type VariantToProcess = {
+  variant: NonNullable<BulkImportProductFragment["variants"]>[number];
+  product: BulkImportProductFragment;
+};
+
 export class StrapiBulkSyncProcessor implements BulkSyncProcessor {
+  private batchSize = process.env.STRAPI_BATCH_SIZE
+    ? parseInt(process.env.STRAPI_BATCH_SIZE, 10)
+    : 10;
+  private delayBetweenBatches = process.env.STRAPI_MILIS_DELAY_BETWEEN_BATCHES
+    ? parseInt(process.env.STRAPI_MILIS_DELAY_BETWEEN_BATCHES, 10)
+    : 1_000;
+
   constructor(private config: StrapiProviderConfig.FullShape) {}
+
+  private createBatches(products: VariantToProcess[]): VariantToProcess[][] {
+    const batches: VariantToProcess[][] = [];
+
+    for (let i = 0; i < products.length; i += this.batchSize) {
+      batches.push(products.slice(i, i + this.batchSize));
+    }
+
+    return batches;
+  }
 
   async uploadProducts(
     products: BulkImportProductFragment[],
@@ -15,39 +37,57 @@ export class StrapiBulkSyncProcessor implements BulkSyncProcessor {
       url: this.config.url,
     });
 
-    products.flatMap(
+    const variantsToProcess = products.flatMap(
       (product) =>
-        product.variants?.map((variant) => {
-          if (hooks.onUploadStart) {
-            hooks.onUploadStart({ variantId: variant.id });
-          }
-
-          return client
-            .upsertProduct({
-              configuration: this.config,
-              variant: {
-                id: variant.id,
-                name: variant.name,
-                channelListings: variant.channelListings,
-                sku: variant.sku,
-                product: {
-                  id: product.id,
-                  name: product.name,
-                  slug: product.slug,
-                },
-              },
-            })
-            .then((r) => {
-              if (hooks.onUploadSuccess) {
-                hooks.onUploadSuccess({ variantId: variant.id });
-              }
-            })
-            .catch((e) => {
-              if (hooks.onUploadError) {
-                hooks.onUploadError({ variantId: variant.id, error: e });
-              }
-            });
-        }),
+        product.variants?.map((variant) => ({
+          variant,
+          product,
+        })) || [],
     );
+
+    const batches = this.createBatches(variantsToProcess);
+
+    await batches.reduce(async (previousBatch, currentBatch, index) => {
+      await previousBatch;
+
+      const batchPromises = currentBatch.map(async ({ variant, product }) => {
+        if (hooks.onUploadStart) {
+          hooks.onUploadStart({ variantId: variant.id });
+        }
+
+        try {
+          await client.upsertProduct({
+            configuration: this.config,
+            variant: {
+              id: variant.id,
+              name: variant.name,
+              channelListings: variant.channelListings,
+              sku: variant.sku,
+              product: {
+                id: product.id,
+                name: product.name,
+                slug: product.slug,
+              },
+            },
+          });
+
+          if (hooks.onUploadSuccess) {
+            hooks.onUploadSuccess({ variantId: variant.id });
+          }
+        } catch (e) {
+          if (hooks.onUploadError) {
+            const error = e instanceof Error ? e : new Error(String(e));
+
+            hooks.onUploadError({ variantId: variant.id, error });
+          }
+        }
+      });
+
+      await Promise.all(batchPromises);
+
+      if (index < batches.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, this.delayBetweenBatches));
+      }
+    }, Promise.resolve());
   }
 }

--- a/apps/cms/turbo.json
+++ b/apps/cms/turbo.json
@@ -13,7 +13,9 @@
         "REST_APL_TOKEN",
         "SECRET_KEY",
         "SENTRY_AUTH_TOKEN",
-        "SENTRY_PROJECT"
+        "SENTRY_PROJECT",
+        "STRAPI_BATCH_SIZE",
+        "STRAPI_MILIS_DELAY_BETWEEN_BATCHES"
       ]
     }
   }


### PR DESCRIPTION
## Scope of the PR
Added bulk processing of uploading products to Strapi CMS. After this change you can use `STRAPI_BATCH_SIZE` to control number to request send in the same batch to Strapi API with `STRAPI_MILIS_DELAY_BETWEEN_BATCHES` controlling how frequent those batches are send to Strapi API.

This is in preview - after we confirm that batching works for clients we can add global setting for other providers.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
