### PR TITLE
Update AvaTax UI

### DIFF
--- a/.changeset/wet-onions-jog.md
+++ b/.changeset/wet-onions-jog.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Update AvaTax UI. This includes: removing providers mentions where possible, changing form labels of AvaTax configuration, adding breadcrumbs to tax code matcher view.

--- a/apps/avatax/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
+++ b/apps/avatax/src/modules/avatax/ui/avatax-configuration-address-fragment.tsx
@@ -157,7 +157,7 @@ export const AvataxConfigurationAddressFragment = (
             control={control}
             disabled={disabled}
             name="address.zip"
-            label="Zip"
+            label="Zip Code"
             helperText={formState.errors.address?.zip?.message}
           />
           {suggestions?.zip && <FieldSuggestion suggestion={suggestions.zip} />}

--- a/apps/avatax/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
+++ b/apps/avatax/src/modules/avatax/ui/avatax-configuration-credentials-fragment.tsx
@@ -61,7 +61,7 @@ export const AvataxConfigurationCredentialsFragment = (
             control={control}
             name="credentials.username"
             required
-            label="Username *"
+            label="Account Number *"
             helperText={formState.errors.credentials?.username?.message}
           />
           <HelperText>
@@ -75,7 +75,7 @@ export const AvataxConfigurationCredentialsFragment = (
             name="credentials.password"
             type="password"
             required
-            label="Password *"
+            label="License Key *"
             helperText={formState.errors.credentials?.password?.message}
           />
           <HelperText>

--- a/apps/avatax/src/modules/avatax/ui/avatax-tax-code-matcher-table.tsx
+++ b/apps/avatax/src/modules/avatax/ui/avatax-tax-code-matcher-table.tsx
@@ -1,5 +1,5 @@
 import { TextLink } from "@saleor/apps-ui";
-import { Box, Text } from "@saleor/macaw-ui";
+import { Skeleton, Text } from "@saleor/macaw-ui";
 
 import { trpcClient } from "../../trpc/trpc-client";
 import { AppCard } from "../../ui/app-card";
@@ -11,9 +11,9 @@ export const AvataxTaxCodeMatcherTable = () => {
 
   if (isLoading) {
     return (
-      <Box>
-        <Text color="default2">Loading...</Text>
-      </Box>
+      <AppCard>
+        <Skeleton />
+      </AppCard>
     );
   }
 

--- a/apps/avatax/src/modules/avatax/ui/edit-avatax-configuration.tsx
+++ b/apps/avatax/src/modules/avatax/ui/edit-avatax-configuration.tsx
@@ -1,5 +1,5 @@
 import { useDashboardNotification } from "@saleor/apps-shared/use-dashboard-notification";
-import { Box, Button, Text } from "@saleor/macaw-ui";
+import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui";
 import { useRouter } from "next/router";
 import React from "react";
 import { z } from "zod";
@@ -125,11 +125,10 @@ export const EditAvataxConfiguration = () => {
     };
   }, [validateCredentialsHandler, validateCredentialsMutation]);
 
-  if (isGetLoading) {
-    // todo: replace with skeleton once its available in Macaw
+  if (isGetLoading || isDeleteLoading) {
     return (
       <Box>
-        <Text color="default2">Loading...</Text>
+        <Skeleton />
       </Box>
     );
   }
@@ -150,7 +149,7 @@ export const EditAvataxConfiguration = () => {
       defaultValues={data.config}
       leftButton={
         <Button onClick={deleteHandler} variant="error" data-testid="delete-avatax-button">
-          Delete provider
+          Delete configuration
         </Button>
       }
     />

--- a/apps/avatax/src/modules/channel-configuration/ui/channel-list.tsx
+++ b/apps/avatax/src/modules/channel-configuration/ui/channel-list.tsx
@@ -1,5 +1,5 @@
 import { actions, useAppBridge } from "@saleor/app-sdk/app-bridge";
-import { Box, Button, Text } from "@saleor/macaw-ui";
+import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui";
 
 import { trpcClient } from "../../trpc/trpc-client";
 import { AppCard } from "../../ui/app-card";
@@ -25,15 +25,6 @@ const NoChannelConfigured = () => {
       <Button data-testid="configure-channel-button" onClick={redirectToTaxes}>
         Configure channels
       </Button>
-    </Box>
-  );
-};
-
-const Skeleton = () => {
-  // todo: replace with skeleton
-  return (
-    <Box height={"100%"} display={"flex"} alignItems={"center"} justifyContent={"center"}>
-      <Text color="default2">Loading...</Text>
     </Box>
   );
 };

--- a/apps/avatax/src/modules/channel-configuration/ui/channel-table.tsx
+++ b/apps/avatax/src/modules/channel-configuration/ui/channel-table.tsx
@@ -55,7 +55,7 @@ export const ChannelTable = () => {
       <Table.THead color={"default2"}>
         <Table.TR>
           <Table.TH>Channel slug</Table.TH>
-          <Table.TH>Provider</Table.TH>
+          <Table.TH>Configuration</Table.TH>
         </Table.TR>
       </Table.THead>
       <Table.TBody>

--- a/apps/avatax/src/modules/provider-connections/ui/providers-list.tsx
+++ b/apps/avatax/src/modules/provider-connections/ui/providers-list.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text } from "@saleor/macaw-ui";
+import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui";
 import { useRouter } from "next/router";
 
 import { trpcClient } from "../../trpc/trpc-client";
@@ -17,19 +17,13 @@ const AddProvider = () => {
       height={"100%"}
       justifyContent={"center"}
     >
-      <Text>No providers configured yet</Text>
-      <Button data-testid="no-providers-list-add-button" onClick={() => router.push("/providers")}>
-        Add first provider
+      <Text>No configurations created yet</Text>
+      <Button
+        data-testid="no-providers-list-add-button"
+        onClick={() => router.push("/providers/avatax")}
+      >
+        Add first configuration
       </Button>
-    </Box>
-  );
-};
-
-const Skeleton = () => {
-  // todo: replace with skeleton
-  return (
-    <Box height={"100%"} display={"flex"} alignItems={"center"} justifyContent={"center"}>
-      <Text color="default2">Loading...</Text>
     </Box>
   );
 };

--- a/apps/avatax/src/modules/provider-connections/ui/providers-section.tsx
+++ b/apps/avatax/src/modules/provider-connections/ui/providers-section.tsx
@@ -7,7 +7,7 @@ import { ProvidersList } from "./providers-list";
 const Intro = () => {
   return (
     <Section.Description
-      title="Tax providers"
+      title="AvaTax configurations"
       data-testid="providers-intro"
       description={
         <>

--- a/apps/avatax/src/modules/ui/matcher-section.tsx
+++ b/apps/avatax/src/modules/ui/matcher-section.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text } from "@saleor/macaw-ui";
+import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui";
 import { useRouter } from "next/router";
 
 import { trpcClient } from "../trpc/trpc-client";
@@ -18,18 +18,11 @@ const MatcherTable = () => {
   return (
     <AppCard __minHeight={"320px"} height="100%" data-testid="matcher-table">
       {isLoading ? (
-        <Box height="100%" display={"flex"} alignItems={"center"} justifyContent={"center"}>
-          <Text color="default2">Loading...</Text>
-        </Box>
+        <Skeleton />
       ) : (
         <>
           {isConfigured ? (
             <Table.Container>
-              <Table.THead>
-                <Table.TR>
-                  <Table.TH>Provider</Table.TH>
-                </Table.TR>
-              </Table.THead>
               <Table.TBody>
                 {isAvatax && (
                   <Table.TR>
@@ -69,10 +62,10 @@ const Intro = () => {
       title="Tax code matcher"
       description={
         <>
-          Tax Code Matcher allows you to map Saleor tax classes to provider tax codes to extend
+          Tax Code Matcher allows you to map Saleor tax classes to AvaTax tax codes to extend
           products base tax rate.
           <Text as="span" display="block" marginY={4} size={4}>
-            You need to have at least one provider configured to use this feature.
+            You need to have at least one configuration saved to use this feature.
           </Text>
         </>
       }

--- a/apps/avatax/src/modules/ui/providers-table.tsx
+++ b/apps/avatax/src/modules/ui/providers-table.tsx
@@ -3,7 +3,6 @@ import { useRouter } from "next/router";
 
 import { ProviderConnection } from "../provider-connections/provider-connections";
 import { trpcClient } from "../trpc/trpc-client";
-import { ProviderLabel } from "./provider-label";
 import { Table } from "./table";
 
 export const ProvidersTable = () => {
@@ -19,16 +18,13 @@ export const ProvidersTable = () => {
       <Table.THead color={"default2"}>
         <Table.TR>
           <Table.TH>Name</Table.TH>
-          <Table.TH>Provider</Table.TH>
         </Table.TR>
       </Table.THead>
       <Table.TBody>
         {data?.map((item) => (
           <Table.TR key={item.id}>
             <Table.TD>{item.config.name}</Table.TD>
-            <Table.TD>
-              <ProviderLabel name={item.provider} />
-            </Table.TD>
+
             <Table.TD>
               <Box display={"flex"} justifyContent={"flex-end"} gap={2}>
                 <Button

--- a/apps/avatax/src/pages/configuration.tsx
+++ b/apps/avatax/src/pages/configuration.tsx
@@ -1,4 +1,5 @@
 import { useAppBridge } from "@saleor/app-sdk/app-bridge";
+import { TextLink } from "@saleor/apps-ui";
 import { Box, Button, Text } from "@saleor/macaw-ui";
 import { useRouter } from "next/router";
 
@@ -14,7 +15,11 @@ const Header = () => {
   return (
     <Box display="flex" justifyContent="space-between">
       <Section.Header>
-        Configure the app by connecting to AvaTax. You can connect to multiple accounts.
+        Configure the app by connecting to AvaTax. Read the{" "}
+        <TextLink href="https://docs.saleor.io/developer/app-store/apps/avatax/overview" newTab>
+          documentation
+        </TextLink>{" "}
+        to learn more.
       </Section.Header>
       <Button onClick={() => push("/logs")}>Open Logs</Button>
     </Box>

--- a/apps/avatax/src/pages/providers/avatax/matcher.tsx
+++ b/apps/avatax/src/pages/providers/avatax/matcher.tsx
@@ -1,16 +1,35 @@
 import { useDashboardNotification } from "@saleor/apps-shared/use-dashboard-notification";
 import { TextLink } from "@saleor/apps-ui";
-import { Box, Text } from "@saleor/macaw-ui";
+import { Skeleton, Text } from "@saleor/macaw-ui";
 import { useRouter } from "next/router";
+import { ReactNode } from "react";
+
+import { AppCard } from "@/modules/ui/app-card";
+import { AppPageLayout } from "@/modules/ui/app-page-layout";
 
 import { AvataxTaxCodeMatcherTable } from "../../../modules/avatax/ui/avatax-tax-code-matcher-table";
 import { trpcClient } from "../../../modules/trpc/trpc-client";
-import { AppColumns } from "../../../modules/ui/app-columns";
 import { AppDashboardLink } from "../../../modules/ui/app-dashboard-link";
 import { Section } from "../../../modules/ui/app-section";
 
-const Header = () => {
-  return <Section.Header>Match Saleor tax classes to AvaTax tax codes</Section.Header>;
+const Layout = ({ children }: { children: ReactNode }) => {
+  return (
+    <AppPageLayout
+      top={<Section.Header>Match Saleor tax classes to AvaTax tax codes</Section.Header>}
+      breadcrumbs={[
+        {
+          href: "/configuration",
+          label: "Configuration",
+        },
+        {
+          href: "/matcher",
+          label: "Matcher",
+        },
+      ]}
+    >
+      {children}
+    </AppPageLayout>
+  );
 };
 
 const Description = () => {
@@ -63,17 +82,20 @@ const AvataxMatcher = () => {
 
   if (isLoading) {
     return (
-      <Box>
-        <Text>Loading...</Text>
-      </Box>
+      <Layout>
+        <Description />
+        <AppCard>
+          <Skeleton />
+        </AppCard>
+      </Layout>
     );
   }
 
   return (
-    <AppColumns top={<Header />}>
+    <Layout>
       <Description />
       <AvataxTaxCodeMatcherTable />
-    </AppColumns>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## Scope of the PR

<!-- Describe briefly the changes made in this PR -->
Update AvaTax UI. This includes: removing providers mentions where possible, changing form labels of AvaTax configuration, adding breadcrumbs to tax code matcher view.

Configurations page:
![2025-09-05 at 13 43 16 - CleanShot@2x](https://github.com/user-attachments/assets/1453852d-b486-4658-bfba-58fa7f214992)

Single configuration page:
![2025-09-05 at 13 43 41 - CleanShot@2x](https://github.com/user-attachments/assets/63983624-db65-4179-9634-9deb179b900d)

Tax code matcher page:
![2025-09-05 at 13 44 21 - CleanShot@2x](https://github.com/user-attachments/assets/97b784fd-a5d0-449f-a311-e90cae3e6076)



## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
