### PR TITLE
Fix Stripe PaymentIntent metadata not being passed to API

### DIFF
--- a/.changeset/fix-stripe-metadata-missing.md
+++ b/.changeset/fix-stripe-metadata-missing.md
@@ -1,0 +1,9 @@
+---
+"saleor-app-payment-stripe": patch
+---
+
+Fix missing metadata in Stripe PaymentIntent creation
+
+Fixes a critical bug where metadata (including `saleor_transaction_id`, `saleor_source_id`, and `saleor_source_type`) was not being passed to Stripe when creating PaymentIntents. This caused webhook processing to fail with "Object created outside of Saleor is not processable" error after the July 24 security update that enforces metadata validation.
+
+The metadata was being prepared correctly in the transaction-initialize-session webhook handler but was not included in the actual Stripe API call.

--- a/.changeset/fix-stripe-metadata-missing.md
+++ b/.changeset/fix-stripe-metadata-missing.md
@@ -1,9 +1,0 @@
----
-"saleor-app-payment-stripe": patch
----
-
-Fix missing metadata in Stripe PaymentIntent creation
-
-Fixes a critical bug where metadata (including `saleor_transaction_id`, `saleor_source_id`, and `saleor_source_type`) was not being passed to Stripe when creating PaymentIntents. This caused webhook processing to fail with "Object created outside of Saleor is not processable" error after the July 24 security update that enforces metadata validation.
-
-The metadata was being prepared correctly in the transaction-initialize-session webhook handler but was not included in the actual Stripe API call.

--- a/.changeset/giant-parents-collect.md
+++ b/.changeset/giant-parents-collect.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-payment-stripe": patch
+---
+
+Pass metadata to Stripe when creating PaymentIntents to fix webhook validation errors.

--- a/apps/stripe/src/modules/stripe/stripe-payment-intents-api.test.ts
+++ b/apps/stripe/src/modules/stripe/stripe-payment-intents-api.test.ts
@@ -46,11 +46,48 @@ describe("StripePaymentIntentsApi", () => {
             enabled: true,
           },
           currency: "usd",
+          metadata: {
+            saleor_source_id: "checkout-id",
+            saleor_source_type: "Checkout",
+            saleor_transaction_id: mockedSaleorTransactionId,
+          },
           payment_method_options: {
             klarna: {
               capture_method: "manual",
             },
           },
+        },
+        { idempotencyKey: "IK" },
+      );
+    });
+
+    it("Calls inner Stripe SDK without metadata when not provided", async () => {
+      const clientWrapper = StripeClient.createFromRestrictedKey(mockedStripeRestrictedKey);
+      const instance = StripePaymentIntentsApi.createFromClient(clientWrapper);
+
+      vi.spyOn(clientWrapper.nativeClient.paymentIntents, "create").mockResolvedValue(
+        // @ts-expect-error - in this test we dont care about the response
+        {},
+      );
+
+      await instance.createPaymentIntent({
+        idempotencyKey: "IK",
+        stripeMoney: StripeMoney.createFromSaleorAmount({
+          amount: 12.34,
+          currency: "USD",
+        })._unsafeUnwrap(),
+        intentParams: {
+          automatic_payment_methods: { enabled: true },
+        },
+      });
+
+      expect(clientWrapper.nativeClient.paymentIntents.create).toHaveBeenCalledExactlyOnceWith(
+        {
+          amount: 1234,
+          automatic_payment_methods: {
+            enabled: true,
+          },
+          currency: "usd",
         },
         { idempotencyKey: "IK" },
       );

--- a/apps/stripe/src/modules/stripe/stripe-payment-intents-api.ts
+++ b/apps/stripe/src/modules/stripe/stripe-payment-intents-api.ts
@@ -33,6 +33,7 @@ export class StripePaymentIntentsApi implements IStripePaymentIntentsApi {
           ...args.intentParams,
           amount: args.stripeMoney.amount,
           currency: args.stripeMoney.currency,
+          ...(args.metadata && { metadata: args.metadata }),
         },
         {
           idempotencyKey: args.idempotencyKey,


### PR DESCRIPTION
## Problem

Stripe webhooks fail with \"Object created outside of Saleor is not processable\" when processing PaymentIntents created via `transactionInitialize`.

## Solution  

Add missing metadata (saleor_transaction_id, saleor_source_id, saleor_source_type) to Stripe API call in `createPaymentIntent`.

## Details

The metadata was being prepared but not passed to Stripe's API. This issue surfaced after the July 24 security update that enforces metadata validation.

### Changes
- Pass metadata to `paymentIntents.create()` API call
- Add test coverage for metadata handling

## Test plan

- [x] Unit tests pass
- [ ] Create checkout and call `transactionInitialize`
- [ ] Verify PaymentIntent in Stripe Dashboard contains metadata
- [ ] Confirm webhook processing succeeds