### PR TITLE
Refactor Stripe tests mocks

### DIFF
--- a/apps/stripe/src/__tests__/integration/webhooks/fixtures/transaction-initialize-session-fixture.ts
+++ b/apps/stripe/src/__tests__/integration/webhooks/fixtures/transaction-initialize-session-fixture.ts
@@ -1,7 +1,7 @@
 import {
   mockedSaleorAppId,
   mockedSaleorChannelId,
-  mockedSaleorTransactionIdBranded,
+  mockedSaleorTransactionId,
 } from "@/__tests__/mocks/constants";
 import { parseTransactionInitializeSessionEventData } from "@/app/api/webhooks/saleor/transaction-initialize-session/event-data-parser";
 import { TransactionInitializeSessionEventFragment } from "@/generated/graphql";
@@ -32,7 +32,7 @@ export const transactionInitializeSessionFixture =
       },
       idempotencyKey: "123",
       transaction: {
-        id: mockedSaleorTransactionIdBranded,
+        id: mockedSaleorTransactionId,
       },
     };
   };

--- a/apps/stripe/src/__tests__/integration/webhooks/transaction-cancelation-requested.test.ts
+++ b/apps/stripe/src/__tests__/integration/webhooks/transaction-cancelation-requested.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockedSaleorAppId,
   mockedSaleorChannelId,
-  mockedSaleorTransactionIdBranded,
+  mockedSaleorTransactionId,
 } from "@/__tests__/mocks/constants";
 import { mockStripeWebhookSecret } from "@/__tests__/mocks/stripe-webhook-secret";
 import * as cancelationRequestedHandlers from "@/app/api/webhooks/saleor/transaction-cancelation-requested/route";
@@ -129,7 +129,7 @@ describe("TransactionCancellationRequested webhook: integration", async () => {
         appId: mockedSaleorAppId,
       },
       new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),

--- a/apps/stripe/src/__tests__/integration/webhooks/transaction-charge-requested.test.ts
+++ b/apps/stripe/src/__tests__/integration/webhooks/transaction-charge-requested.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockedSaleorAppId,
   mockedSaleorChannelId,
-  mockedSaleorTransactionIdBranded,
+  mockedSaleorTransactionId,
 } from "@/__tests__/mocks/constants";
 import { mockStripeWebhookSecret } from "@/__tests__/mocks/stripe-webhook-secret";
 import * as chargeRequestedHandlers from "@/app/api/webhooks/saleor/transaction-charge-requested/route";
@@ -134,7 +134,7 @@ describe("TransactionChargeRequested webhook: integration", async () => {
         appId: mockedSaleorAppId,
       },
       new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),

--- a/apps/stripe/src/__tests__/integration/webhooks/transaction-process-session.test.ts
+++ b/apps/stripe/src/__tests__/integration/webhooks/transaction-process-session.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockedSaleorAppId,
   mockedSaleorChannelId,
-  mockedSaleorTransactionIdBranded,
+  mockedSaleorTransactionId,
 } from "@/__tests__/mocks/constants";
 import { mockStripeWebhookSecret } from "@/__tests__/mocks/stripe-webhook-secret";
 import * as transactionProcessSession from "@/app/api/webhooks/saleor/transaction-process-session/route";
