### PR TITLE
Add delete old deplyoments script

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -83,7 +83,9 @@ export default {
     "Neue",
     "Segoe",
     "Undiscounted",
-    "OIDC", "oidc"
+    "OIDC", "oidc",
+    "substate",
+    "Unaliased"
   ],
   language: "en-US",
   useGitignore: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2973,6 +2973,15 @@ importers:
         specifier: 'catalog:'
         version: 3.1.1(@types/node@22.13.10)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.10.2(@types/node@22.13.10)(typescript@5.8.2))(terser@5.18.0)(tsx@4.19.3)(yaml@2.7.0)
 
+  scripts:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.10
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.2
+
 packages:
 
   '@0no-co/graphql.web@1.0.4':
@@ -4409,21 +4418,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.5.1':
-    resolution: {integrity: sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint-community/regexpp@4.12.2':
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
@@ -10849,16 +10848,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -11873,6 +11862,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -12148,15 +12138,15 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
 
   '@ardatan/relay-compiler@12.0.0(graphql@16.7.1)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/generator': 7.27.0
+      '@babel/generator': 7.28.6
       '@babel/parser': 7.28.6
       '@babel/runtime': 7.25.6
-      '@babel/traverse': 7.27.0
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.6)
       chalk: 4.1.2
@@ -13370,7 +13360,7 @@ snapshots:
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
-      '@babel/template': 7.27.0
+      '@babel/template': 7.28.6
       '@babel/types': 7.28.6
 
   '@babel/helper-globals@7.28.0': {}
@@ -13386,7 +13376,7 @@ snapshots:
   '@babel/helper-module-imports@7.25.9':
     dependencies:
       '@babel/traverse': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -13400,15 +13390,6 @@ snapshots:
   '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.27.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.28.6)':
-    dependencies:
-      '@babel/core': 7.28.6
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
       '@babel/traverse': 7.27.0
@@ -13444,8 +13425,8 @@ snapshots:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.22.5
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/template': 7.27.0
-      '@babel/traverse': 7.27.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -13496,28 +13477,28 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-create-class-features-plugin': 7.22.5(@babel/core@7.28.6)
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.28.6)':
     dependencies:
-      '@babel/compat-data': 7.26.8
+      '@babel/compat-data': 7.28.6
       '@babel/core': 7.28.6
-      '@babel/helper-compilation-targets': 7.27.0
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.6)
       '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.28.6)
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-flow@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.26.10)':
     dependencies:
@@ -13532,36 +13513,36 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-classes@7.23.8(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.27.0
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.28.6)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
@@ -13569,48 +13550,48 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/template': 7.27.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
 
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-flow-strip-types@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-flow': 7.23.3(@babel/core@7.28.6)
 
   '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-compilation-targets': 7.27.0
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-function-name': 7.23.0
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.28.6)
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-simple-access': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -13618,28 +13599,28 @@ snapshots:
   '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.28.6)
 
   '@babel/plugin-transform-parameters@7.22.5(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -13665,8 +13646,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.6
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.28.6)
       '@babel/types': 7.28.6
     transitivePeerDependencies:
@@ -13675,18 +13656,18 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.28.6)':
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.23.9':
     dependencies:
@@ -14264,17 +14245,10 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.23.0(jiti@2.4.2))':
-    dependencies:
-      eslint: 9.23.0(jiti@2.4.2)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.23.0(jiti@2.4.2))':
     dependencies:
       eslint: 9.23.0(jiti@2.4.2)
       eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint-community/regexpp@4.12.2': {}
 
@@ -14436,9 +14410,9 @@ snapshots:
 
   '@graphql-codegen/cli@5.0.2(@types/node@22.13.10)(enquirer@2.4.1)(graphql@16.7.1)(typescript@5.8.2)':
     dependencies:
