### PR TITLE
Handle JWT failures on the frontend

### DIFF
--- a/.changeset/jwt-verification-401-no-sentry.md
+++ b/.changeset/jwt-verification-401-no-sentry.md
@@ -1,0 +1,12 @@
+---
+"saleor-app-avatax": patch
+"saleor-app-cms": patch
+"saleor-app-payment-np-atobarai": patch
+"saleor-app-products-feed": patch
+"saleor-app-search": patch
+"saleor-app-segment": patch
+"saleor-app-smtp": patch
+"saleor-app-payment-stripe": patch
+---
+
+Failed JWT verification in tRPC procedures no longer reports to Sentry as an error. Before, an expired or invalid token raised a 500 (or 403) and produced an error in monitoring even though it was a normal client-side auth failure. Now it logs a warning and returns 401, so dashboards stay clean and the client can react to the auth state correctly.

--- a/apps/avatax/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/avatax/src/modules/trpc/protected-client-procedure.ts
@@ -89,7 +89,7 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
       ],
     });
   } catch (e) {
-    logger.error("JWT verification failed, throwing", { error: e });
+    logger.warn("JWT verification failed, throwing", { error: e });
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: "JWT verification failed.",

--- a/apps/cms/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/cms/src/modules/trpc/protected-client-procedure.ts
@@ -88,9 +88,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
         ],
       });
     } catch (e) {
-      logger.error("JWT verification failed, throwing", { error: e });
+      logger.warn("JWT verification failed, throwing", { error: e });
       throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
+        code: "UNAUTHORIZED",
         message: "JWT verification failed",
       });
     }

--- a/apps/np-atobarai/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/np-atobarai/src/modules/trpc/protected-client-procedure.ts
@@ -98,9 +98,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
       requiredPermissions: meta?.requiredClientPermissions,
     });
   } catch (e) {
-    logger.error("JWT verification failed, throwing", { error: e });
+    logger.warn("JWT verification failed, throwing", { error: e });
     throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
+      code: "UNAUTHORIZED",
       message: "JWT verification failed",
     });
   }

--- a/apps/products-feed/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/products-feed/src/modules/trpc/protected-client-procedure.ts
@@ -91,9 +91,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
       ],
     });
   } catch (e) {
-    logger.error("JWT verification failed, throwing", { error: e });
+    logger.warn("JWT verification failed, throwing", { error: e });
     throw new TRPCError({
-      code: "INTERNAL_SERVER_ERROR",
+      code: "UNAUTHORIZED",
       message: "JWT verification failed",
     });
   }

--- a/apps/search/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/search/src/modules/trpc/protected-client-procedure.ts
@@ -99,9 +99,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
         ],
       });
     } catch (e) {
-      logger.error("JWT verification failed, throwing", { error: e });
+      logger.warn("JWT verification failed, throwing", { error: e });
       throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
+        code: "UNAUTHORIZED",
         message: "JWT verification failed",
       });
     }

--- a/apps/segment/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/segment/src/modules/trpc/protected-client-procedure.ts
@@ -88,9 +88,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
         ],
       });
     } catch (e) {
-      logger.error("JWT verification failed, throwing", { error: e });
+      logger.warn("JWT verification failed, throwing", { error: e });
       throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
+        code: "UNAUTHORIZED",
         message: "JWT verification failed",
       });
     }

--- a/apps/smtp/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/smtp/src/modules/trpc/protected-client-procedure.ts
@@ -1,7 +1,6 @@
 import { verifyJWT } from "@saleor/app-sdk/auth";
 import { REQUIRED_SALEOR_PERMISSIONS } from "@saleor/apps-shared/permissions";
 import { setSentrySaleorUser } from "@saleor/sentry-utils";
-import { captureException } from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
 
 import { createInstrumentedGraphqlClient } from "../../lib/create-instrumented-graphql-client";
@@ -90,10 +89,9 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
         ],
       });
     } catch (e) {
-      captureException(e);
-      logger.error("JWT verification failed, throwing", { error: e });
+      logger.warn("JWT verification failed, throwing", { error: e });
       throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
+        code: "UNAUTHORIZED",
         message: "JWT verification failed",
       });
     }

--- a/apps/stripe/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/stripe/src/modules/trpc/protected-client-procedure.ts
@@ -100,7 +100,7 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
   } catch (e) {
     logger.warn("JWT verification failed, throwing", { error: e });
     throw new TRPCError({
-      code: "FORBIDDEN",
+      code: "UNAUTHORIZED",
       message: "JWT verification failed",
     });
   }


### PR DESCRIPTION
This PR unifies behavior when user tries to open app frontend *outside* the Dashboard. This fails because JWT token is not attached.

Now it's *not* reporting to sentry and *not* logging error. HTTP returns 401 to the frontend