### PR TITLE
Updated pnpm settings to better security

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,14 @@
+blockExoticSubdeps: true
+
+minimumReleaseAge: 1440 # 24h
+
+trustPolicy: no-downgrade
+
 packages:
   - apps/*
   - packages/*
   - templates/*
+
 onlyBuiltDependencies:
   - "@sentry/cli"
   - core-js
@@ -10,6 +17,11 @@ onlyBuiltDependencies:
   - msw
   - protobufjs
   - sharp
+
+overrides:
+  # form-data has vulnerability, fixed on 3.0.4
+  form-data@3.0.1: 3.0.4
+
 catalog:
   "node-mocks-http": 1.16.1
   "@opentelemetry/api": 1.9.0
@@ -75,6 +87,4 @@ catalog:
   "@graphql-codegen/typescript-operations": 4.1.3
   "@graphql-codegen/typescript-urql": 4.0.0
   "@graphql-typed-document-node/core": 3.2.0
-overrides:
-  # form-data has vulnerability, fixed on 3.0.4
-  form-data@3.0.1: 3.0.4
+


### PR DESCRIPTION
Updated pnpm settings to improve supply chain attacks:
- Installing packages only if older than 24h: https://pnpm.io/settings#minimumreleaseage
- Trusted packages cannot be downgraded to less secure: https://pnpm.io/settings#trustpolicy
- Exotic sub dependencies (referencing git repo, or tarballs) are prohibited: https://pnpm.io/settings#blockexoticsubdeps

Other pnpm settings were also moved from package.json to pnpm-workspace.yaml