-      '@babel/generator': 7.27.0
-      '@babel/template': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/generator': 7.28.6
+      '@babel/template': 7.28.6
+      '@babel/types': 7.28.6
       '@graphql-codegen/client-preset': 4.2.3(graphql@16.7.1)
       '@graphql-codegen/core': 4.0.2(graphql@16.7.1)
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.7.1)
@@ -14484,8 +14458,8 @@ snapshots:
 
   '@graphql-codegen/client-preset@4.2.3(graphql@16.7.1)':
     dependencies:
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/template': 7.27.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/template': 7.28.6
       '@graphql-codegen/add': 5.0.2(graphql@16.7.1)
       '@graphql-codegen/gql-tag-operations': 4.0.5(graphql@16.7.1)
       '@graphql-codegen/plugin-helpers': 5.0.3(graphql@16.7.1)
@@ -15042,7 +15016,7 @@ snapshots:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.4
       jose: 5.10.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json-stable-stringify: 1.1.1
       lodash: 4.17.21
       scuid: 1.1.0
@@ -15355,8 +15329,8 @@ snapshots:
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -15627,7 +15601,7 @@ snapshots:
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.28.0
       forwarded-parse: 2.1.2
-      semver: 7.7.3
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -15752,7 +15726,7 @@ snapshots:
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.13.1
       require-in-the-middle: 7.5.2
-      semver: 7.7.1
+      semver: 7.7.4
       shimmer: 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -15824,7 +15798,7 @@ snapshots:
       '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      semver: 7.7.1
+      semver: 7.7.4
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
@@ -18775,7 +18749,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       file-entry-cache: 9.1.0
       get-stdin: 9.0.0
-      semver: 7.7.3
+      semver: 7.7.4
       tinyglobby: 0.2.12
 
   css-select@5.1.0:
@@ -19282,8 +19256,8 @@ snapshots:
 
   eslint-plugin-es-x@7.8.0(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.23.0(jiti@2.4.2))
+      '@eslint-community/regexpp': 4.12.2
       eslint: 9.23.0(jiti@2.4.2)
       eslint-compat-utils: 0.5.1(eslint@9.23.0(jiti@2.4.2))
 
@@ -19318,7 +19292,7 @@ snapshots:
 
   eslint-plugin-n@17.16.2(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.23.0(jiti@2.4.2))
       enhanced-resolve: 5.18.1
       eslint: 9.23.0(jiti@2.4.2)
       eslint-plugin-es-x: 7.8.0(eslint@9.23.0(jiti@2.4.2))
@@ -19326,7 +19300,7 @@ snapshots:
       globals: 15.15.0
       ignore: 5.3.2
       minimatch: 9.0.5
