### PR TITLE
Remove deprecated SaleorCloudAPL from all apps

### DIFF
--- a/.changeset/kind-baboons-swim.md
+++ b/.changeset/kind-baboons-swim.md
@@ -1,0 +1,11 @@
+---
+"saleor-app-products-feed": patch
+"saleor-app-klaviyo": patch
+"saleor-app-segment": patch
+"saleor-app-avatax": patch
+"saleor-app-search": patch
+"saleor-app-smtp": patch
+"saleor-app-cms": patch
+---
+
+Removed legacy SaleorCloudAPL initialization. This APL is deprecated and will be removed in app-sdk. Apps can no longer use it. This is not marked as a major change, because this API is private to Saleor Cloud

--- a/apps/avatax/saleor-app.ts
+++ b/apps/avatax/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
 import { env } from "@/env";
@@ -31,20 +30,6 @@ switch (env.APL) {
           logger.debug(`[DynamoAPL] ${message}`);
         }
       },
-    });
-
-    break;
-  }
-
-  // todo: deprecate in sdk, remove in apps, clean envs
-  case "saleor-cloud": {
-    if (!env.REST_APL_ENDPOINT || !env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: env.REST_APL_ENDPOINT,
-      token: env.REST_APL_TOKEN,
     });
 
     break;

