### PR TITLE
Change webhook operations to fail with warn instead of errors

### DIFF
--- a/.changeset/lovely-bananas-march.md
+++ b/.changeset/lovely-bananas-march.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-payment-stripe": patch
+---
+
+Changed legacy-webhook management logic to use "warn" instead of "error" for logs.

--- a/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
@@ -89,7 +89,7 @@ export class StripeWebhookUseCase {
     const result = await this.webhookManager.removeWebhook({ webhookId, restrictedKey });
 
     if (result.isErr()) {
-      this.logger.error(`Failed to remove webhook ${webhookId}`, result.error);
+      this.logger.warn(`Failed to remove webhook ${webhookId}`, result.error);
 
       return err(new BaseError("Failed to remove webhook", { cause: result.error }));
     }
@@ -273,7 +273,7 @@ export class StripeWebhookUseCase {
       const processingResult = await this.processLegacyWebhook(webhookParams);
 
       if (processingResult.isErr()) {
-        this.logger.error("Received legacy webhook but failed to handle removing it", {
+        this.logger.warn("Received legacy webhook but failed to handle removing it", {
           error: processingResult.error,
         });
 

--- a/apps/stripe/src/modules/stripe/stripe-webhook-manager.ts
+++ b/apps/stripe/src/modules/stripe/stripe-webhook-manager.ts
@@ -70,7 +70,7 @@ export class StripeWebhookManager {
         status: webhook.status as "enabled" | "disabled",
       });
     } catch (e) {
-      this.logger.error("Error retrieving webhook", { error: e });
+      this.logger.warn("Error retrieving webhook", { error: e });
 
       return err(new CantFetchWebhookError("Error retrieving webhook", { cause: e }));
     }
@@ -92,7 +92,7 @@ export class StripeWebhookManager {
 
       return ok(null);
     } catch (e) {
-      this.logger.error("Error removing webhook", { error: e });
+      this.logger.warn("Error removing webhook", { error: e });
 
       return err(new CantRemoveWebhookError("Error removing webhook", { cause: e }));
     }


### PR DESCRIPTION
We can't control it fully, because if user-provided RK is outdated, we can't clean up webhooks. Hence we can't print errors - it will be false-positives for us
