### PR TITLE
fix(stripe): downgrade missing-config webhook log to warning

### DIFF
--- a/.changeset/stripe-config-missing-warning.md
+++ b/.changeset/stripe-config-missing-warning.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-payment-stripe": patch
+---
+
+Stripe no longer raises an error alert when it receives webhook events for a configuration that no longer exists. This happens when a configuration is deleted but its webhook endpoint is still active in Stripe — something outside the app's control. The situation is now surfaced to you as an App Problem, prompting you to remove the orphaned webhook in your Stripe Dashboard.

--- a/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
@@ -336,7 +336,9 @@ export class StripeWebhookUseCase {
     }
 
     if (!config.value) {
-      this.logger.error("Config for given webhook is missing");
+      // Not an app error - Stripe may keep sending events for a deleted config (orphaned webhook).
+      // Surfaced to the user via AppProblems below instead of alerting us.
+      this.logger.warn("Config for given webhook is missing");
 
       after(() => problemReporter.reportConfigMissing(webhookParams.configurationId));
 

--- a/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/use-case.ts
@@ -336,8 +336,10 @@ export class StripeWebhookUseCase {
     }
 
     if (!config.value) {
-      // Not an app error - Stripe may keep sending events for a deleted config (orphaned webhook).
-      // Surfaced to the user via AppProblems below instead of alerting us.
+      /*
+       * Not an app error - Stripe may keep sending events for a deleted config (orphaned webhook).
+       * Surfaced to the user via AppProblems below instead of alerting us.
+       */
       this.logger.warn("Config for given webhook is missing");
 
       after(() => problemReporter.reportConfigMissing(webhookParams.configurationId));


### PR DESCRIPTION
Stripe may keep sending events for a deleted config (orphaned webhook), which we don't control. **Log it as a warning instead of an error so it stops alerting,** and rely on the existing AppProblems report to surface it to the user.