--- a/apps/avatax/src/env.ts
+++ b/apps/avatax/src/env.ts
@@ -15,7 +15,7 @@ export const env = createEnv({
   },
   server: {
     ALLOWED_DOMAIN_PATTERN: z.string().optional(),
-    APL: z.enum(["saleor-cloud", "file", "dynamodb"]).optional().default("file"),
+    APL: z.enum(["file", "dynamodb"]).optional().default("file"),
     APP_API_BASE_URL: z.string().optional(),
     APP_IFRAME_BASE_URL: z.string().optional(),
     APP_LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),

--- a/apps/cms/src/saleor-app.ts
+++ b/apps/cms/src/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { UpstashAPL } from "@saleor/app-sdk/APL/upstash";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
@@ -56,19 +55,6 @@ switch (aplType) {
     apl = new FileAPL();
 
     break;
-
-  case "saleor-cloud": {
-    if (!process.env.REST_APL_ENDPOINT || !process.env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: process.env.REST_APL_ENDPOINT,
-      token: process.env.REST_APL_TOKEN,
-    });
-
-    break;
-  }
 
   default: {
     throw new Error("Invalid APL config, ");

--- a/apps/klaviyo/saleor-app.ts
+++ b/apps/klaviyo/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { UpstashAPL } from "@saleor/app-sdk/APL/upstash";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
@@ -61,19 +60,6 @@ switch (aplType) {
     apl = new FileAPL();
 
     break;
-
-  case "saleor-cloud": {
-    if (!process.env.REST_APL_ENDPOINT || !process.env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: process.env.REST_APL_ENDPOINT,
-      token: process.env.REST_APL_TOKEN,
-    });
-
-    break;
-  }
 
   default: {
     throw new Error("Invalid APL config, ");

--- a/apps/products-feed/src/saleor-app.ts
+++ b/apps/products-feed/src/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { UpstashAPL } from "@saleor/app-sdk/APL/upstash";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
@@ -56,19 +55,6 @@ switch (aplType) {
     apl = new FileAPL();
 
     break;
-
-  case "saleor-cloud": {
-    if (!process.env.REST_APL_ENDPOINT || !process.env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: process.env.REST_APL_ENDPOINT,
-      token: process.env.REST_APL_TOKEN,
-    });
-
-    break;
-  }
 
   default: {
     throw new Error("Invalid APL config, ");

--- a/apps/search/saleor-app.ts
+++ b/apps/search/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { UpstashAPL } from "@saleor/app-sdk/APL/upstash";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
@@ -60,19 +59,6 @@ switch (aplType) {
     apl = new FileAPL();
 
     break;
-
-  case "saleor-cloud": {
-    if (!process.env.REST_APL_ENDPOINT || !process.env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: process.env.REST_APL_ENDPOINT as string,
-      token: process.env.REST_APL_TOKEN as string,
-    });
-
-    break;
-  }
 
   default: {
     throw new Error("Invalid APL config");

--- a/apps/segment/src/env.ts
+++ b/apps/segment/src/env.ts
@@ -13,7 +13,7 @@ export const env = createEnv({
   },
   server: {
     ALLOWED_DOMAIN_PATTERN: z.string().optional(),
-    APL: z.enum(["saleor-cloud", "file", "dynamodb"]).optional().default("file"),
+    APL: z.enum(["file", "dynamodb"]).optional().default("file"),
     APP_API_BASE_URL: z.string().optional(),
     APP_IFRAME_BASE_URL: z.string().optional(),
     APP_LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),

--- a/apps/segment/src/saleor-app.ts
+++ b/apps/segment/src/saleor-app.ts
@@ -1,20 +1,16 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
 import { segmentMainTable } from "@/modules/db/segment-main-table";
 
 import { env } from "./env";
-import { BaseError } from "./errors";
 import { createLogger } from "./logger";
 
 const logger = createLogger("saleor-app");
 
 export let apl: APL;
-
-const MisconfiguredSaleorCloudAPLError = BaseError.subclass("MisconfiguredSaleorCloudAPLError");
 
 switch (env.APL) {
   case "dynamodb": {
@@ -28,21 +24,6 @@ switch (env.APL) {
         }
       },
     });
-    break;
-  }
-
-  case "saleor-cloud": {
-    if (!env.REST_APL_ENDPOINT || !env.REST_APL_TOKEN) {
-      throw new MisconfiguredSaleorCloudAPLError(
-        "Rest APL is not configured - missing env variables. Check saleor-app.ts",
-      );
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: env.REST_APL_ENDPOINT,
-      token: env.REST_APL_TOKEN,
-    });
-
     break;
   }
 

--- a/apps/smtp/src/saleor-app.ts
+++ b/apps/smtp/src/saleor-app.ts
@@ -1,7 +1,6 @@
 import { APL } from "@saleor/app-sdk/APL";
 import { DynamoAPL } from "@saleor/app-sdk/APL/dynamodb";
 import { FileAPL } from "@saleor/app-sdk/APL/file";
-import { SaleorCloudAPL } from "@saleor/app-sdk/APL/saleor-cloud";
 import { UpstashAPL } from "@saleor/app-sdk/APL/upstash";
 import { SaleorApp } from "@saleor/app-sdk/saleor-app";
 
@@ -55,19 +54,6 @@ switch (aplType) {
     apl = new FileAPL();
 
     break;
-
-  case "saleor-cloud": {
-    if (!process.env.REST_APL_ENDPOINT || !process.env.REST_APL_TOKEN) {
-      throw new Error("Rest APL is not configured - missing env variables. Check saleor-app.ts");
-    }
-
-    apl = new SaleorCloudAPL({
-      resourceUrl: process.env.REST_APL_ENDPOINT,
-      token: process.env.REST_APL_TOKEN,
-    });
-
-    break;
-  }
 
   default: {
     throw new Error("Invalid APL config, ");


### PR DESCRIPTION
## Summary

- Removed `SaleorCloudAPL` initialization from all apps (AvaTax, CMS, Klaviyo, Products Feed, Search, Segment, SMTP)
- Removed `saleor-cloud` option from APL enum in env configuration (AvaTax, Segment)
- Cleaned up related imports and error classes

## Motivation

The `SaleorCloudAPL` is deprecated and will be removed from app-sdk. Apps can no longer use this APL type. This change prepares the apps for the upcoming SDK update.

## Affected Apps

- saleor-app-avatax
- saleor-app-cms
- saleor-app-klaviyo
- saleor-app-products-feed
- saleor-app-search
- saleor-app-segment
- saleor-app-smtp

## Breaking Changes

None for external users. This APL is private to Saleor Cloud infrastructure.

## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).