### PR TITLE
Dynamic AvaTax client app name / app version based on env vars

### DIFF
--- a/.changeset/nice-taxis-fail.md
+++ b/.changeset/nice-taxis-fail.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Allow AvaTax app name and app version to be dynamically set up via env variables.

--- a/apps/avatax/src/env.ts
+++ b/apps/avatax/src/env.ts
@@ -1,6 +1,8 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+import packageJson from "@/package.json";
+
 // https://env.t3.gg/docs/recipes#booleans
 const booleanSchema = z
   .string()
@@ -18,6 +20,8 @@ export const env = createEnv({
     APP_IFRAME_BASE_URL: z.string().optional(),
     APP_LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
     AVATAX_CLIENT_TIMEOUT: z.coerce.number().optional().default(15000),
+    AVATAX_CLIENT_APP_NAME: z.string().optional().default("Saleor"),
+    AVATAX_CLIENT_APP_VERSION: z.string().optional().default(packageJson.version),
     AWS_ACCESS_KEY_ID: z.string(),
     AWS_REGION: z.string(),
     AWS_SECRET_ACCESS_KEY: z.string(),
@@ -67,6 +71,8 @@ export const env = createEnv({
     APP_IFRAME_BASE_URL: process.env.APP_IFRAME_BASE_URL,
     APP_LOG_LEVEL: process.env.APP_LOG_LEVEL,
     AVATAX_CLIENT_TIMEOUT: process.env.AVATAX_CLIENT_TIMEOUT,
+    AVATAX_CLIENT_APP_NAME: process.env.AVATAX_CLIENT_APP_NAME,
+    AVATAX_CLIENT_APP_VERSION: process.env.AVATAX_CLIENT_APP_VERSION,
     AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
     AWS_REGION: process.env.AWS_REGION,
     AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,

--- a/apps/avatax/src/modules/avatax/avatax-sdk-client-factory.ts
+++ b/apps/avatax/src/modules/avatax/avatax-sdk-client-factory.ts
@@ -3,8 +3,6 @@ import { LogOptions } from "avatax/lib/utils/logger";
 
 import { env } from "@/env";
 
-import packageJson from "../../../package.json";
-
 type AvataxSettings = {
   appName: string;
   appVersion: string;
@@ -15,8 +13,8 @@ type AvataxSettings = {
 };
 
 const defaultAvataxSettings: AvataxSettings = {
-  appName: packageJson.name,
-  appVersion: packageJson.version,
+  appName: env.AVATAX_CLIENT_APP_NAME,
+  appVersion: env.AVATAX_CLIENT_APP_VERSION,
   environment: "sandbox",
   machineName: "tax-app",
   timeout: env.AVATAX_CLIENT_TIMEOUT,

--- a/apps/avatax/tsconfig.json
+++ b/apps/avatax/tsconfig.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"],
+      "@/generated/*": ["generated/*"],
+      "@/package.json": ["package.json"]
     },
     "plugins": [
       {
@@ -23,7 +23,5 @@
     "reset.d.ts",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/apps/avatax/turbo.json
+++ b/apps/avatax/turbo.json
@@ -10,6 +10,8 @@
         "APP_API_BASE_URL",
         "APP_IFRAME_BASE_URL",
         "AVATAX_CLIENT_TIMEOUT",
+        "AVATAX_CLIENT_APP_NAME",
+        "AVATAX_CLIENT_APP_VERSION",
         "AWS_ACCESS_KEY_ID",
         "AWS_REGION",
         "AWS_SECRET_ACCESS_KEY",


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly the changes made in this PR -->
Allow AvaTax app name and app version to be dynamically set up via env variables.

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
