### PR TITLE
Allow using SKU as GTIN attribute

### DIFF
--- a/.changeset/products-feed-sku-as-gtin.md
+++ b/.changeset/products-feed-sku-as-gtin.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-products-feed": patch
+---
+
+Added a "Use SKU as GTIN" toggle to the Google feed attribute mapping. When enabled, variants without a mapped GTIN attribute use their SKU as the GTIN, so you no longer need to duplicate SKUs into a custom attribute. Products that have a mapped GTIN attribute keep that value.

--- a/apps/products-feed/src/modules/app-configuration/app-config.test.ts
+++ b/apps/products-feed/src/modules/app-configuration/app-config.test.ts
@@ -26,6 +26,7 @@ const exampleAttributeMappingConfig: RootConfig["attributeMapping"] = {
   sizeAttributeIds: [],
   gtinAttributeIds: [],
   shippingLabelAttributeIds: [],
+  useSkuAsGtin: false,
 };
 
 const exampleTitleTemplate: RootConfig["titleTemplate"] =
@@ -57,6 +58,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: [],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: [],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{variant.product.name}} - {{variant.name}}",
         imageSize: 1024,
@@ -91,6 +93,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: [],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: [],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{variant.product.name}} - {{variant.name}}",
         imageSize: 1024,
@@ -124,6 +127,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: [],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: [],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{ variant.name }}",
         imageSize: 1024,
@@ -149,6 +153,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: [],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: [],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{ variant.name }}",
         imageSize: 1024,
@@ -180,6 +185,7 @@ describe("AppConfig", function () {
         sizeAttributeIds: ["size-id"],
         gtinAttributeIds: [],
         shippingLabelAttributeIds: ["shipping-label-id"],
+        useSkuAsGtin: false,
       },
       titleTemplate: "{{ variant.product.name }} - {{ variant.name }}",
       imageSize: 1024,
@@ -209,6 +215,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: ["size-id"],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: ["shipping-label-id"],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{ variant.product.name }} - {{ variant.name }}",
         imageSize: 1024,
@@ -239,6 +246,7 @@ describe("AppConfig", function () {
           sizeAttributeIds: ["size-id"],
           gtinAttributeIds: [],
           shippingLabelAttributeIds: ["shipping-label-id"],
+          useSkuAsGtin: false,
         },
         titleTemplate: "{{ variant.product.name }} - {{ variant.name }}",
         imageSize: 1024,
@@ -272,6 +280,7 @@ describe("AppConfig", function () {
         sizeAttributeIds: ["size-id"],
         gtinAttributeIds: [],
         shippingLabelAttributeIds: ["shipping-label-id"],
+        useSkuAsGtin: false,
       });
     });
   });
@@ -338,5 +347,28 @@ describe("AppConfig", function () {
       accessKeyId: "access",
       secretAccessKey: "secret",
     });
+  });
+
+  it("Defaults useSkuAsGtin to false when not provided", () => {
+    const config = new AppConfig();
+
+    expect(config.getAttributeMapping()?.useSkuAsGtin).toBe(false);
+  });
+
+  it("Persists useSkuAsGtin when set through attribute mapping", () => {
+    const config = new AppConfig();
+
+    config.setAttributeMapping({
+      brandAttributeIds: [],
+      colorAttributeIds: [],
+      patternAttributeIds: [],
+      materialAttributeIds: [],
+      sizeAttributeIds: [],
+      gtinAttributeIds: [],
+      shippingLabelAttributeIds: [],
+      useSkuAsGtin: true,
+    });
+
+    expect(config.getAttributeMapping()?.useSkuAsGtin).toBe(true);
   });
 });

