### PR TITLE
fix: align lucide icon sizes and orders icon with dashboard conventions

### DIFF
--- a/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
+++ b/apps/avatax/src/modules/client-logs/ui/logs-browser.tsx
@@ -86,13 +86,13 @@ const LogsPagiation = ({
         <Button
           onClick={onBackwardButtonClick}
           disabled={isBackwardButtonDisabled}
-          icon={<ChevronLeft size={20} />}
+          icon={<ChevronLeft size={16} />}
           variant="secondary"
         />
         <Button
           onClick={onForwardButtonClick}
           disabled={isForwardButtonDisabled}
-          icon={<ChevronRight size={20} />}
+          icon={<ChevronRight size={16} />}
           variant="secondary"
         />
       </Box>

--- a/apps/avatax/src/modules/ui/providers-table.tsx
+++ b/apps/avatax/src/modules/ui/providers-table.tsx
@@ -30,7 +30,7 @@ export const ProvidersTable = () => {
               <Box display={"flex"} justifyContent={"flex-end"} gap={2}>
                 <Button
                   onClick={() => editClickHandler(item)}
-                  icon={<Pencil size={20} />}
+                  icon={<Pencil size={16} />}
                   data-testid="provider-edit-button"
                   variant="secondary"
                 >

--- a/apps/cms/src/modules/bulk-sync/bulk-sync-view.tsx
+++ b/apps/cms/src/modules/bulk-sync/bulk-sync-view.tsx
@@ -117,7 +117,7 @@ export const BulkSyncView = ({
           <Breadcrumbs.Item key="connection-name">
             <Box display="flex" gap={2} alignItems="center">
               {connection.channelSlug}
-              <ArrowRight size={20} /> {configuration.configName}
+              <ArrowRight size={16} /> {configuration.configName}
             </Box>
           </Breadcrumbs.Item>,
         ]}

--- a/apps/cms/src/modules/channel-provider-connection/add-connection-form.tsx
+++ b/apps/cms/src/modules/channel-provider-connection/add-connection-form.tsx
@@ -66,7 +66,7 @@ export const AddConnectionForm = (props: {
             })) ?? []
           }
         />
-        <ArrowRight size={20} />
+        <ArrowRight size={16} />
         <Select
           required
           size="small"

--- a/apps/dummy-payment-app/src/pages/app/checkout.tsx
+++ b/apps/dummy-payment-app/src/pages/app/checkout.tsx
@@ -398,7 +398,7 @@ const CheckoutPage = () => {
                   </Box>
                   <Button
                     variant="tertiary"
-                    icon={<Trash2 size={20} />}
+                    icon={<Trash2 size={16} />}
                     disabled={isBusy}
                     onClick={() => handleRemoveLine(index)}
                   />
@@ -424,21 +424,21 @@ const CheckoutPage = () => {
           >
             Create checkout
           </Button>
-          <ArrowRight size={20} />
+          <ArrowRight size={16} />
           <Button
             onClick={() => handleExecuteDeliveryUpdate()}
             disabled={!createdCheckout || isBusy}
           >
             Set delivery
           </Button>
-          <ArrowRight size={20} />
+          <ArrowRight size={16} />
           <Button
             disabled={!createdCheckout || isBusy}
             onClick={() => handleExecuteInitializeTransaction()}
           >
             Initialize transaction
           </Button>
-          <ArrowRight size={20} />
+          <ArrowRight size={16} />
           <Button
             disabled={!createdCheckout || !deliveryUpdateResult.data || isBusy}
             onClick={() => handleExecuteCompleteCheckout()}
@@ -567,7 +567,7 @@ const CheckoutPage = () => {
                   gap={2}
                   alignItems="center"
                 >
-                  <ExternalLink size={20} />
+                  <ExternalLink size={16} />
                   <Text fontWeight="bold" color="accent1">
                     Report changes on transaction
                   </Text>
@@ -587,7 +587,7 @@ const CheckoutPage = () => {
               gap={2}
               alignItems="center"
             >
-              <ExternalLink size={20} />
+              <ExternalLink size={16} />
               <Text fontWeight="bold" color="accent1">
                 Created order{" "}
                 {completeCheckoutResult.data.checkoutComplete?.order?.number ?? "Error"}

--- a/apps/dummy-payment-app/src/pages/app/transactions/[id].tsx
+++ b/apps/dummy-payment-app/src/pages/app/transactions/[id].tsx
@@ -1,6 +1,6 @@
 import { actions, useAppBridge } from "@saleor/app-sdk/app-bridge";
 import { Box, Button, Spinner, Text } from "@saleor/macaw-ui";
-import { ShoppingBag } from "lucide-react";
+import { ShoppingCart } from "lucide-react";
 import { useRouter } from "next/router";
 
 import { SectionWithDescription } from "@/components/section-with-description";
@@ -71,7 +71,7 @@ const EventReporterPage = () => {
         </Box>
         {orderId && (
           <Button variant="secondary" onClick={() => navigateToOrder(orderId)}>
-            <ShoppingBag size={20} />
+            <ShoppingCart size={16} />
             Open order
           </Button>
         )}

--- a/apps/dummy-payment-app/src/providers/graph-ql-provider.tsx
+++ b/apps/dummy-payment-app/src/providers/graph-ql-provider.tsx
@@ -81,7 +81,7 @@ function NotConnectedError() {
               display="flex"
               alignItems="center"
             >
-              <Copy size={20} />
+              <Copy size={16} />
             </Box>
           </Box>
         </Box>

--- a/apps/onboarding/src/modules/onboarding/welcome-page-onboarding-accordion.tsx
+++ b/apps/onboarding/src/modules/onboarding/welcome-page-onboarding-accordion.tsx
@@ -58,7 +58,7 @@ export const WelcomePageOnboardingAccordion = () => {
                 transition="ease"
                 __transform={`${extendedStepId === step.id ? "rotate(180deg)" : "none"}`}
               >
-                <ChevronDown size={20} />
+                <ChevronDown size={16} />
               </Box>
             </Box>
           </Accordion.Trigger>

--- a/apps/onboarding/src/modules/onboarding/welcome-page-onboarding.tsx
+++ b/apps/onboarding/src/modules/onboarding/welcome-page-onboarding.tsx
@@ -64,7 +64,7 @@ export const WelcomePageOnboarding = () => {
                 size="small"
                 data-test-id="onboarding-accordion-trigger"
               >
-                <ChevronDown size={20} />
+                <ChevronDown size={16} />
               </Button>
             </Accordion.Trigger>
           </DashboardCard.Header>

--- a/apps/products-feed/src/modules/category-mapping/construct-category-breadcrumbs.tsx
+++ b/apps/products-feed/src/modules/category-mapping/construct-category-breadcrumbs.tsx
@@ -21,7 +21,7 @@ export const CategoryBreadcrumbs = (props: { category: CategoryWithMappingFragme
             <Text size={4} fontWeight={isLast ? "bold" : "regular"}>
               {category}
             </Text>
-            {!isLast && <ChevronRight size={20} />}
+            {!isLast && <ChevronRight size={16} />}
           </Box>
         );
       })}

--- a/apps/smtp/src/modules/channels/ui/universal-channels-section.tsx
+++ b/apps/smtp/src/modules/channels/ui/universal-channels-section.tsx
@@ -95,13 +95,13 @@ export const UniversalChannelsSection = ({
                   >
                     <Switch.Item id="1" value="restrict">
                       <Box display="flex" alignItems="center" gap={1}>
-                        <Pencil size={20} />
+                        <Pencil size={16} />
                         <Text>Include</Text>
                       </Box>
                     </Switch.Item>
                     <Switch.Item id="2" value="exclude">
                       <Box display="flex" alignItems="center" gap={1}>
-                        <Tag size={20} />
+                        <Tag size={16} />
                         <Text>Exclude</Text>
                       </Box>
                     </Switch.Item>

--- a/apps/stripe/src/modules/ui/stripe-configs/delete-configuration-modal-content.tsx
+++ b/apps/stripe/src/modules/ui/stripe-configs/delete-configuration-modal-content.tsx
@@ -24,7 +24,7 @@ export const DeleteConfigurationModalContent = (props: { onDeleteClick: () => vo
             Delete configuration
           </Text>
           <Modal.Close>
-            <Button variant="tertiary" icon={<X size={20} />} size="small" />
+            <Button variant="tertiary" icon={<X size={16} />} size="small" />
           </Modal.Close>
         </Box>
         <Text>Are you sure you want to delete this configuration?</Text>

--- a/packages/ui/src/configs-list.tsx
+++ b/packages/ui/src/configs-list.tsx
@@ -70,7 +70,7 @@ export const ConfigsList = ({
                   disabled={isLoading}
                   marginLeft={4}
                   display="block"
-                  icon={<Trash2 size={20} />}
+                  icon={<Trash2 size={16} />}
                   variant="secondary"
                   onClick={() => setConfigIdContext(config.id)}
                 />

--- a/packages/ui/src/delete-configuration-modal-content.tsx
+++ b/packages/ui/src/delete-configuration-modal-content.tsx
@@ -23,7 +23,7 @@ export const DeleteConfigurationModalContent = (props: { onDeleteClick: () => vo
             Delete configuration
           </Text>
           <Modal.Close>
-            <Button variant="tertiary" icon={<X size={20} />} size="small" />
+            <Button variant="tertiary" icon={<X size={16} />} size="small" />
           </Modal.Close>
         </Box>
         <Text>Are you sure you want to delete this configuration?</Text>


### PR DESCRIPTION
The macaw-ui v2 migration used size={20} for all lucide icons and ShoppingBag for orders. Match the Saleor Dashboard's lucide conventions: size={16} for inline/button icons and ShoppingCart for order references.

## Scope of the PR

<!-- Describe briefly the changes made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