-      semver: 7.7.1
+      semver: 7.7.4
 
   eslint-plugin-neverthrow-must-use@0.1.2(@typescript-eslint/parser@8.53.1(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
@@ -19424,7 +19398,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.3.4
       escape-string-regexp: 4.0.0
       eslint-scope: 8.3.0
       eslint-visitor-keys: 4.2.1
@@ -20692,11 +20666,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.17
       is-glob: 4.0.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       lodash: 4.17.21
       minimist: 1.2.8
       prettier: 3.5.3
-      tinyglobby: 0.2.12
+      tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
 
@@ -22437,10 +22411,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.1: {}
-
-  semver@7.7.3: {}
-
   semver@7.7.4: {}
 
   sentence-case@3.0.4:
@@ -22713,7 +22683,7 @@ snapshots:
       get-stdin: 9.0.0
       git-hooks-list: 3.2.0
       is-plain-obj: 4.1.0
-      semver: 7.7.3
+      semver: 7.7.4
       sort-object-keys: 1.1.3
       tinyglobby: 0.2.12
 
@@ -23372,7 +23342,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.2.4(@types/node@22.13.10)(jiti@2.4.2)(terser@5.18.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ packages:
   - apps/*
   - packages/*
   - templates/*
+  - scripts
 
 onlyBuiltDependencies:
   - "@sentry/cli"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,81 @@
+# Scripts
+
+Maintenance scripts for the saleor-apps monorepo.
+
+## `remove-old-vercel-deployments.ts`
+
+Lists Vercel deployments older than N days across every app in this repo and
+prints the `vercel remove ... --safe --yes` command(s) to delete them.
+**The script does not mutate anything.** Copy the printed commands and run
+them manually — that way the Vercel CLI handles the "still serving traffic"
+check interactively via its `--safe` flag (keeps the live production
+deployment plus any aliased preview).
+
+### Prerequisites
+
+- Node 22.6+ (for native TypeScript type stripping — `--experimental-strip-types`)
+- Vercel CLI installed and logged in: `npm i -g vercel && vercel login`
+
+Authentication reuses the token stored by `vercel login`. No API token is read
+from the environment and none is committed to the repo.
+
+### Required environment variables
+
+| Var | What |
+| --- | --- |
+| `VERCEL_TEAM_SLUG` | Slug of the Vercel team that owns the projects. Passed to the CLI as `-S`. |
+
+
+### Usage
+
+Node runs the TypeScript directly — no build step, no tsx dependency.
+
+```bash
+# List old deployments for every app (default: older than 7 days)
+VERCEL_TEAM_SLUG=... \
+  pnpm remove-old-vercel-deployments
+
+# Only one app
+pnpm remove-old-vercel-deployments --app=stripe
+
+# Custom age threshold
+pnpm remove-old-vercel-deployments --max-age-days=14
+```
+
+The script writes progress and summary to stderr and the `vercel remove`
+commands to stdout, so you can pipe stdout to a file or `sh` once reviewed:
+
+```bash
+VERCEL_TEAM_SLUG=... \
+  pnpm remove-old-vercel-deployments > remove.sh
+# review remove.sh, then:
+sh remove.sh
+```
+
+### How it works
+
+1. Reads `apps/*/package.json` and takes the `name` field as the Vercel
+   project name. Every app in this repo already follows this convention.
+2. Calls `vercel api /v6/deployments?projectId=<name>&until=<cutoff>` to page
+   through deployments older than the cutoff. The CLI injects the bearer
+   token from `vercel login`, so no token plumbing is needed.
+3. Prints a per-project table (as `#`-prefixed shell comments) with each
+   deployment's `uid`, `created`, `target`, `aliasAssigned` timestamp, and
+   `url` so you can sanity-check before running anything.
+4. Prints one or more `vercel remove <ids> --safe --yes -S <team>` commands
+   (chunked at 50 IDs per command to stay under shell arg limits). You run
+   them manually. `--safe` performs the "still serving traffic" check
+   server-side at delete time, so an alias that moves between listing and
+   deletion will not cause an in-use deployment to be removed.
+
+Because the preview table is emitted as shell comments, piping output to a
+file (`> remove.sh`) yields a script where `sh remove.sh` runs only the
+`vercel remove` lines and ignores the annotations.
+
+### Flags
+
+| Flag | Default | What |
+| --- | --- | --- |
+| `--max-age-days=<n>` | `7` | Consider deployments older than this many days. |
+| `--app=<dirname>` | all | Limit to a single app directory under `apps/`. |
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,8 +60,12 @@ sh remove.sh
    through deployments older than the cutoff. The CLI injects the bearer
    token from `vercel login`, so no token plumbing is needed.
 3. Prints a per-project table (as `#`-prefixed shell comments) with each
-   deployment's `uid`, `created`, `target`, `aliasAssigned` timestamp, and
-   `url` so you can sanity-check before running anything.
+   deployment's `uid`, `created`, `target`, `aliasAssigned` timestamp,
+   `substate` (`STAGED`/`ROLLING`/`PROMOTED` — `PROMOTED` means the
+   deployment has served production traffic), `rb` (`Y` if it is a
+   rollback candidate), `customEnv` (custom environment slug if pinned),
+   and `url` so you can sanity-check before running anything. These fields
+   help explain why a deployment might survive `--safe`.
 4. Prints one or more `vercel remove <ids> --safe --yes -S <team>` commands
    (chunked at 50 IDs per command to stay under shell arg limits). You run
    them manually. `--safe` performs the "still serving traffic" check
@@ -72,10 +76,29 @@ Because the preview table is emitted as shell comments, piping output to a
 file (`> remove.sh`) yields a script where `sh remove.sh` runs only the
 `vercel remove` lines and ignores the annotations.
 
+### Handling aliased deployments
+
+`vercel remove --safe` silently skips any deployment that still has an active
+alias — the CLI fetches aliases per deployment at delete time and omits the
+aliased ones from the batch. The script does NOT fetch aliases itself.
+
+Recommended workflow:
+
+1. Run the script and execute the emitted `vercel remove ... --safe --yes`
+   commands. Unaliased old deployments get deleted; aliased ones survive.
+2. Re-run the script with the same flags. Anything still in the output is,
+   by definition, old AND currently aliased — the set that needs human
+   judgement.
+3. Inspect each surviving deployment (`vercel inspect <url>` or the Vercel
+   dashboard) to see which aliases point to it, then either drop the alias
+   and re-run the cleanup, or `vercel remove <id> --yes` (without `--safe`)
+   if you are sure it can go.
+
 ### Flags
 
 | Flag | Default | What |
 | --- | --- | --- |
 | `--max-age-days=<n>` | `7` | Consider deployments older than this many days. |
 | `--app=<dirname>` | all | Limit to a single app directory under `apps/`. |
+| `--with-aliases` | off | Fetch team aliases once and append each deployment's active alias domains to its row. Costs ~1 paginated API call regardless of project count. |
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@saleor/apps-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "license": "(BSD-3-Clause AND CC-BY-4.0)",
+  "type": "module",
+  "scripts": {
+    "remove-old-vercel-deployments": "node --experimental-strip-types --disable-warning=ExperimentalWarning remove-old-vercel-deployments.ts"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/scripts/remove-old-vercel-deployments.ts
+++ b/scripts/remove-old-vercel-deployments.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
+/**
+ * List old Vercel deployments for every app in this monorepo and print the
+ * `vercel remove` command(s) needed to delete them. The script itself does
+ * NOT mutate anything — paste the printed commands into your terminal to
+ * actually remove the deployments.
+ *
+ * Each app under `apps/*` is a separate Vercel project whose project name
+ * matches the `name` field in `apps/<app>/package.json`.
+ *
+ * Deletion is done manually so you can review and let `vercel remove`
+ * handle the "still serving traffic" check interactively via its `--safe`
+ * flag. `--safe` skips deployments that currently have an active alias —
+ * the live production deployment plus any aliased preview.
+ *
+ * Required env vars:
+ *   VERCEL_TEAM_SLUG  - Vercel team slug (passed as `-S` to the CLI)
+ *
+ * Usage:
+ *   node --experimental-strip-types scripts/remove-old-vercel-deployments.ts
+ *   node --experimental-strip-types scripts/remove-old-vercel-deployments.ts --app=stripe
+ *   node --experimental-strip-types scripts/remove-old-vercel-deployments.ts --max-age-days=14
+ */
+import { execFile } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs, promisify } from "node:util";
+
+const execFileP = promisify(execFile);
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const appsDir = join(repoRoot, "apps");
+
+const { values } = parseArgs({
+  options: {
+    "max-age-days": { type: "string", default: "7" },
+    app: { type: "string" },
+  },
+});
+
+const maxAgeDays = Number(values["max-age-days"]);
+const singleApp = values.app;
+
+const teamSlug = process.env.VERCEL_TEAM_SLUG;
+
+if (!teamSlug) {
+  console.error("VERCEL_TEAM_SLUG not set");
+  process.exit(1);
+}
+if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+  console.error("--max-age-days must be a positive number");
+  process.exit(1);
+}
+
+const cutoffMs = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+
+const IDS_PER_COMMAND = 50;
+
+type Deployment = {
+  uid: string;
+  url?: string;
+  created: number;
+  target?: string | null;
+  aliasAssigned?: number | null;
+};
+
+type DeploymentsResponse = {
+  deployments?: Deployment[];
+};
+
+async function vercelApi<T>(path: string): Promise<T> {
+  const { stdout } = await execFileP("vercel", ["api", path, "-S", teamSlug!]);
+  return JSON.parse(stdout) as T;
+}
+
+async function readProjectNames(): Promise<string[]> {
+  const entries = singleApp ? [singleApp] : await readdir(appsDir);
+  const names: string[] = [];
+
+  for (const entry of entries) {
+    const pkgPath = join(appsDir, entry, "package.json");
+    try {
+      const pkg = JSON.parse(await readFile(pkgPath, "utf8")) as { name?: string };
+      if (pkg.name) {
+        names.push(pkg.name);
+      } else {
+        console.warn(`skip apps/${entry}: package.json has no name`);
+      }
+    } catch {
+      console.warn(`skip apps/${entry}: cannot read package.json`);
+    }
+  }
+
+  return names;
+}
+
+async function listOldDeployments(projectName: string): Promise<Deployment[]> {
+  const all: Deployment[] = [];
+  let until = cutoffMs;
+
+  while (true) {
+    const params = new URLSearchParams({
+      projectId: projectName,
+      until: String(until),
+      limit: "100",
+    });
+    const res = await vercelApi<DeploymentsResponse>(`/v6/deployments?${params.toString()}`);
+    const page = res.deployments ?? [];
+    if (page.length === 0) break;
+
+    all.push(...page);
+
+    const oldest = page[page.length - 1]?.created;
+    if (typeof oldest !== "number" || oldest === until) break;
+    until = oldest;
+  }
+
+  return all;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+function formatTimestamp(ms: number | null | undefined): string {
+  if (typeof ms !== "number") return "-";
+  return new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+function printProjectBlock(projectName: string, deployments: Deployment[]) {
+  console.log(`\n# ${projectName} — ${deployments.length} deployment(s) older than ${maxAgeDays}d`);
+  console.log(
+    "#   " +
+    pad("uid", 36) +
+    "  " +
+    pad("created", 20) +
+    "  " +
+    pad("target", 10) +
+    "  " +
+    pad("aliasAssigned", 20) +
+    "  url",
+  );
+  console.log(
+    "#   " +
+    "-".repeat(36) +
+    "  " +
+    "-".repeat(20) +
+    "  " +
+    "-".repeat(10) +
+    "  " +
+    "-".repeat(20) +
+    "  ---",
+  );
+  for (const d of deployments) {
+    console.log(
+      "#   " +
+      pad(d.uid, 36) +
+      "  " +
+      pad(formatTimestamp(d.created), 20) +
+      "  " +
+      pad(d.target ?? "preview", 10) +
+      "  " +
+      pad(formatTimestamp(d.aliasAssigned), 20) +
+      "  " +
+      (d.url ?? "-"),
+    );
+  }
+  console.log(
+    "# Review the list above. `--safe` will server-side skip any deployment",
+  );
+  console.log("# that still has an active alias at the moment `vercel remove` runs.");
+  const ids = deployments.map((d) => d.uid);
+  for (const part of chunk(ids, IDS_PER_COMMAND)) {
+    console.log(`vercel remove ${part.join(" ")} --safe --yes -S ${teamSlug}`);
+  }
+}
+
+async function main() {
+  const projects = await readProjectNames();
+  console.error(
+    `Scanning ${projects.length} project(s). Cutoff: ${new Date(cutoffMs).toISOString()}`,
+  );
+
+  let total = 0;
+  const failures: string[] = [];
+
+  for (const project of projects) {
+    try {
+      const deployments = await listOldDeployments(project);
+      if (deployments.length === 0) {
+        console.error(`${project}: nothing to remove`);
+        continue;
+      }
+      printProjectBlock(project, deployments);
+      total += deployments.length;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${project}: ${msg}`);
+      failures.push(project);
+    }
+  }
+
+  console.error(
+    `\nFound ${total} deployment(s) to remove across ${projects.length} project(s).`,
+  );
+  console.error(`Run the 'vercel remove' commands above to delete them.`);
+
+  if (failures.length > 0) {
+    console.error(`Failures: ${failures.join(", ")}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/remove-old-vercel-deployments.ts
+++ b/scripts/remove-old-vercel-deployments.ts
@@ -36,11 +36,13 @@ const { values } = parseArgs({
   options: {
     "max-age-days": { type: "string", default: "7" },
     app: { type: "string" },
+    "with-aliases": { type: "boolean", default: false },
   },
 });
 
 const maxAgeDays = Number(values["max-age-days"]);
 const singleApp = values.app;
+const withAliases = values["with-aliases"] ?? false;
 
 const teamSlug = process.env.VERCEL_TEAM_SLUG;
 
@@ -62,12 +64,52 @@ type Deployment = {
   url?: string;
   created: number;
   target?: string | null;
-  aliasAssigned?: number | null;
+  aliasAssigned?: number | boolean | null;
+  readySubstate?: string;
+  isRollbackCandidate?: boolean | null;
+  customEnvironment?: { slug?: string };
 };
 
 type DeploymentsResponse = {
   deployments?: Deployment[];
 };
+
+type Alias = {
+  alias: string;
+  deploymentId: string;
+  deletedAt?: number | null;
+};
+
+type AliasesResponse = {
+  aliases?: Alias[];
+  pagination?: { next?: number | null };
+};
+
+async function fetchAliasesByDeployment(): Promise<Map<string, string[]>> {
+  const map = new Map<string, string[]>();
+  let next: number | undefined;
+  let pages = 0;
+
+  while (true) {
+    const params = new URLSearchParams({ limit: "100" });
+    if (next !== undefined) params.set("until", String(next));
+    const res = await vercelApi<AliasesResponse>(`/v4/aliases?${params.toString()}`);
+    const page = res.aliases ?? [];
+    pages++;
+    for (const a of page) {
+      if (a.deletedAt) continue;
+      const existing = map.get(a.deploymentId);
+      if (existing) existing.push(a.alias);
+      else map.set(a.deploymentId, [a.alias]);
+    }
+    const n = res.pagination?.next;
+    if (typeof n !== "number" || n === next) break;
+    next = n;
+  }
+
+  console.error(`Fetched aliases: ${map.size} deployment(s) aliased across ${pages} page(s).`);
+  return map;
+}
 
 async function vercelApi<T>(path: string): Promise<T> {
   const { stdout } = await execFileP("vercel", ["api", path, "-S", teamSlug!]);
@@ -127,7 +169,7 @@ function chunk<T>(arr: T[], size: number): T[][] {
   return out;
 }
 
-function formatTimestamp(ms: number | null | undefined): string {
+function formatTimestamp(ms: number | boolean | null | undefined): string {
   if (typeof ms !== "number") return "-";
   return new Date(ms).toISOString().replace(/\.\d{3}Z$/, "Z");
 }
@@ -136,7 +178,11 @@ function pad(s: string, width: number): string {
   return s.length >= width ? s : s + " ".repeat(width - s.length);
 }
 
-function printProjectBlock(projectName: string, deployments: Deployment[]) {
+function printProjectBlock(
+  projectName: string,
+  deployments: Deployment[],
+  aliasMap: Map<string, string[]> | null,
+) {
   console.log(`\n# ${projectName} — ${deployments.length} deployment(s) older than ${maxAgeDays}d`);
   console.log(
     "#   " +
@@ -147,6 +193,12 @@ function printProjectBlock(projectName: string, deployments: Deployment[]) {
     pad("target", 10) +
     "  " +
     pad("aliasAssigned", 20) +
+    "  " +
+    pad("substate", 10) +
+    "  " +
+    pad("rb", 2) +
+    "  " +
+    pad("customEnv", 15) +
     "  url",
   );
   console.log(
@@ -158,9 +210,21 @@ function printProjectBlock(projectName: string, deployments: Deployment[]) {
     "-".repeat(10) +
     "  " +
     "-".repeat(20) +
+    "  " +
+    "-".repeat(10) +
+    "  " +
+    "-".repeat(2) +
+    "  " +
+    "-".repeat(15) +
     "  ---",
   );
   for (const d of deployments) {
+    const aliases = aliasMap?.get(d.uid) ?? [];
+    const aliasSuffix = aliasMap
+      ? aliases.length > 0
+        ? `   aliases: ${aliases.join(", ")}`
+        : "   aliases: -"
+      : "";
     console.log(
       "#   " +
       pad(d.uid, 36) +
@@ -171,7 +235,14 @@ function printProjectBlock(projectName: string, deployments: Deployment[]) {
       "  " +
       pad(formatTimestamp(d.aliasAssigned), 20) +
       "  " +
-      (d.url ?? "-"),
+      pad(d.readySubstate ?? "-", 10) +
+      "  " +
+      pad(d.isRollbackCandidate ? "Y" : "-", 2) +
+      "  " +
+      pad(d.customEnvironment?.slug ?? "-", 15) +
+      "  " +
+      (d.url ?? "-") +
+      aliasSuffix,
     );
   }
   console.log(
@@ -187,8 +258,10 @@ function printProjectBlock(projectName: string, deployments: Deployment[]) {
 async function main() {
   const projects = await readProjectNames();
   console.error(
-    `Scanning ${projects.length} project(s). Cutoff: ${new Date(cutoffMs).toISOString()}`,
+    `Scanning ${projects.length} project(s). Cutoff: ${new Date(cutoffMs).toISOString()}. with-aliases=${withAliases}`,
   );
+
+  const aliasMap = withAliases ? await fetchAliasesByDeployment() : null;
 
   let total = 0;
   const failures: string[] = [];
@@ -200,7 +273,7 @@ async function main() {
         console.error(`${project}: nothing to remove`);
         continue;
       }
-      printProjectBlock(project, deployments);
+      printProjectBlock(project, deployments, aliasMap);
       total += deployments.length;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
Adds script to delete old deployments from Vercel.

Requires installing Vercel CLI - script fetches deployments from their API and outputs it as a command to run via Vercel CLI.

The actual safety check is done by Vercel CLI: `--safe` flag makes sure that no deployment is deleted if it has alias assigned (production, staging, branch name, etc.).

Deployments with alias have to be deleted manually, when no `--safe --yes` flags are passed, Vercel CLI asks for confirmation before delete.

Example output:

```
# saleor-app-avatax — 13 deployment(s) older than 7d
#   uid                                   created               target      aliasAssigned         substate    rb  customEnv        url
#   ------------------------------------  --------------------  ----------  --------------------  ----------  --  ---------------  ---
#   dpl_(ommmited)      2026-04-13T11:12:38Z  preview     2026-04-13T11:14:42Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-04-13T10:38:08Z  preview     2026-04-13T10:40:17Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-04-10T11:14:04Z  preview     2026-04-10T11:15:52Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-04-10T10:31:53Z  preview     2026-04-10T10:34:02Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-04-08T15:18:08Z  preview     2026-04-08T15:20:15Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-04-08T11:07:39Z  preview     2026-04-08T11:09:25Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-30T15:41:16Z  preview     2026-03-30T15:43:22Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-30T10:59:52Z  preview     2026-03-30T11:01:58Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-27T14:02:23Z  preview     2026-03-27T14:04:41Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-26T21:55:54Z  preview     2026-03-26T21:58:22Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-26T10:51:58Z  preview     2026-03-26T10:54:09Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-23T09:43:52Z  preview     2026-03-23T09:45:53Z  STAGED      -   -                (ommited)
#   dpl_(ommmited)      2026-03-05T14:32:45Z  preview     2026-03-05T14:35:08Z  STAGED      -   -                (ommited)
# Review the list above. `--safe` will server-side skip any deployment
# that still has an active alias at the moment `vercel remove` runs.
vercel remove (actual deployments) --safe --yes -S <org_slug>
```