--- a/apps/products-feed/src/modules/app-configuration/app-config.ts
+++ b/apps/products-feed/src/modules/app-configuration/app-config.ts
@@ -26,6 +26,7 @@ const attributeMappingSchema = z.object({
   patternAttributeIds: z.array(z.string()).default([]),
   gtinAttributeIds: z.array(z.string()).default([]),
   shippingLabelAttributeIds: z.array(z.string()).default([]),
+  useSkuAsGtin: z.boolean().default(false),
 });
 
 const s3ConfigSchema = z.object({

--- a/apps/products-feed/src/modules/app-configuration/attribute-mapping-form.tsx
+++ b/apps/products-feed/src/modules/app-configuration/attribute-mapping-form.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useDashboardNotification } from "@saleor/apps-shared/use-dashboard-notification";
 import { Box, Button, Text } from "@saleor/macaw-ui";
-import { Multiselect } from "@saleor/react-hook-form-macaw";
+import { Multiselect, Toggle } from "@saleor/react-hook-form-macaw";
 import { useCallback, useMemo } from "react";
 import { useForm } from "react-hook-form";
 
@@ -65,12 +65,22 @@ export const AttributeMappingConfigurationForm = (props: Props) => {
         label="Size attributes"
         options={options}
       />
-      <Multiselect
-        control={control}
-        name="gtinAttributeIds"
-        label="GTIN attributes"
-        options={options}
-      />
+      <Box display={"flex"} flexDirection={"column"} gap={2}>
+        <Multiselect
+          control={control}
+          name="gtinAttributeIds"
+          label="GTIN attributes"
+          options={options}
+        />
+        <Toggle name="useSkuAsGtin" control={control}>
+          <Text>Use SKU as GTIN (fallback)</Text>
+        </Toggle>
+        <Text size={2} color={"default2"}>
+          When a product has no mapped GTIN attribute, its SKU is used as the GTIN. Products with a
+          mapped GTIN attribute keep that value. Only enable this if your SKUs are genuine
+          GTINs/barcodes — Google may reject invalid GTIN values.
+        </Text>
+      </Box>
       <Multiselect
         control={control}
         name="shippingLabelAttributeIds"

--- a/apps/products-feed/src/modules/app-configuration/attribute-mapping-form.tsx
+++ b/apps/products-feed/src/modules/app-configuration/attribute-mapping-form.tsx
@@ -125,6 +125,7 @@ export const ConnectedAttributeMappingForm = () => {
       materialAttributeIds: [],
       gtinAttributeIds: [],
       shippingLabelAttributeIds: [],
+      useSkuAsGtin: false,
     };
   }, [data]);
 

--- a/apps/products-feed/src/modules/google-feed/attribute-mapping.test.ts
+++ b/apps/products-feed/src/modules/google-feed/attribute-mapping.test.ts
@@ -159,6 +159,7 @@ describe("attribute-mapping", () => {
             sizeAttributeIds: ["size-id"],
             gtinAttributeIds: ["gtin-id"],
             shippingLabelAttributeIds: ["shipping-label-id"],
+            useSkuAsGtin: false,
           },
         }),
       ).toStrictEqual({
@@ -274,6 +275,7 @@ describe("attribute-mapping", () => {
             patternAttributeIds: ["pattern-id"],
             gtinAttributeIds: ["gtin-id"],
             shippingLabelAttributeIds: ["shipping-label-id"],
+            useSkuAsGtin: false,
           },
         }),
       ).toStrictEqual({

--- a/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.test.ts
+++ b/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { type RootConfig } from "../app-configuration/app-config";
+import { type ProductVariant } from "./fetch-product-data";
+import { productVariantToProxy } from "./product-variant-to-proxy";
+
+const productBase: ProductVariant["product"] = {
+  name: "Product",
+  __typename: "Product",
+  id: "product-id",
+  category: {
+    id: "cat-id",
+    __typename: "Category",
+    name: "Category Name",
+    googleCategoryId: "1",
+  },
+  productType: {
+    isShippingRequired: true,
+  },
+  description: "Product description",
+  seoDescription: "Seo description",
+  slug: "product-slug",
+  thumbnail: { __typename: "Image", url: "" },
+  attributes: [
+    {
+      attribute: { id: "gtin-attr" },
+      values: [{ name: "mapped-gtin-value" }],
+    },
+  ],
+};
+
+const priceBase: ProductVariant["pricing"] = {
+  __typename: "VariantPricingInfo",
+  price: {
+    __typename: "TaxedMoney",
+    gross: { __typename: "Money", amount: 1, currency: "USD" },
+  },
+};
+
+const baseMapping: RootConfig["attributeMapping"] = {
+  brandAttributeIds: [],
+  colorAttributeIds: [],
+  patternAttributeIds: [],
+  materialAttributeIds: [],
+  sizeAttributeIds: [],
+  gtinAttributeIds: [],
+  shippingLabelAttributeIds: [],
+  useSkuAsGtin: false,
+};
+
+const buildVariant = (overrides?: Partial<ProductVariant>): ProductVariant => ({
+  id: "variant-id",
+  __typename: "ProductVariant",
+  sku: "SKU-123",
+  quantityAvailable: 1,
+  pricing: priceBase,
+  name: "Variant",
+  product: productBase,
+  attributes: [],
+  ...overrides,
+});
+
+const findGtin = (item: { [key: string]: unknown }[]) => item.find((entry) => "g:gtin" in entry);
+
+const run = (variant: ProductVariant, attributeMapping: RootConfig["attributeMapping"]) =>
+  productVariantToProxy({
+    variant,
+    titleTemplate: "{{variant.product.name}}",
+    productStorefrontUrl: "https://example.com/product",
+    attributeMapping,
+  });
+
+describe("productVariantToProxy — GTIN resolution", () => {
+  it("uses the mapped GTIN attribute value even when useSkuAsGtin is on", () => {
+    const result = run(buildVariant(), {
+      ...baseMapping,
+      gtinAttributeIds: ["gtin-attr"],
+      useSkuAsGtin: true,
+    });
+
+    expect(findGtin(result.item)).toStrictEqual({
+      "g:gtin": [{ "#text": "mapped-gtin-value" }],
+    });
+  });
+
+  it("falls back to SKU when no GTIN attribute is mapped and useSkuAsGtin is on", () => {
+    const result = run(buildVariant(), {
+      ...baseMapping,
+      useSkuAsGtin: true,
+    });
+
+    expect(findGtin(result.item)).toStrictEqual({
+      "g:gtin": [{ "#text": "SKU-123" }],
+    });
+  });
+
+  it("omits GTIN when useSkuAsGtin is on but the variant has no SKU", () => {
+    const result = run(buildVariant({ sku: null }), {
+      ...baseMapping,
+      useSkuAsGtin: true,
+    });
+
+    expect(findGtin(result.item)).toBeUndefined();
+  });
+
+  it("does not use SKU when useSkuAsGtin is off (regression)", () => {
+    const result = run(buildVariant(), {
+      ...baseMapping,
+      useSkuAsGtin: false,
+    });
+
+    expect(findGtin(result.item)).toBeUndefined();
+  });
+});

--- a/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.test.ts
+++ b/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.test.ts
@@ -111,4 +111,35 @@ describe("productVariantToProxy — GTIN resolution", () => {
 
     expect(findGtin(result.item)).toBeUndefined();
   });
+
+  it("falls through to SKU when mapped GTIN attribute is an empty string", () => {
+    const productWithEmptyGtin: ProductVariant["product"] = {
+      ...productBase,
+      attributes: [
+        {
+          attribute: { id: "gtin-attr" },
+          values: [{ name: "" }],
+        },
+      ],
+    };
+
+    const result = run(buildVariant({ product: productWithEmptyGtin }), {
+      ...baseMapping,
+      gtinAttributeIds: ["gtin-attr"],
+      useSkuAsGtin: true,
+    });
+
+    expect(findGtin(result.item)).toStrictEqual({
+      "g:gtin": [{ "#text": "SKU-123" }],
+    });
+  });
+
+  it("omits GTIN when useSkuAsGtin is on but the SKU is an empty string", () => {
+    const result = run(buildVariant({ sku: "" }), {
+      ...baseMapping,
+      useSkuAsGtin: true,
+    });
+
+    expect(findGtin(result.item)).toBeUndefined();
+  });
 });

