### PR TITLE
change PF to sequentially fetch variants

### DIFF
--- a/.changeset/poor-otters-kick.md
+++ b/.changeset/poor-otters-kick.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": patch
+---
+
+Changed app to fetch chunks of products sequential instead of parallel to avoid abusing the API


### PR DESCRIPTION
Fixes issue of abusing Saleor API with too many parallel requests