### PR TITLE
Fix tax strategy strict validation

### DIFF
--- a/.changeset/avatax-null-tax-strategy.md
+++ b/.changeset/avatax-null-tax-strategy.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Fixed AvaTax `ORDER_CONFIRMED` webhook failing with a validation error when a channel has no tax calculation strategy configured. Previously the app only accepted `TAX_APP` or `FLAT_RATES` and rejected the payload (returning a 500) when `taxCalculationStrategy` was `null`. Now a `null` strategy is accepted and treated like `FLAT_RATES` — the order is skipped instead of erroring, since the app is not the configured tax calculator for that channel.

--- a/apps/avatax/src/app/api/webhooks/order-confirmed/route.ts
+++ b/apps/avatax/src/app/api/webhooks/order-confirmed/route.ts
@@ -152,25 +152,26 @@ const handler = orderConfirmedAsyncWebhook.createHandler(async (_req, ctx) => {
           );
         }
 
-        if (confirmedOrderEvent.isStrategyFlatRates()) {
-          logger.info("Order has flat rates tax strategy, skipping...");
+        if (!confirmedOrderEvent.isStrategyTaxApp()) {
+          logger.info("Order channel is not configured to use the tax app, skipping...");
 
           OrderConfirmedLogRequest.createErrorLog({
             sourceId: payload.order?.id,
             channelId: payload.order?.channel.id,
-            errorReason: "Order has flat tax rates strategy",
+            errorReason: "Order channel does not use the tax app strategy",
           })
             .mapErr(captureException)
             .map(logWriter.writeLog);
 
           span.setStatus({
             code: SpanStatusCode.OK,
-            message: "Failed to commit transaction in AvaTax: order has flat tax rates strategy",
+            message:
+              "Failed to commit transaction in AvaTax: order channel does not use the tax app strategy",
           });
 
           return Response.json(
             {
-              message: `Order ${payload.order?.id} has flat rates tax strategy.`,
+              message: `Order ${payload.order?.id} channel does not use the tax app strategy.`,
             },
             { status: 202 },
           );

--- a/apps/avatax/src/modules/saleor/order-confirmed/event.test.ts
+++ b/apps/avatax/src/modules/saleor/order-confirmed/event.test.ts
@@ -49,15 +49,15 @@ describe("SaleorOrderConfirmedEvent", () => {
     });
   });
 
-  describe("isStrategyFlatRates method", () => {
-    it("should return false if order has tax calculation strategy set to TAX_APP", () => {
+  describe("isStrategyTaxApp method", () => {
+    it("should return true if order has tax calculation strategy set to TAX_APP", () => {
       const payload = SaleorOrderConfirmedEventMockFactory.getGraphqlPayload();
       const event = SaleorOrderConfirmedEvent.createFromGraphQL(payload)._unsafeUnwrap();
 
-      expect(event.isStrategyFlatRates()).toBe(false);
+      expect(event.isStrategyTaxApp()).toBe(true);
     });
 
-    it("should return true if order has tax calculation strategy set to FLAT_RATES", () => {
+    it("should return false if order has tax calculation strategy set to FLAT_RATES", () => {
       const payload = SaleorOrderConfirmedEventMockFactory.getGraphqlPayload();
       const event = SaleorOrderConfirmedEvent.createFromGraphQL({
         ...payload,
@@ -74,7 +74,27 @@ describe("SaleorOrderConfirmedEvent", () => {
         },
       })._unsafeUnwrap();
 
-      expect(event.isStrategyFlatRates()).toBe(true);
+      expect(event.isStrategyTaxApp()).toBe(false);
+    });
+
+    it("should return false if order has tax calculation strategy set to null", () => {
+      const payload = SaleorOrderConfirmedEventMockFactory.getGraphqlPayload();
+      const event = SaleorOrderConfirmedEvent.createFromGraphQL({
+        ...payload,
+        order: {
+          ...payload.order,
+          channel: {
+            slug: "channel-slug",
+            id: "channel-id",
+            taxConfiguration: {
+              pricesEnteredWithTax: true,
+              taxCalculationStrategy: null,
+            },
+          },
+        },
+      })._unsafeUnwrap();
+
+      expect(event.isStrategyTaxApp()).toBe(false);
     });
   });
 

--- a/apps/avatax/src/modules/saleor/order-confirmed/event.ts
+++ b/apps/avatax/src/modules/saleor/order-confirmed/event.ts
@@ -21,7 +21,9 @@ export class SaleorOrderConfirmedEvent {
       channel: z.object({
         taxConfiguration: z.object({
           pricesEnteredWithTax: z.boolean(),
-          taxCalculationStrategy: z.union([z.literal("TAX_APP"), z.literal("FLAT_RATES")]),
+          taxCalculationStrategy: z
+            .union([z.literal("TAX_APP"), z.literal("FLAT_RATES")])
+            .nullable(),
         }),
         slug: z.string(),
       }),
@@ -85,8 +87,13 @@ export class SaleorOrderConfirmedEvent {
 
   isFulfilled = () => this.rawPayload.order.status === "FULFILLED";
 
-  isStrategyFlatRates = () =>
-    this.rawPayload.order.channel.taxConfiguration.taxCalculationStrategy === "FLAT_RATES";
+  /**
+   * Returns true only when the channel is explicitly configured to use the tax app (TAX_APP).
+   * Any other value - FLAT_RATES or a missing strategy (null) - means the app is not the tax
+   * calculator for that channel, so we skip committing to AvaTax.
+   */
+  isStrategyTaxApp = () =>
+    this.rawPayload.order.channel.taxConfiguration.taxCalculationStrategy === "TAX_APP";
 
   getIsTaxIncluded = () => this.rawPayload.order.channel.taxConfiguration.pricesEnteredWithTax;
 


### PR DESCRIPTION
Fixes too strict validation of Saleor payload, causing app returning 500 instead gracefully ignoring the event