--- a/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
+++ b/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
@@ -89,7 +89,7 @@ export const productVariantToProxy = ({
     pattern: attributes?.pattern,
     size: attributes?.size,
     gtin:
-      attributes?.gtin || (attributeMapping?.useSkuAsGtin ? variant.sku ?? undefined : undefined),
+      attributes?.gtin || (attributeMapping?.useSkuAsGtin ? variant.sku || undefined : undefined),
     shipping_label: attributes?.shipping_label,
     weight,
     ...pricing,

--- a/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
+++ b/apps/products-feed/src/modules/google-feed/product-variant-to-proxy.ts
@@ -88,7 +88,8 @@ export const productVariantToProxy = ({
     brand: attributes?.brand,
     pattern: attributes?.pattern,
     size: attributes?.size,
-    gtin: attributes?.gtin,
+    gtin:
+      attributes?.gtin || (attributeMapping?.useSkuAsGtin ? variant.sku ?? undefined : undefined),
     shipping_label: attributes?.shipping_label,
     weight,
     ...pricing,

--- a/cspell.config.js
+++ b/cspell.config.js
@@ -84,7 +84,7 @@ export default {
     "Neue",
     "Segoe",
     "Undiscounted",
-    "OIDC", "oidc", "CANCELATION", "saleors"
+    "OIDC", "oidc", "CANCELATION", "saleors", "GTIN"
   ],
   language: "en-US",
   useGitignore: true,


### PR DESCRIPTION
Add useSkuAsGtin boolean field to app configuration

Once set, app will use SKU (from Saleor) and set it as GTIN attribute in the XML.

Configured custom attribute (attribute → GTIN mapping) will still override SKU.

Field is optional - SKU doesn't have to be in GTIN format