### PR TITLE
fix(smtp): map config service errors to correct tRPC codes

### DIFF
--- a/.changeset/smtp-template-validation-bad-request.md
+++ b/.changeset/smtp-template-validation-bad-request.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-smtp": patch
+---
+
+Fixed saving an email event configuration with an invalid template (e.g. a Handlebars helper called with the wrong argument type) returning a generic "Internal server error". These template problems are now reported as validation errors, so the UI shows the actual reason (for example "expected the first argument to be a number") instead of an unexpected server error. As a side effect, invalid-template attempts are no longer reported as application errors in monitoring.

--- a/apps/smtp/src/modules/smtp/configuration/smtp-configuration.router.test.ts
+++ b/apps/smtp/src/modules/smtp/configuration/smtp-configuration.router.test.ts
@@ -2,7 +2,11 @@ import { TRPCError } from "@trpc/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { saleorApp } from "../../../saleor-app";
-import { smtpConfigurationRouter } from "./smtp-configuration.router";
+import {
+  smtpConfigurationRouter,
+  throwTrpcErrorFromConfigurationServiceError,
+} from "./smtp-configuration.router";
+import { SmtpConfigurationService } from "./smtp-configuration.service";
 
 const validMjmlTemplate = `<mjml>
   <mj-body>
@@ -262,6 +266,71 @@ describe("smtpConfigurationRouter", () => {
           expect(trpcError.message.length).toBeGreaterThan(0);
         }
       });
+    });
+  });
+
+  describe("throwTrpcErrorFromConfigurationServiceError", () => {
+    const getThrownError = (error: unknown) => {
+      try {
+        throwTrpcErrorFromConfigurationServiceError(error);
+      } catch (e) {
+        return e as TRPCError;
+      }
+
+      throw new Error("Expected function to throw");
+    };
+
+    it("should map TemplateValidationError to BAD_REQUEST (not INTERNAL_SERVER_ERROR)", () => {
+      const error = new SmtpConfigurationService.TemplateValidationError(
+        "expected the first argument to be a number",
+        { props: { errorContext: "BODY_TEMPLATE" } },
+      );
+
+      const thrown = getThrownError(error);
+
+      expect(thrown).toBeInstanceOf(TRPCError);
+      expect(thrown.code).toBe("BAD_REQUEST");
+      expect(thrown.message).toBe("expected the first argument to be a number");
+    });
+
+    it("should map ConfigNotFoundError to NOT_FOUND", () => {
+      const error = new SmtpConfigurationService.ConfigNotFoundError("Configuration not found");
+
+      const thrown = getThrownError(error);
+
+      expect(thrown.code).toBe("NOT_FOUND");
+    });
+
+    it("should map EventConfigNotFoundError to NOT_FOUND", () => {
+      const error = new SmtpConfigurationService.EventConfigNotFoundError(
+        "Event configuration not found",
+      );
+
+      const thrown = getThrownError(error);
+
+      expect(thrown.code).toBe("NOT_FOUND");
+    });
+
+    it("should map CantFetchConfigError to INTERNAL_SERVER_ERROR", () => {
+      const error = new SmtpConfigurationService.CantFetchConfigError("Can't fetch configuration");
+
+      const thrown = getThrownError(error);
+
+      expect(thrown.code).toBe("INTERNAL_SERVER_ERROR");
+    });
+
+    it("should map WrongSaleorVersionError to INTERNAL_SERVER_ERROR", () => {
+      const error = new SmtpConfigurationService.WrongSaleorVersionError("Wrong Saleor version");
+
+      const thrown = getThrownError(error);
+
+      expect(thrown.code).toBe("INTERNAL_SERVER_ERROR");
+    });
+
+    it("should map unknown errors to INTERNAL_SERVER_ERROR", () => {
+      const thrown = getThrownError(new Error("Some unexpected error"));
+
+      expect(thrown.code).toBe("INTERNAL_SERVER_ERROR");
     });
   });
 

--- a/apps/smtp/src/modules/smtp/configuration/smtp-configuration.service.ts
+++ b/apps/smtp/src/modules/smtp/configuration/smtp-configuration.service.ts
@@ -49,13 +49,19 @@ function hasErrorContext(error: unknown): error is { errorContext?: ErrorContext
 
 export class SmtpConfigurationService implements IGetSmtpConfiguration, IGetFallbackSmtpEnabled {
   static SmtpConfigurationServiceError = BaseError.subclass("SmtpConfigurationServiceError");
-  static ConfigNotFoundError = BaseError.subclass("ConfigNotFoundError");
-  static EventConfigNotFoundError = BaseError.subclass("EventConfigNotFoundError");
-  static CantFetchConfigError = BaseError.subclass("CantFetchConfigError");
-  static WrongSaleorVersionError = BaseError.subclass("WrongSaleorVersionError");
-  static TemplateValidationError = BaseError.subclass("TemplateValidationError", {
-    props: {} as TemplateValidationErrorProps,
-  });
+  static ConfigNotFoundError = this.SmtpConfigurationServiceError.subclass("ConfigNotFoundError");
+  static EventConfigNotFoundError = this.SmtpConfigurationServiceError.subclass(
+    "EventConfigNotFoundError",
+  );
+  static CantFetchConfigError = this.SmtpConfigurationServiceError.subclass("CantFetchConfigError");
+  static WrongSaleorVersionError =
+    this.SmtpConfigurationServiceError.subclass("WrongSaleorVersionError");
+  static TemplateValidationError = this.SmtpConfigurationServiceError.subclass(
+    "TemplateValidationError",
+    {
+      props: {} as TemplateValidationErrorProps,
+    },
+  );
 
   private configurationData?: SmtpConfig;
   private metadataConfigurator: SmtpMetadataManager;


### PR DESCRIPTION
Template validation errors (and other SmtpConfigurationService errors) were surfaced as INTERNAL_SERVER_ERROR instead of BAD_REQUEST/NOT_FOUND.

The error subclasses were created via BaseError.subclass(), making them siblings of SmtpConfigurationServiceError rather than children. The router's error mapper is gated on
`instanceof SmtpConfigurationServiceError`, which was therefore always false, so every error fell through to the generic INTERNAL_SERVER_ERROR. This also caused validation errors to be logged at ERROR level (the tRPC wrapper only escalates INTERNAL_SERVER_ERROR), flooding monitoring.

Make the subclasses actual children of SmtpConfigurationServiceError so the mapper matches, matching the pattern already used in EmailCompiler.

## Scope of the PR

<!-- Describe briefly the changes made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
