### PR TITLE
Avatax: Add dates validation

### DIFF
--- a/.changeset/avatax-logs-date-range-validation.md
+++ b/.changeset/avatax-logs-date-range-validation.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Fixed Client Logs date filter showing an opaque error when the "From" date was after the "To" date. Before, the request was sent and DynamoDB rejected it with a generic validation error. Now the form skips the request and shows a clear inline message, and the API rejects inverted ranges with a 400 response.

--- a/apps/avatax/src/modules/client-logs/client-logs.router.test.ts
+++ b/apps/avatax/src/modules/client-logs/client-logs.router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isDynamoValidationError } from "./client-logs.router";
+import { getByDateInputSchema, isDynamoValidationError } from "./client-logs.router";
 
 describe("isDynamoValidationError", () => {
   it("returns true when cause is a ValidationException", () => {
@@ -45,5 +45,38 @@ describe("isDynamoValidationError", () => {
     const error = new Error("Some error", { cause: "not an error" });
 
     expect(isDynamoValidationError(error)).toBe(false);
+  });
+});
+
+describe("getByDateInputSchema", () => {
+  it("accepts a range where startDate is before endDate", () => {
+    const result = getByDateInputSchema.safeParse({
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-01-02T00:00:00.000Z",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a range where startDate equals endDate", () => {
+    const result = getByDateInputSchema.safeParse({
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an inverted range where startDate is after endDate", () => {
+    const result = getByDateInputSchema.safeParse({
+      startDate: "2026-01-02T00:00:00.000Z",
+      endDate: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(result.success).toBe(false);
+
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("startDate must be before or equal to endDate");
+    }
   });
 });

--- a/apps/avatax/src/modules/client-logs/client-logs.router.ts
+++ b/apps/avatax/src/modules/client-logs/client-logs.router.ts
@@ -16,6 +16,17 @@ import { ClientLogDynamoEntityFactory, LogsTable } from "./dynamo-logs-table";
 
 const logger = createLogger("clientLogsRouter");
 
+export const getByDateInputSchema = z
+  .object({
+    startDate: z.string().datetime(),
+    endDate: z.string().datetime(),
+    lastEvaluatedKey: z.record(z.unknown()).optional(),
+  })
+  .refine((data) => new Date(data.startDate) <= new Date(data.endDate), {
+    message: "startDate must be before or equal to endDate",
+    path: ["startDate"],
+  });
+
 export function isDynamoValidationError(error: unknown): boolean {
   if (error instanceof Error && error.cause instanceof Error) {
     return error.cause.name === "ValidationException";
@@ -64,13 +75,7 @@ const procedureWithLogsRepository = protectedClientProcedure.use(({ ctx, next })
  */
 export const clientLogsRouter = router({
   getByDate: procedureWithLogsRepository
-    .input(
-      z.object({
-        startDate: z.string().datetime(),
-        endDate: z.string().datetime(),
-        lastEvaluatedKey: z.record(z.unknown()).optional(),
-      }),
-    )
+    .input(getByDateInputSchema)
     .query(
       async ({
         input,

--- a/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
+++ b/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
@@ -129,11 +129,16 @@ const LogsByDate = () => {
     };
   });
 
-  const { data, error, isLoading } = trpcClient.clientLogs.getByDate.useQuery({
-    startDate: formatDateForQuery(rangeDates.start),
-    endDate: formatDateForQuery(rangeDates.end),
-    lastEvaluatedKey: currentEvaluatedKey,
-  });
+  const isRangeValid = rangeDates.start <= rangeDates.end;
+
+  const { data, error, isLoading } = trpcClient.clientLogs.getByDate.useQuery(
+    {
+      startDate: formatDateForQuery(rangeDates.start),
+      endDate: formatDateForQuery(rangeDates.end),
+      lastEvaluatedKey: currentEvaluatedKey,
+    },
+    { enabled: isRangeValid },
+  );
 
   const isEmpty = !isLoading && data?.clientLogs && data.clientLogs.length === 0;
   const isLoaded = !isLoading && data?.clientLogs && data.clientLogs.length > 0;
@@ -168,6 +173,9 @@ const LogsByDate = () => {
           <Text marginX={2}>To</Text>
         </RangeInput>
       </Box>
+      {!isRangeValid && (
+        <Text color="critical1">&quot;From&quot; date must be before &quot;To&quot; date</Text>
+      )}
       {error && <Text color="critical1">{error.message}</Text>}
       {isEmpty && <Text>No logs are available for specified date range</Text>}
       {isLoaded && <LogsList logs={logs} />}


### PR DESCRIPTION
Client logs browser lacked validation. When user set end date to be before start date, invalid variables were passed to Database, causing it to crash

Now both tRPC procedure and frontend is validated against it

`INC-1026`