### PR TITLE
Remove redundant error logging in Stripe app tRPC procedure

### DIFF
--- a/.changeset/kind-lizards-hammer.md
+++ b/.changeset/kind-lizards-hammer.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-payment-stripe": patch
+---
+
+Removed unnecessary error logs that printed all non-ok responses from tRPC in the main Procedure. That is not necessary because main tRPC config already prints errors from 500 status errors. Now only one error will be logged if necessary

--- a/apps/stripe/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/stripe/src/modules/trpc/protected-client-procedure.ts
@@ -109,16 +109,6 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
   });
 });
 
-const logErrors = middleware(async ({ next }) => {
-  const result = await next();
-
-  if (!result.ok) {
-    logger.error(result.error.message, { error: result.error });
-  }
-
-  return result;
-});
-
 /**
  * Construct common graphQL client and attach it to the context
  *
@@ -128,7 +118,6 @@ const logErrors = middleware(async ({ next }) => {
  * TODO: Rethink middleware composition to enable safe server-side router calls
  */
 export const protectedClientProcedure = procedure
-  .use(logErrors)
   .use(attachAppToken)
   .use(validateClientToken)
   .use(attachSharedServices);


### PR DESCRIPTION
## Summary
- Removed the `logErrors` middleware from `protectedClientProcedure` in the Stripe app
- This middleware was redundantly logging all non-ok responses from tRPC
- The main tRPC config already handles logging for 500 status errors
- Eliminates duplicate error logs and reduces log noise

## Changes
- Deleted `logErrors` middleware function from `apps/stripe/src/modules/trpc/protected-client-procedure.ts:112`
- Removed `.use(logErrors)` from the middleware chain