@@ -131,7 +131,7 @@ describe("TransactionProcessSession webhook: integration", async () => {
         appId: mockedSaleorAppId,
       },
       new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId,
         saleorTransactionFlow,
         resolvedTransactionFlow,
@@ -202,7 +202,7 @@ describe("TransactionProcessSession webhook: integration", async () => {
         appId: mockedSaleorAppId,
       },
       new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId,
         saleorTransactionFlow,
         resolvedTransactionFlow,

--- a/apps/stripe/src/__tests__/integration/webhooks/transaction-refund-requested.test.ts
+++ b/apps/stripe/src/__tests__/integration/webhooks/transaction-refund-requested.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockedSaleorAppId,
   mockedSaleorChannelId,
-  mockedSaleorTransactionIdBranded,
+  mockedSaleorTransactionId,
 } from "@/__tests__/mocks/constants";
 import { mockStripeWebhookSecret } from "@/__tests__/mocks/stripe-webhook-secret";
 import * as transactionRefundRequested from "@/app/api/webhooks/saleor/transaction-refund-requested/route";
@@ -128,7 +128,7 @@ describe("TransactionRefundRequested webhook: integration", async () => {
         appId: mockedSaleorAppId,
       },
       new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),

--- a/apps/stripe/src/__tests__/mocks/constants.ts
+++ b/apps/stripe/src/__tests__/mocks/constants.ts
@@ -13,11 +13,7 @@ export const mockAdyenWebhookUrl = `${mockAppUrlBase}?${new URLSearchParams({
   [WebhookParams.configurationIdIdSearchParam]: mockedConfigurationId,
   [WebhookParams.appIdSearchParam]: mockedSaleorAppId,
 }).toString()}`;
-/**
- *  @deprecated - use `mockedSaleorTransactionIdBranded` instead
- */
-export const mockedSaleorTransactionId = "mocked-transaction-id";
-export const mockedSaleorTransactionIdBranded = createSaleorTransactionId("mocked-transaction-id");
+export const mockedSaleorTransactionId = createSaleorTransactionId("mocked-transaction-id");
 
 export const getMockedSaleorMoney = (amount: number = 10_00, currency: string = "usd") =>
   SaleorMoney.createFromStripe({

--- a/apps/stripe/src/__tests__/mocks/mocked-recorded-transaction.ts
+++ b/apps/stripe/src/__tests__/mocks/mocked-recorded-transaction.ts
@@ -1,4 +1,4 @@
-import { mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import {
   createResolvedTransactionFlow,
@@ -23,7 +23,7 @@ type Params = {
 
 export const getMockedRecordedTransaction = (params?: Params): RecordedTransaction => {
   const finalParams = {
-    saleorTransactionId: mockedSaleorTransactionIdBranded,
+    saleorTransactionId: mockedSaleorTransactionId,
     stripePaymentIntentId: mockedStripePaymentIntentId,
     saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
     resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),

--- a/apps/stripe/src/__tests__/mocks/saleor-events/transaction-cancelation-request-event.ts
+++ b/apps/stripe/src/__tests__/mocks/saleor-events/transaction-cancelation-request-event.ts
@@ -1,7 +1,7 @@
 import { TransactionCancelationRequestedEventFragment } from "@/generated/graphql";
 
-import { mockedSaleorChannelId } from "./constants";
-import { mockedStripePaymentIntentId } from "./mocked-stripe-payment-intent-id";
+import { mockedSaleorChannelId } from "../constants";
+import { mockedStripePaymentIntentId } from "../mocked-stripe-payment-intent-id";
 
 export const getMockedTransactionCancelationRequestedEvent =
   (): TransactionCancelationRequestedEventFragment => ({

--- a/apps/stripe/src/__tests__/mocks/saleor-events/transaction-charge-requested-event.ts
+++ b/apps/stripe/src/__tests__/mocks/saleor-events/transaction-charge-requested-event.ts
@@ -1,7 +1,7 @@
 import { TransactionChargeRequestedEventFragment } from "@/generated/graphql";
 
-import { mockedSaleorChannelId } from "./constants";
-import { mockedStripePaymentIntentId } from "./mocked-stripe-payment-intent-id";
+import { mockedSaleorChannelId } from "../constants";
+import { mockedStripePaymentIntentId } from "../mocked-stripe-payment-intent-id";
 
 export const getMockedTransactionChargeRequestedEvent =
   (): TransactionChargeRequestedEventFragment => ({

--- a/apps/stripe/src/__tests__/mocks/saleor-events/transaction-initialize-session-event.ts
+++ b/apps/stripe/src/__tests__/mocks/saleor-events/transaction-initialize-session-event.ts
@@ -1,7 +1,7 @@
 import { parseTransactionInitializeSessionEventData } from "@/app/api/webhooks/saleor/transaction-initialize-session/event-data-parser";
 import { TransactionInitializeSessionEventFragment } from "@/generated/graphql";
 
-import { mockedSaleorChannelId, mockedSaleorTransactionId } from "./constants";
+import { mockedSaleorChannelId, mockedSaleorTransactionId } from "../constants";
 
 export const getMockedTransactionInitializeSessionEvent = (args?: {
   actionType: "CHARGE" | "AUTHORIZATION";

--- a/apps/stripe/src/__tests__/mocks/saleor-events/transaction-process-session-event.ts
+++ b/apps/stripe/src/__tests__/mocks/saleor-events/transaction-process-session-event.ts
@@ -1,7 +1,7 @@
 import { TransactionProcessSessionEventFragment } from "@/generated/graphql";
 
-import { mockedSaleorChannelId } from "./constants";
-import { mockedStripePaymentIntentId } from "./mocked-stripe-payment-intent-id";
+import { mockedSaleorChannelId } from "../constants";
+import { mockedStripePaymentIntentId } from "../mocked-stripe-payment-intent-id";
 
 export const getMockedTransactionProcessSessionEvent = (args?: {
   actionType: "CHARGE" | "AUTHORIZATION";

--- a/apps/stripe/src/__tests__/mocks/saleor-events/transaction-refund-request-event.ts
+++ b/apps/stripe/src/__tests__/mocks/saleor-events/transaction-refund-request-event.ts
@@ -1,7 +1,7 @@
 import { TransactionRefundRequestedEventFragment } from "@/generated/graphql";
 
-import { mockedSaleorChannelId } from "./constants";
-import { mockedStripePaymentIntentId } from "./mocked-stripe-payment-intent-id";
+import { mockedSaleorChannelId } from "../constants";
+import { mockedStripePaymentIntentId } from "../mocked-stripe-payment-intent-id";
 
 export const getMockedTransactionRefundRequestedEvent =
   (): TransactionRefundRequestedEventFragment => ({

--- a/apps/stripe/src/app/api/webhooks/saleor/transaction-cancelation-requested/use-case.test.ts
+++ b/apps/stripe/src/app/api/webhooks/saleor/transaction-cancelation-requested/use-case.test.ts
@@ -7,7 +7,7 @@ import { mockedSaleorAppId } from "@/__tests__/mocks/constants";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { mockedStripePaymentIntentsApi } from "@/__tests__/mocks/mocked-stripe-payment-intents-api";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
-import { getMockedTransactionCancelationRequestedEvent } from "@/__tests__/mocks/transaction-cancelation-request-event";
+import { getMockedTransactionCancelationRequestedEvent } from "@/__tests__/mocks/saleor-events/transaction-cancelation-request-event";
 import {
   AppIsNotConfiguredResponse,
   BrokenAppResponse,

--- a/apps/stripe/src/app/api/webhooks/saleor/transaction-charge-requested/use-case.test.ts
+++ b/apps/stripe/src/app/api/webhooks/saleor/transaction-charge-requested/use-case.test.ts
@@ -7,7 +7,7 @@ import { mockedSaleorAppId } from "@/__tests__/mocks/constants";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { mockedStripePaymentIntentsApi } from "@/__tests__/mocks/mocked-stripe-payment-intents-api";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
-import { getMockedTransactionChargeRequestedEvent } from "@/__tests__/mocks/transaction-charge-requested-event";
+import { getMockedTransactionChargeRequestedEvent } from "@/__tests__/mocks/saleor-events/transaction-charge-requested-event";
 import {
   AppIsNotConfiguredResponse,
   BrokenAppResponse,

--- a/apps/stripe/src/app/api/webhooks/saleor/transaction-initialize-session/use-case.test.ts
+++ b/apps/stripe/src/app/api/webhooks/saleor/transaction-initialize-session/use-case.test.ts
@@ -7,7 +7,7 @@ import { mockedSaleorAppId } from "@/__tests__/mocks/constants";
 import { mockedStripePaymentIntentsApi } from "@/__tests__/mocks/mocked-stripe-payment-intents-api";
 import { MockedTransactionRecorder } from "@/__tests__/mocks/mocked-transaction-recorder";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
-import { getMockedTransactionInitializeSessionEvent } from "@/__tests__/mocks/transaction-initialize-session-event";
+import { getMockedTransactionInitializeSessionEvent } from "@/__tests__/mocks/saleor-events/transaction-initialize-session-event";
 import {
   AppIsNotConfiguredResponse,
   BrokenAppResponse,

--- a/apps/stripe/src/app/api/webhooks/saleor/transaction-process-session/use-case.test.ts
+++ b/apps/stripe/src/app/api/webhooks/saleor/transaction-process-session/use-case.test.ts
@@ -10,7 +10,7 @@ import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-pay
 import { mockedStripePaymentIntentsApi } from "@/__tests__/mocks/mocked-stripe-payment-intents-api";
 import { MockedTransactionRecorder } from "@/__tests__/mocks/mocked-transaction-recorder";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
-import { getMockedTransactionProcessSessionEvent } from "@/__tests__/mocks/transaction-process-session-event";
+import { getMockedTransactionProcessSessionEvent } from "@/__tests__/mocks/saleor-events/transaction-process-session-event";
 import {
   AppIsNotConfiguredResponse,
   BrokenAppResponse,

--- a/apps/stripe/src/app/api/webhooks/saleor/transaction-refund-requested/use-case.test.ts
+++ b/apps/stripe/src/app/api/webhooks/saleor/transaction-refund-requested/use-case.test.ts
@@ -8,7 +8,7 @@ import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-pay
 import { mockedStripeRefundId } from "@/__tests__/mocks/mocked-stripe-refund-id";
 import { mockedStripeRefundsApi } from "@/__tests__/mocks/mocked-stripe-refunds-api";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
-import { getMockedTransactionRefundRequestedEvent } from "@/__tests__/mocks/transaction-refund-request-event";
+import { getMockedTransactionRefundRequestedEvent } from "@/__tests__/mocks/saleor-events/transaction-refund-request-event";
 import {
   AppIsNotConfiguredResponse,
   BrokenAppResponse,

--- a/apps/stripe/src/app/api/webhooks/stripe/transaction-event-report-variables-resolver.test.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/transaction-event-report-variables-resolver.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getMockedSaleorMoney,
-  mockedSaleorTransactionIdBranded,
-} from "@/__tests__/mocks/constants";
+import { getMockedSaleorMoney, mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { getMockedPaymentIntentDashboardUrl } from "@/__tests__/mocks/mocked-payment-intent-dashboard-url";
 import { getMockedRefundDashboardUrl } from "@/__tests__/mocks/mocked-refund-dashboard-url";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
@@ -44,7 +41,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       externalUrl: getMockedPaymentIntentDashboardUrl({
         stripeEnv: "LIVE",
       }),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -77,7 +74,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       externalUrl: getMockedPaymentIntentDashboardUrl({
         stripeEnv: "LIVE",
       }),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -113,7 +110,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       }),
       saleorMoney: getMockedSaleorMoney(),
       transactionResult,
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -148,7 +145,7 @@ describe("TransactionEventReportVariablesResolver", () => {
         stripeEnv: "LIVE",
       }),
       transactionResult,
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -179,7 +176,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       stripeObjectId: mockedStripePaymentIntentId,
       externalUrl: getMockedPaymentIntentDashboardUrl(),
       transactionResult,
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -208,7 +205,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       stripeObjectId: mockedStripePaymentIntentId,
       externalUrl: getMockedPaymentIntentDashboardUrl(),
       transactionResult,
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -239,7 +236,7 @@ describe("TransactionEventReportVariablesResolver", () => {
         stripeEnv: "LIVE",
       }),
       transactionResult,
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -272,7 +269,7 @@ describe("TransactionEventReportVariablesResolver", () => {
         stripeEnv: "LIVE",
       }),
       saleorMoney: getMockedSaleorMoney(),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -303,7 +300,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       stripeObjectId: mockedStripeRefundId,
       externalUrl: getMockedRefundDashboardUrl(),
       saleorMoney: getMockedSaleorMoney(),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -334,7 +331,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       stripeObjectId: mockedStripeRefundId,
       externalUrl: getMockedRefundDashboardUrl(),
       saleorMoney: getMockedSaleorMoney(),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 
@@ -365,7 +362,7 @@ describe("TransactionEventReportVariablesResolver", () => {
       stripeObjectId: mockedStripeRefundId,
       externalUrl: getMockedRefundDashboardUrl(),
       saleorMoney: getMockedSaleorMoney(),
-      saleorTransactionId: mockedSaleorTransactionIdBranded,
+      saleorTransactionId: mockedSaleorTransactionId,
       timestamp: new Date("2023-10-01T00:00:00Z"),
     });
 

--- a/apps/stripe/src/app/api/webhooks/stripe/use-case-error.test.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/use-case-error.test.ts
@@ -4,7 +4,7 @@ import Stripe from "stripe";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mockedAppConfigRepo } from "@/__tests__/mocks/app-config-repo";
-import { mockAdyenWebhookUrl, mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockAdyenWebhookUrl, mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { mockAuthData } from "@/__tests__/mocks/mock-auth-data";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { MockedTransactionRecorder } from "@/__tests__/mocks/mocked-transaction-recorder";
@@ -166,7 +166,7 @@ describe("StripeWebhookUseCase - Error cases", () => {
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -214,7 +214,7 @@ describe("StripeWebhookUseCase - Error cases", () => {
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),

--- a/apps/stripe/src/app/api/webhooks/stripe/use-case-success.test.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/use-case-success.test.ts
@@ -3,7 +3,7 @@ import { ok } from "neverthrow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mockedAppConfigRepo } from "@/__tests__/mocks/app-config-repo";
-import { mockAdyenWebhookUrl, mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockAdyenWebhookUrl, mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { mockAuthData } from "@/__tests__/mocks/mock-auth-data";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { MockedTransactionRecorder } from "@/__tests__/mocks/mocked-transaction-recorder";
@@ -74,7 +74,7 @@ describe("StripeWebhookUseCase - handling payment_intent.success event", () => {
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -141,7 +141,7 @@ describe("StripeWebhookUseCase - handling payment_intent.success event", () => {
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -227,7 +227,7 @@ describe("StripeWebhookUseCase - handling payment_intent.amount_capturable_updat
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -313,7 +313,7 @@ describe("StripeWebhookUseCase - handling payment_intent.payment_failed event", 
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -380,7 +380,7 @@ describe("StripeWebhookUseCase - handling payment_intent.payment_failed event", 
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -465,7 +465,7 @@ describe("StripeWebhookUseCase - handling payment_intent.processing event", () =
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -530,7 +530,7 @@ describe("StripeWebhookUseCase - handling payment_intent.processing event", () =
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -613,7 +613,7 @@ describe("StripeWebhookUseCase - handling payment_intent.requires_action event",
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -680,7 +680,7 @@ describe("StripeWebhookUseCase - handling payment_intent.requires_action event",
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -765,7 +765,7 @@ describe("StripeWebhookUseCase - handling payment_intent.canceled event", () => 
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -830,7 +830,7 @@ describe("StripeWebhookUseCase - handling payment_intent.canceled event", () => 
 
     mockTransactionRecorder.transactions = {
       [stripePiId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: stripePiId,
         saleorTransactionFlow: createSaleorTransactionFlow("AUTHORIZATION"),
         resolvedTransactionFlow: createResolvedTransactionFlow("AUTHORIZATION"),
@@ -912,7 +912,7 @@ describe("StripeWebhookUseCase - handling charge.refund.updated event", () => {
 
     mockTransactionRecorder.transactions = {
       [mockedStripePaymentIntentId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: mockedStripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -980,7 +980,7 @@ describe("StripeWebhookUseCase - handling charge.refund.updated event", () => {
 
     mockTransactionRecorder.transactions = {
       [mockedStripePaymentIntentId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: mockedStripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),
@@ -1048,7 +1048,7 @@ describe("StripeWebhookUseCase - handling charge.refund.updated event", () => {
 
     mockTransactionRecorder.transactions = {
       [mockedStripePaymentIntentId]: new RecordedTransaction({
-        saleorTransactionId: mockedSaleorTransactionIdBranded,
+        saleorTransactionId: mockedSaleorTransactionId,
         stripePaymentIntentId: mockedStripePaymentIntentId,
         saleorTransactionFlow: createSaleorTransactionFlow("CHARGE"),
         resolvedTransactionFlow: createResolvedTransactionFlow("CHARGE"),

--- a/apps/stripe/src/modules/stripe/stripe-payment-intents-api.test.ts
+++ b/apps/stripe/src/modules/stripe/stripe-payment-intents-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { mockedStripeRestrictedKey } from "@/__tests__/mocks/mocked-stripe-restricted-key";
 import { StripeClient } from "@/modules/stripe/stripe-client";
 import { StripeMoney } from "@/modules/stripe/stripe-money";
@@ -27,7 +27,7 @@ describe("StripePaymentIntentsApi", () => {
         metadata: {
           saleor_source_id: "checkout-id",
           saleor_source_type: "Checkout",
-          saleor_transaction_id: mockedSaleorTransactionIdBranded,
+          saleor_transaction_id: mockedSaleorTransactionId,
         },
         intentParams: {
           automatic_payment_methods: { enabled: true },

--- a/apps/stripe/src/modules/transactions-recording/repositories/dynamodb/dynamodb-transaction-recorder-repo.test.ts
+++ b/apps/stripe/src/modules/transactions-recording/repositories/dynamodb/dynamodb-transaction-recorder-repo.test.ts
@@ -2,7 +2,7 @@ import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dyn
 import { mockClient } from "aws-sdk-client-mock";
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { mockedSaleorAppId, mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockedSaleorAppId, mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { getMockedRecordedTransaction } from "@/__tests__/mocks/mocked-recorded-transaction";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
@@ -89,7 +89,7 @@ describe("DynamoDBTransactionRecorderRepo", () => {
             PK: "https://foo.bar.saleor.cloud/graphql/#saleor-app-id",
             SK: "TRANSACTION#pi_TEST_TEST_TEST",
             paymentIntentId: mockedStripePaymentIntentId,
-            saleorTransactionId: mockedSaleorTransactionIdBranded,
+            saleorTransactionId: mockedSaleorTransactionId,
             saleorTransactionFlow: "CHARGE",
             resolvedTransactionFlow: "CHARGE",
             selectedPaymentMethod: "card",

--- a/apps/stripe/src/modules/transactions-recording/repositories/dynamodb/recorded-transaction-db-model.test.ts
+++ b/apps/stripe/src/modules/transactions-recording/repositories/dynamodb/recorded-transaction-db-model.test.ts
@@ -1,7 +1,7 @@
 import { Parser } from "dynamodb-toolbox";
 import { describe, expect, it } from "vitest";
 
-import { mockedSaleorAppId, mockedSaleorTransactionIdBranded } from "@/__tests__/mocks/constants";
+import { mockedSaleorAppId, mockedSaleorTransactionId } from "@/__tests__/mocks/constants";
 import { mockAuthData } from "@/__tests__/mocks/mock-auth-data";
 import { mockedStripePaymentIntentId } from "@/__tests__/mocks/mocked-stripe-payment-intent-id";
 import { mockedSaleorApiUrl } from "@/__tests__/mocks/saleor-api-url";
@@ -30,8 +30,8 @@ describe("DynamoDbRecordedTransaction", () => {
       expect(() =>
         parser.parse({
           PK: `${mockedSaleorApiUrl}#${mockedSaleorAppId}`,
-          SK: `TRANSACTION#${mockedSaleorTransactionIdBranded}`,
-          saleorTransactionId: mockedSaleorTransactionIdBranded,
+          SK: `TRANSACTION#${mockedSaleorTransactionId}`,
+          saleorTransactionId: mockedSaleorTransactionId,
           saleorTransactionFlow: "AUTHORIZATION",
           resolvedTransactionFlow: "CHARGE",
           selectedPaymentMethod: "card",
@@ -41,9 +41,9 @@ describe("DynamoDbRecordedTransaction", () => {
       expect(
         parser.parse({
           PK: `${mockedSaleorApiUrl}#${mockedSaleorAppId}`,
-          SK: `TRANSACTION#${mockedSaleorTransactionIdBranded}`,
+          SK: `TRANSACTION#${mockedSaleorTransactionId}`,
           paymentIntentId: mockedStripePaymentIntentId,
-          saleorTransactionId: mockedSaleorTransactionIdBranded,
+          saleorTransactionId: mockedSaleorTransactionId,
           saleorTransactionFlow: "AUTHORIZATION",
           resolvedTransactionFlow: "CHARGE",
           selectedPaymentMethod: "card",


### PR DESCRIPTION
## Scope of the PR
* Removed deprecated `mockedSaleorTransactionId` and use branded one (with rename)
* Moved Saleor events mocks into own folder

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
