### PR TITLE
build: switch labeller to `pull_request` event

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,9 @@
 name: "Pull Request Labeler"
 
 on:
-  - pull_request_target
+  pull_request:
+
+permissions: {}
 
 jobs:
   triage:


### PR DESCRIPTION
`pull_request_target` is not really needed in our context as we do not really receive any external contribution (other than bots/agents)

Thus, this doesn't warrant the risks that `pull_request_target` exposes Saleor to



## Checklist

- [x] I added changesets and [read good practices](/.changeset/README.md).
