### PR TITLE
PXTX-812 Use SEO description in Google feed when available

### DIFF
--- a/.changeset/products-feed-seo-description.md
+++ b/.changeset/products-feed-seo-description.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": patch
+---
+
+The Google Merchant Center feed now uses a product's SEO description for the `g:description` attribute when one is set. Before, the feed always used the regular product description; now it prefers the SEO description and only falls back to the regular description when the SEO description is empty. This lets merchants control the description sent to Google Merchant Center via the product's SEO settings.

--- a/apps/products-feed/src/modules/google-feed/get-description-attribute-value.test.ts
+++ b/apps/products-feed/src/modules/google-feed/get-description-attribute-value.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { getDescriptionAttributeValue } from "./get-description-attribute-value";
+
+const editorJsDescription = JSON.stringify({
+  time: 1,
+  version: "2.24.3",
+  blocks: [{ id: "1", type: "paragraph", data: { text: "Rich text description" } }],
+});
+
+describe("getDescriptionAttributeValue", () => {
+  it("Returns SEO description when it is available", () => {
+    expect(
+      getDescriptionAttributeValue({
+        description: editorJsDescription,
+        seoDescription: "SEO description",
+      }),
+    ).toBe("SEO description");
+  });
+
+  it("Falls back to rendered rich-text description when SEO description is empty", () => {
+    expect(
+      getDescriptionAttributeValue({
+        description: editorJsDescription,
+        seoDescription: "",
+      }),
+    ).toBe("Rich text description");
+  });
+
+  it("Falls back to rendered rich-text description when SEO description is missing", () => {
+    expect(
+      getDescriptionAttributeValue({
+        description: editorJsDescription,
+        seoDescription: null,
+      }),
+    ).toBe("Rich text description");
+  });
+
+  it("Returns undefined when neither SEO nor rich-text description is available", () => {
+    expect(
+      getDescriptionAttributeValue({
+        description: "",
+        seoDescription: "",
+      }),
+    ).toBe(undefined);
+
+    expect(getDescriptionAttributeValue({})).toBe(undefined);
+  });
+});

--- a/apps/products-feed/src/modules/google-feed/get-description-attribute-value.ts
+++ b/apps/products-feed/src/modules/google-feed/get-description-attribute-value.ts
@@ -1,0 +1,24 @@
+import { EditorJsPlaintextRenderer } from "@saleor/apps-shared/editor-js-plaintext-renderer";
+
+interface GetDescriptionAttributeValueArgs {
+  description?: string | null;
+  seoDescription?: string | null;
+}
+
+/*
+ * Returns value for the "g:description" attribute.
+ * Prefers the product's SEO description (plain text) when available,
+ * otherwise falls back to the rich-text description rendered to plain text.
+ *
+ * Google Docs specification: https://support.google.com/merchants/answer/6324468?hl=en
+ */
+export const getDescriptionAttributeValue = ({
+  description,
+  seoDescription,
+}: GetDescriptionAttributeValueArgs) => {
+  if (seoDescription?.length) {
+    return seoDescription;
+  }
+
+  return EditorJsPlaintextRenderer({ stringData: description ?? "" });
+};

--- a/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
+++ b/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
@@ -1,10 +1,9 @@
-import { EditorJsPlaintextRenderer } from "@saleor/apps-shared/editor-js-plaintext-renderer";
-
 import { type RootConfig } from "../app-configuration/app-config";
 import { renderHandlebarsTemplate } from "../handlebarsTemplates/render-handlebars-template";
 import { transformTemplateFormat } from "../handlebarsTemplates/transform-template-format";
 import { getMappedAttributes } from "./attribute-mapping";
 import { type ProductVariant } from "./fetch-product-data";
+import { getDescriptionAttributeValue } from "./get-description-attribute-value";
 import { getRelatedMedia, getVariantMediaMap } from "./get-related-media";
 import { getWeightAttributeValue } from "./get-weight-attribute-value";
 import { priceMapping } from "./price-mapping";
@@ -74,7 +73,10 @@ export const productVariantToProxy = ({
     slug: variant.product.slug,
     variantId: variant.id,
     sku: variant.sku ?? undefined,
-    description: EditorJsPlaintextRenderer({ stringData: variant.product.description ?? "" }),
+    description: getDescriptionAttributeValue({
+      description: variant.product.description,
+      seoDescription: variant.product.seoDescription,
+    }),
     availability:
       variant.quantityAvailable && variant.quantityAvailable > 0 ? "in_stock" : "out_of_stock",
     category: variant.product.category?.name || "unknown",


### PR DESCRIPTION
Product Feed app now prefers a product's SEO description for the g:description attribute in the Google Merchant Center feed, falling back to the regular (EditorJS) description only when the SEO description is empty.

