### PR TITLE
Fix example payload for email change request and confirmation emails

### DIFF
--- a/.changeset/violet-pets-camp.md
+++ b/.changeset/violet-pets-camp.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-smtp": patch
+---
+
+Fixed default payload for accountChangeEmailRequest and accountChangeEmailConfirm emails.

--- a/apps/smtp/src/lib/notify-event-types.ts
+++ b/apps/smtp/src/lib/notify-event-types.ts
@@ -90,7 +90,7 @@ export interface NotifyPayloadAccountChangeEmailRequest {
   new_email: string;
   old_email: string;
   recipient_email: string;
-  reset_url: string;
+  redirect_url: string;
   site_name: string;
   token: string;
   user: User;
@@ -100,9 +100,10 @@ export interface NotifyPayloadAccountChangeEmailConfirmation {
   channel_slug: string;
   domain: string;
   logo_url: string;
+  new_email: string;
+  old_email: string;
   recipient_email: string;
   site_name: string;
-  token: string;
   user: User;
 }
 

--- a/apps/smtp/src/modules/event-handlers/default-payloads.ts
+++ b/apps/smtp/src/modules/event-handlers/default-payloads.ts
@@ -10,6 +10,7 @@ import {
   OrderRefundedWebhookPayloadFragment,
 } from "../../../generated/graphql";
 import {
+  NotifyPayloadAccountChangeEmailConfirmation,
   NotifyPayloadAccountChangeEmailRequest,
   NotifyPayloadAccountConfirmation,
   NotifyPayloadAccountDelete,
@@ -309,7 +310,7 @@ const accountChangeEmailRequestPayload: NotifyPayloadAccountChangeEmailRequest =
   token: "bmt4kc-d6e379b762697f6aa357527af36bb9f6",
   old_email: "test@example.com1",
   new_email: "new.email@example.com1",
-  reset_url:
+  redirect_url:
     "http://example.com/reset?email=user%40example.com&token=bmt4kc-d6e379b762697f6aa357527af36bb9f6",
   channel_slug: "default-channel",
   domain: "demo.saleor.cloud",
@@ -317,7 +318,7 @@ const accountChangeEmailRequestPayload: NotifyPayloadAccountChangeEmailRequest =
   logo_url: "",
 };
 
-const accountChangeEmailConfirmPayload: NotifyPayloadAccountChangeEmailRequest = {
+const accountChangeEmailConfirmPayload: NotifyPayloadAccountChangeEmailConfirmation = {
   user: {
     id: "VXNlcjoxOTY=",
     email: "user@example.com",
@@ -332,9 +333,6 @@ const accountChangeEmailConfirmPayload: NotifyPayloadAccountChangeEmailRequest =
   recipient_email: "user@example.com",
   old_email: "old@example.com",
   new_email: "new@example.com",
-  token: "bmt4kc-d6e379b762697f6aa357527af36bb9f6",
-  reset_url:
-    "http://example.com/reset?email=user%40example.com&token=bmt4kc-d6e379b762697f6aa357527af36bb9f6",
   channel_slug: "default-channel",
   domain: "demo.saleor.cloud",
   site_name: "Saleor e-commerce",


### PR DESCRIPTION
## Scope of the PR

Fixed default payload for the following emails:
- accountChangeEmailRequest - changed invalid `reset_url` field to `redirect_url`
- accountChangeEmailConfirm - removed two fields that doesn't exist in the payload for this event:`token` and `reset_url`
  
## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
