### PR TITLE
ENG-1670 Use full gift card code in sent email template

### DIFF
--- a/.changeset/smtp-gift-card-full-code.md
+++ b/.changeset/smtp-gift-card-full-code.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-smtp": patch
+---
+
+Fixed the default "Gift card sent" email template so it shows the full redeemable gift card code instead of the masked display code. Before, the email rendered `giftCard.displayCode`, which only contains the last 4 characters of the code, so customers could not actually redeem the gift card. Now the template uses `giftCard.code` and shows the complete code.

--- a/apps/smtp/src/modules/smtp/default-templates.ts
+++ b/apps/smtp/src/modules/smtp/default-templates.ts
@@ -453,7 +453,7 @@ ${mjHead}
     <mj-section padding="24px 0 0">
       <mj-column background-color="${colors.accent}" border-radius="8px" padding="24px">
         <mj-text font-size="12px" font-weight="600" color="${colors.muted}" letter-spacing="1px" padding="0 0 8px">YOUR GIFT CARD CODE</mj-text>
-        <mj-text font-size="28px" font-weight="700" color="${colors.primary}" letter-spacing="2px" padding="0 0 16px">{{giftCard.displayCode}}</mj-text>
+        <mj-text font-size="28px" font-weight="700" color="${colors.primary}" letter-spacing="2px" padding="0 0 16px">{{giftCard.code}}</mj-text>
         {{#if giftCard.currentBalance}}
         <mj-text font-size="18px" font-weight="600" color="${colors.primary}" padding="0 0 4px">
           {{giftCard.currentBalance.amount}} {{giftCard.currentBalance.currency}}


### PR DESCRIPTION
The default "Gift card sent" template rendered `giftCard.displayCode`, which Saleor returns masked (last 4 chars only), so customers received an unusable code. Switch to `giftCard.code` to show the full, redeemable code. The field is already fetched in the webhook fragment, so no schema/codegen change is needed.