### PR TITLE
Fix SMTP app fallback configuration loading

### DIFF
--- a/.changeset/fix-smtp-fallback-section-loading.md
+++ b/.changeset/fix-smtp-fallback-section-loading.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-smtp": patch
+---
+
+Fixed the "Fallback behavior" section on the configuration page being stuck in a loading state for apps installed before the fallback setting was introduced. Previously, configurations saved without the fallback setting caused the section to show a skeleton loader forever. Now the section loads correctly, with the fallback disabled by default.

--- a/apps/smtp/src/modules/smtp/configuration/smtp-metadata-manager.test.ts
+++ b/apps/smtp/src/modules/smtp/configuration/smtp-metadata-manager.test.ts
@@ -25,7 +25,31 @@ describe("SmtpMetadataManager", () => {
       const instance = new SmtpMetadataManager(metadataManager, SALEOR_API_URL);
       const result = await instance.getConfig().unwrapOr("error");
 
-      expect(result).toStrictEqual({ key: "value" });
+      expect(result).toStrictEqual({ key: "value", useSaleorSmtpFallback: false });
+    });
+
+    it("defaults useSaleorSmtpFallback to false for configs saved before the field existed", async () => {
+      const metadataManager = new MockSettingsManager();
+
+      vi.spyOn(metadataManager, "get").mockResolvedValue('{"configurations": []}');
+
+      const instance = new SmtpMetadataManager(metadataManager, SALEOR_API_URL);
+      const result = await instance.getConfig().unwrapOr("error");
+
+      expect(result).toStrictEqual({ configurations: [], useSaleorSmtpFallback: false });
+    });
+
+    it("preserves useSaleorSmtpFallback when set in stored config", async () => {
+      const metadataManager = new MockSettingsManager();
+
+      vi.spyOn(metadataManager, "get").mockResolvedValue(
+        '{"configurations": [], "useSaleorSmtpFallback": true}',
+      );
+
+      const instance = new SmtpMetadataManager(metadataManager, SALEOR_API_URL);
+      const result = await instance.getConfig().unwrapOr("error");
+
+      expect(result).toStrictEqual({ configurations: [], useSaleorSmtpFallback: true });
     });
 
     it("raises error when pulling configuration exceeds the timeout", async () => {

--- a/apps/smtp/src/modules/smtp/configuration/smtp-metadata-manager.ts
+++ b/apps/smtp/src/modules/smtp/configuration/smtp-metadata-manager.ts
@@ -65,7 +65,14 @@ export class SmtpMetadataManager {
 
       this.logger.debug("Config found, will parse JSON now");
 
-      return fromThrowable(JSON.parse, SmtpMetadataManager.ParseConfigError.normalize)(config);
+      return fromThrowable(
+        JSON.parse,
+        SmtpMetadataManager.ParseConfigError.normalize,
+      )(config).map((parsed) => ({
+        ...parsed,
+        // Configs saved before this field existed don't have it; default to disabled
+        useSaleorSmtpFallback: parsed.useSaleorSmtpFallback ?? false,
+      }));
     });
   }
 


### PR DESCRIPTION
Fixed the "Fallback behavior" section on the configuration page being stuck in a loading state for apps installed before the fallback setting was introduced. Previously, configurations saved without the fallback setting caused the section to show a skeleton loader forever. Now the section loads correctly, with the fallback disabled by default.