### PR TITLE
chore: upgrade Axios to v1.15.2

### DIFF
--- a/.changeset/cute-cloths-jam.md
+++ b/.changeset/cute-cloths-jam.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-cms": patch
+---
+
+Upgraded Axios to v1.15.2 to fix CVE-2026-40175 and more

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,7 @@ overrides:
   form-data@>=4.0.0 <=4.0.0: '>=4.0.4'
   protobufjs@<7.5.6: '>=7.5.8 <8'
   protobufjs@>=8 <8.2.0: '>=8.2.0'
+  axios@<1.15.2: '>=1.15.2'
 
 importers:
 
@@ -7344,11 +7345,8 @@ packages:
   aws-sdk-client-mock@4.0.1:
     resolution: {integrity: sha512-yD2mmgy73Xce097G5hIpr1k7j50qzvJ49/+6osGZiCyk4m6cwhb+2x7kKFY1gEMwTzaS8+m8fXv9SB29SkRYyQ==}
 
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
-
-  axios@1.5.1:
-    resolution: {integrity: sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
@@ -8579,15 +8577,6 @@ packages:
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -10573,6 +10562,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -18246,18 +18239,11 @@ snapshots:
       sinon: 16.1.3
       tslib: 2.8.1
 
-  axios@0.27.2:
+  axios@1.15.2:
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.11
       form-data: 4.0.5
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.5.1:
-    dependencies:
-      follow-redirects: 1.15.2
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -18699,7 +18685,7 @@ snapshots:
     dependencies:
       '@contentful/rich-text-types': 16.3.0
       '@types/json-patch': 0.0.30
-      axios: 1.5.1
+      axios: 1.15.2
       contentful-sdk-core: 8.1.0
       fast-copy: 3.0.1
       lodash.isplainobject: 4.0.6
@@ -19773,8 +19759,6 @@ snapshots:
   flatted@3.3.1: {}
 
   follow-redirects@1.15.11: {}
-
-  follow-redirects@1.15.2: {}
 
   for-each@0.3.5:
     dependencies:
@@ -22152,6 +22136,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
   pseudomap@1.0.2: {}
 
   psl@1.9.0: {}
@@ -22839,7 +22825,7 @@ snapshots:
     dependencies:
       '@types/js-cookie': 3.0.3
       '@types/qs': 6.9.7
-      axios: 0.27.2
+      axios: 1.15.2
       defu: 5.0.1
       js-cookie: 3.0.5
       qs: 6.11.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,8 @@ minimumReleaseAgeExclude:
   - "@protobufjs/inquire@1.1.1" # needed by 'protobufjs@7.5.8'
   - "@protobufjs/utf8@1.1.1" # needed by 'protobufjs@7.5.8'
   - "@protobufjs/codegen@2.0.5" # needed by 'protobufjs@7.5.8'
+  # Fixes CVE-2026-40175 and more
+  - axios@1.15.2
 
 # Requires installing versions only with provenance (published via CI, not npm token)
 # Allows installing "downgraded" deps, if they are older than 30 days
@@ -67,6 +69,8 @@ overrides:
   # CVE-2026-44295, CVE-2026-45740
   "protobufjs@<7.5.6": ">=7.5.8 <8"
   "protobufjs@>=8 <8.2.0": ">=8.2.0"
+  # Fixes CVE-2026-40175 and more
+  "axios@<1.15.2": ">=1.15.2"
 
 catalog:
   "node-mocks-http": 1.16.1


### PR DESCRIPTION
Fixes ENG-1561 - only impacts the following:

```
$ pnpm why -r axios
Legend: production dependency, optional only, dev only

saleor-app-cms@2.15.7 /apps/apps/cms (PRIVATE)

dependencies:
contentful-management 10.46.4
└── axios 1.15.2
strapi-sdk-js 2.3.4
└── axios 1.15.2
```


## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
