### PR TITLE
Pass order number as document code

### DIFF
--- a/.changeset/chilly-oranges-dance.md
+++ b/.changeset/chilly-oranges-dance.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": minor
+---
+
+Send Saleor order number instead of order id as AvaTax document code. Previously app was using first 20 characters of order id. This was causing a problem on AvaTax side as there weren't any way of connecting Saleor order (as order id was truncated to first 20 chars). After this change app will send order number (e.g 2137) instead. Thanks to that you will see it in AvaTax dashboard and you will be able to use this number for searching for order in Saleor.

--- a/apps/avatax/src/modules/avatax/avatax-document-code-resolver.test.ts
+++ b/apps/avatax/src/modules/avatax/avatax-document-code-resolver.test.ts
@@ -8,31 +8,40 @@ const resolver = new AvataxDocumentCodeResolver();
 describe("AvataxDocumentCodeResolver", () => {
   it("returns document code when provided in metadata", () => {
     const order = {
-      id: "id",
+      number: "42",
       avataxDocumentCode: "123",
     } as unknown as OrderConfirmedSubscriptionFragment;
 
     expect(
-      resolver.resolve({ avataxDocumentCode: order.avataxDocumentCode, orderId: order.id }),
+      resolver.resolve({ avataxDocumentCode: order.avataxDocumentCode, orderNumber: order.number }),
     ).toBe("123");
   });
-  it("returns order id when document code is not provided in metadata", () => {
+
+  it("returns order number when document code is not provided in metadata", () => {
     const order = {
-      id: "id",
+      number: "number",
     } as unknown as OrderConfirmedSubscriptionFragment;
 
     expect(
-      resolver.resolve({ avataxDocumentCode: order.avataxDocumentCode, orderId: order.id }),
-    ).toBe("id");
+      resolver.resolve({ avataxDocumentCode: order.avataxDocumentCode, orderNumber: order.number }),
+    ).toBe("number");
   });
+
   it("returns sliced document code when avataxDocumentCode too long", () => {
     expect(
-      resolver.resolve({ avataxDocumentCode: "123456789012345678901234567890", orderId: "id" }),
-    ).toBe("12345678901234567890");
+      resolver.resolve({
+        avataxDocumentCode: "long-document-code-above-20-characters-1234567890",
+        orderNumber: "long-document-code-above-20-characters-",
+      }),
+    ).toBe("long-document-code-a");
   });
-  it("returns sliced document code when orderId too long", () => {
+
+  it("returns sliced document code when orderNumber too long", () => {
     expect(
-      resolver.resolve({ avataxDocumentCode: null, orderId: "123456789012345678901234567890" }),
-    ).toBe("12345678901234567890");
+      resolver.resolve({
+        avataxDocumentCode: null,
+        orderNumber: "long-order-number-above-20-characters-1234567890",
+      }),
+    ).toBe("long-order-number-ab");
   });
 });

--- a/apps/avatax/src/modules/avatax/avatax-document-code-resolver.ts
+++ b/apps/avatax/src/modules/avatax/avatax-document-code-resolver.ts
@@ -1,22 +1,20 @@
 export class AvataxDocumentCodeResolver {
   resolve({
     avataxDocumentCode,
-    orderId,
+    orderNumber,
   }: {
     avataxDocumentCode: string | null | undefined;
-    orderId: string;
+    orderNumber: string;
   }): string {
     /*
      * The value for "code" can be provided in the metadata.
      * Read more: https://developer.avalara.com/erp-integration-guide/sales-tax-badge/transactions/cert-document-codes/
      * The returned document code must be idempotent (same document code for the same order).
      */
-
-    const code = avataxDocumentCode ?? orderId;
+    const code = avataxDocumentCode ?? orderNumber;
 
     /*
      * The requirement from AvaTax API is that document code is a string that must be between 1 and 20 characters long.
-     * // todo: document that its sliced
      */
     return code.slice(0, 20);
   }

--- a/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
+++ b/apps/avatax/src/modules/avatax/order-confirmed/avatax-order-confirmed-payload-transformer.ts
@@ -78,7 +78,7 @@ export class AvataxOrderConfirmedPayloadTransformer {
 
     const code = this.deps.avataxDocumentCodeResolver.resolve({
       avataxDocumentCode: confirmedOrderEvent.getAvaTaxDocumentCode(),
-      orderId: confirmedOrderEvent.getOrderId(),
+      orderNumber: confirmedOrderEvent.getOrderNumber(),
     });
 
     const customerCode = avataxCustomerCode.resolve({

--- a/apps/avatax/src/modules/saleor/order-confirmed/event.ts
+++ b/apps/avatax/src/modules/saleor/order-confirmed/event.ts
@@ -27,6 +27,7 @@ export class SaleorOrderConfirmedEvent {
       }),
       status: z.string(),
       id: z.string(),
+      number: z.string(),
       shippingPrice: z.object({
         gross: z.object({
           amount: z.number(),
@@ -79,6 +80,8 @@ export class SaleorOrderConfirmedEvent {
   getChannelSlug = () => this.rawPayload.order.channel.slug;
 
   getOrderId = () => this.rawPayload.order.id;
+
+  getOrderNumber = () => this.rawPayload.order.number;
 
   isFulfilled = () => this.rawPayload.order.status === "FULFILLED";
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly the changes made in this PR -->

Send Saleor order number instead of order id as AvaTax document code. Previously app was using first 20 characters of order id. This was causing a problem on AvaTax side as there weren't any way of connecting Saleor order (as order id was truncated to first 20 chars). After this change app will send order number (e.g 2137) instead. Thanks to that you will see it in AvaTax dashboard and you will be able to use this number for searching for order in Saleor.

This is how is going to look in AvaTax dashboard:
![2025-09-05 at 11 43 26 - CleanShot@2x](https://github.com/user-attachments/assets/c0732e58-5ffb-4e75-bcb2-1b0a645f9a87)


## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
