### PR TITLE
Remove pnpm audit CI job in favor of Socket.dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,31 +9,6 @@ on:
       - main
 
 jobs:
-  audit:
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: production
-            flag: --prod
-            level: moderate
-          - name: dev
-            flag: --dev
-            level: high
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup PNPM
-        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          run_install: false
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "pnpm"
-      - name: Audit ${{ matrix.name }} dependencies
-        run: pnpm audit ${{ matrix.flag }} --audit-level ${{ matrix.level }}
-
   lint:
     runs-on: ubuntu-22.04
     env:

--- a/adr/0003-use-socket-dev-for-dependency-security.md
+++ b/adr/0003-use-socket-dev-for-dependency-security.md
@@ -1,0 +1,30 @@
+# 3. Use Socket.dev for dependency security
+
+Date: 2026-06-29
+
+## Status
+
+Accepted
+
+## Context
+
+We previously ran `pnpm audit` as a job in our CI (`main.yml`) on every pull request to detect known vulnerabilities in our dependencies. While useful, `pnpm audit` has notable limitations:
+
+- It only reports against the public advisory database (known CVEs), so it misses supply chain threats such as malicious packages, install scripts, typosquatting, or compromised maintainers.
+- It produces noisy results that frequently fail CI on advisories we cannot act on (e.g. transitive dependencies with no available fix), forcing manual triage or overrides.
+- It provides no signal on the introduction of new risky dependencies in a pull request.
+
+We have adopted [Socket.dev](https://socket.dev), which continuously monitors our dependencies and analyzes the actual behavior of packages (network access, filesystem access, install scripts, shell access, etc.) rather than relying solely on a CVE database. Socket integrates directly with GitHub and surfaces findings on pull requests.
+
+## Decision
+
+We will use Socket.dev as our dependency security tooling and remove the `pnpm audit` job from CI.
+
+Dependency security checks are now handled by the Socket.dev GitHub integration, which reviews pull requests for supply chain risks and known vulnerabilities.
+
+## Consequences
+
+- The `audit` job has been removed from `.github/workflows/main.yml`. Pull requests no longer fail on `pnpm audit` results.
+- Dependency security signal comes from Socket.dev's GitHub integration instead of CI.
+- Developers should review Socket.dev findings on pull requests as part of the review process.
+- Configuration and policy for Socket.dev is managed through the Socket.dev dashboard/GitHub app rather than in the repository's CI configuration.


### PR DESCRIPTION
Drop the audit job from main.yml that ran pnpm audit on every PR, and add ADR 0003 documenting the decision to use Socket.dev for dependency security instead.

## Scope of the PR

<!-- Describe briefly the changes made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
