### PR TITLE
Fix AWS SDK initialization with explicit credentials

### DIFF
--- a/.changeset/sweet-rocks-protect.md
+++ b/.changeset/sweet-rocks-protect.md
@@ -1,0 +1,12 @@
+---
+"saleor-app-products-feed": patch
+"saleor-app-payment-np-atobarai": patch
+"saleor-app-klaviyo": patch
+"saleor-app-segment": patch
+"saleor-app-search": patch
+"saleor-app-payment-stripe": patch
+"saleor-app-smtp": patch
+"saleor-app-cms": patch
+---
+
+Fixed how AWS sdk is initialized by explicitly passing credentials. This is caused by Vercel issue, which started to implicitly override some of our credentials by injecting their own.

--- a/apps/cms/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/cms/src/modules/dynamodb/dynamodb-client.ts
@@ -2,7 +2,27 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/klaviyo/src/dynamodb/dynamodb-client.ts
+++ b/apps/klaviyo/src/dynamodb/dynamodb-client.ts
@@ -2,7 +2,27 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/np-atobarai/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/np-atobarai/src/modules/dynamodb/dynamodb-client.ts
@@ -1,8 +1,30 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
+import { env } from "@/lib/env";
+
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = env.AWS_SECRET_ACCESS_KEY;
+  const region = env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/products-feed/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/products-feed/src/modules/dynamodb/dynamodb-client.ts
@@ -2,7 +2,27 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/search/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/search/src/modules/dynamodb/dynamodb-client.ts
@@ -2,11 +2,30 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };
-
 export const createDynamoDBDocumentClient = (client: DynamoDBClient) => {
   return DynamoDBDocumentClient.from(client);
 };

--- a/apps/segment/src/lib/dynamodb-client.ts
+++ b/apps/segment/src/lib/dynamodb-client.ts
@@ -1,8 +1,30 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
+import { env } from "@/env";
+
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = env.AWS_SECRET_ACCESS_KEY;
+  const region = env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/smtp/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/smtp/src/modules/dynamodb/dynamodb-client.ts
@@ -2,7 +2,27 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const region = process.env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };

--- a/apps/stripe/src/modules/dynamodb/dynamodb-client.ts
+++ b/apps/stripe/src/modules/dynamodb/dynamodb-client.ts
@@ -1,8 +1,30 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
+import { env } from "@/lib/env";
+
 export const createDynamoDBClient = () => {
-  const client = new DynamoDBClient();
+  const accessKeyId = env.AWS_ACCESS_KEY_ID;
+  const secretAccessKey = env.AWS_SECRET_ACCESS_KEY;
+  const region = env.AWS_REGION;
+
+  const client = new DynamoDBClient({
+    /**
+     * We need to explicitly pass credentials to the client. If not set, SDK will take env variables.
+     * Some time ago Vercel started to implicitly inject AWS_SESSION_TOKEN which took precedence over AWS_SECRET_ACCESS_KEY,
+     * but it was not *our* token, but Vercel's.
+     *
+     * We should eventually move to OIDC
+     */
+    credentials:
+      accessKeyId && secretAccessKey
+        ? {
+            accessKeyId,
+            secretAccessKey,
+          }
+        : undefined,
+    region,
+  });
 
   return client;
 };


### PR DESCRIPTION
## Summary

Fixed AWS SDK initialization across all apps by explicitly passing credentials to DynamoDB clients. This resolves an issue where Vercel started implicitly injecting `AWS_SESSION_TOKEN` environment variable, which took precedence over our `AWS_SECRET_ACCESS_KEY` credentials.

## Changes

- Updated DynamoDB client initialization in 8 apps (CMS, Klaviyo, NP Atobarai, Products Feed, Search, Segment, SMTP, Stripe)
- Explicitly pass `accessKeyId` and `secretAccessKey` to `DynamoDBClient` constructor when available
- Added inline documentation explaining the issue and noting future migration to OIDC
- Falls back to undefined credentials when env variables are not set (allowing SDK to use default credential chain)

## Root Cause

Vercel recently started injecting their own `AWS_SESSION_TOKEN` into the environment, which AWS SDK prioritizes over static credentials. By explicitly passing credentials, we ensure our apps use the correct AWS credentials rather than Vercel's session token.

## Technical Details

Before:
```typescript
const client = new DynamoDBClient();
```

After:
```typescript
const client = new DynamoDBClient({
  credentials: accessKeyId && secretAccessKey
    ? { accessKeyId, secretAccessKey }
    : undefined,
  region,
});
```

## Related Issues

Addresses Vercel environment variable injection issue affecting AWS SDK credential resolution.

## Checklist

- [x] I added changesets and read good practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)