### PR TITLE
Fix Algolia error handling

### DIFF
--- a/.changeset/search-algolia-api-error-warning.md
+++ b/.changeset/search-algolia-api-error-warning.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-search": patch
+---
+
+Search app no longer raises an error alert when Algolia rejects an indexing request. Errors returned by the Algolia API — for example exceeding the index limit of the Algolia plan — are caused by the merchant's Algolia account, not by a bug in the app, so they are now logged as warnings. Additionally, the Algolia status code is now passed back to Saleor: permanent failures (4xx) are no longer retried, while temporary Algolia outages (5xx) still are.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 **Monorepo Architecture**: This is a Turborepo-managed monorepo containing Saleor Apps built with Next.js, TypeScript, and modern development tooling.
 
-- `/apps/` - Individual Saleor applications (AvaTax, CMS, Klaviyo, Products Feed, Search, Segment, SMTP, Stripe, NP Atobarai)
-- `/packages/` - Shared libraries and utilities (domain, errors, logger, otel, UI components, etc.)
+- `/apps/` - Individual Saleor applications - see [Directory Map](#directory-map-where-to-look) to pick the right one
+- `/packages/` - Shared libraries and utilities - see [Directory Map](#directory-map-where-to-look)
 - `/templates/` - App templates for new development
 - Uses PNPM workspaces with workspace dependencies via `workspace:*`
 
@@ -118,12 +118,48 @@ static ValidationError = BaseError.subclass("ValidationError", {
     - If many changes applied in single commit, create multiple changesets
     - Ensure changeset has a good value, describing what was the actual change. It should be less technical than the commit. Best if it has before/after described.
 
-## App-Specific Notes
+## Directory Map (where to look)
 
-- **AvaTax**: Tax calculation service with comprehensive E2E testing suite
-- **Stripe**: Payment processing with transaction handling use cases
-- **Search**: Algolia integration with webhook-driven product indexing
-- **SMTP**: Email service with template management
-- **CMS**: Content management system integration with bulk sync capabilities
+Requests often name a vendor, protocol or feature instead of a directory. Match the keyword to the
+directory below before searching the whole repo.
+
+### Apps
+
+| Directory                | Package name                     | Keywords                                                                                                                       |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/anonymizer`        | `saleor-app-anonymizer`          | anonymize, GDPR, PII, customer data scrubbing                                                                                    |
+| `apps/avatax`            | `saleor-app-avatax`              | AvaTax, Avalara, tax, tax calculation, tax codes, address validation, `CALCULATE_TAXES`, ORDER_CONFIRMED taxes, entity use code   |
+| `apps/cms`               | `saleor-app-cms`                 | CMS, Contentful, DatoCMS, Strapi, Builder.io, Payload CMS, product sync to CMS, bulk sync, field mapping                          |
+| `apps/dummy-payment-app` | `saleor-app-payment-dummy`       | dummy payment, test payment gateway, transaction flow sandbox                                                                    |
+| `apps/klaviyo`           | `saleor-app-klaviyo`             | Klaviyo, marketing events, customer events                                                                                       |
+| `apps/np-atobarai`       | `saleor-app-payment-np-atobarai` | NP Atobarai, Net Protections, Japan, deferred payment, zip code lookup, 後払い                                                     |
+| `apps/onboarding`        | `saleor-app-onboarding`          | onboarding, welcome widget, Dashboard home page widget                                                                           |
+| `apps/products-feed`     | `saleor-app-products-feed`       | Google Merchant Center, product feed, XML feed, S3 upload, feed template, Handlebars feed attributes                              |
+| `apps/search`            | `saleor-app-search`              | Algolia, search, indexing, index products, `algoliasearch`, webhook-driven product indexing                                      |
+| `apps/segment`           | `saleor-app-segment`             | Segment, Twilio Segment, analytics tracking, track events                                                                        |
+| `apps/smtp`              | `saleor-app-smtp`                | SMTP, email, nodemailer, MJML, email templates, Monaco editor, notification emails, sendgrid-era templates                        |
+| `apps/stripe`            | `saleor-app-payment-stripe`      | Stripe, payment, payment intent, checkout session, refund, transaction, `TRANSACTION_*` webhooks, Stripe webhook signature        |
+
+### Packages
+
+| Directory                          | Package name                      | Keywords                                                                       |
+| ---------------------------------- | --------------------------------- | ------------------------------------------------------------------------------ |
+| `packages/app-problems`            | `@saleor/app-problems`            | app problems, health checks, version compatibility, semver checks               |
+| `packages/domain`                  | `@saleor/apps-domain`             | branded types, `SaleorApiUrl`, `AppId`, shared value objects                    |
+| `packages/dynamo-config-repository` | `@saleor/dynamo-config-repository` | DynamoDB, config repository, entity mapping, `dynamodb-toolbox`               |
+| `packages/errors`                  | `@saleor/errors`                  | `BaseError`, `BaseError.subclass`, error classes, modern-errors                 |
+| `packages/eslint-config`           | `@saleor/eslint-config-apps`      | ESLint rules, lint config                                                       |
+| `packages/handlebars`              | `@saleor/handlebars`              | Handlebars, template compilation, template helpers                              |
+| `packages/logger`                  | `@saleor/apps-logger`             | logger, tslog, structured logging, log context                                  |
+| `packages/otel`                    | `@saleor/apps-otel`               | OpenTelemetry, traces, metrics, spans, instrumentation, OTLP exporter           |
+| `packages/react-hook-form-macaw`   | `@saleor/react-hook-form-macaw`   | form inputs, React Hook Form + Macaw bindings                                   |
+| `packages/sentry-utils`            | `@saleor/sentry-utils`            | Sentry, error reporting, exception capture                                      |
+| `packages/shared`                  | `@saleor/apps-shared`             | urql client, auth exchange, misc shared helpers                                 |
+| `packages/trpc`                    | `@saleor/apps-trpc`               | tRPC setup, protected procedures, context, middleware                           |
+| `packages/typescript-config`       | `@saleor/typescript-config-apps`  | tsconfig, compiler options                                                      |
+| `packages/ui`                      | `@saleor/apps-ui`                 | shared React components, Macaw UI wrappers, layout                              |
+| `packages/webhook-utils`           | `@saleor/webhook-utils`           | webhook migration, webhook registration, webhook manager                        |
+
+If a request names a vendor not listed here, grep `apps/*/package.json` for the dependency first.
 
 Run commands from the root directory for global operations, or from individual app directories for app-specific tasks.

--- a/apps/search/src/lib/algolia/algolia-error-parser.ts
+++ b/apps/search/src/lib/algolia/algolia-error-parser.ts
@@ -64,6 +64,15 @@ export const createRecordSizeErrorMessage = (
 };
 
 export const AlgoliaErrorParser = {
+  /**
+   * Algolia SDK throws ApiError with status + message for every non-2xx response.
+   * Returns null if the error didn't come from the Algolia API.
+   */
+  getStatusCode: (error: unknown): number | null => {
+    const parsed = shape.safeParse(error);
+
+    return parsed.success ? parsed.data.status : null;
+  },
   isAuthError: (error: unknown) => {
     const parsed = shape.safeParse(error);
 

--- a/apps/search/src/pages/api/webhooks/saleor/category_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/category_created.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type CategoryCreated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookCategoryCreated } from "../../../../webhooks/definitions/category-created";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -82,11 +83,12 @@ export const handler: NextJsWebhookHandler<CategoryCreated> = async (req, res, c
         return;
       }
 
-      logger.error("Failed to execute category_created webhook (algoliaClient.createCategory)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute category_created webhook (algoliaClient.createCategory)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute category_created webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/category_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/category_deleted.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type CategoryDeleted } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookCategoryDeleted } from "../../../../webhooks/definitions/category-deleted";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -65,11 +66,12 @@ export const handler: NextJsWebhookHandler<CategoryDeleted> = async (req, res, c
         return;
       }
 
-      logger.error("Failed to execute category_deleted webhook (algoliaClient.deleteCategory)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute category_deleted webhook (algoliaClient.deleteCategory)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute category_deleted webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/category_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/category_updated.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type CategoryUpdated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookCategoryUpdated } from "../../../../webhooks/definitions/category-updated";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -82,11 +83,12 @@ export const handler: NextJsWebhookHandler<CategoryUpdated> = async (req, res, c
         return;
       }
 
-      logger.error("Failed to execute category_updated webhook (algoliaClient.updateCategory)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute category_updated webhook (algoliaClient.updateCategory)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute category_updated webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/page_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/page_created.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type PageCreated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookPageCreated } from "../../../../webhooks/definitions/page-created";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -98,11 +99,12 @@ export const handler: NextJsWebhookHandler<PageCreated> = async (req, res, conte
         return;
       }
 
-      logger.error("Failed to execute page_created webhook (algoliaClient.createPage)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute page_created webhook (algoliaClient.createPage)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute page_created webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/page_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/page_deleted.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type PageDeleted } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookPageDeleted } from "../../../../webhooks/definitions/page-deleted";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -81,11 +82,12 @@ export const handler: NextJsWebhookHandler<PageDeleted> = async (req, res, conte
         return;
       }
 
-      logger.error("Failed to execute page_deleted webhook (algoliaClient.deletePage)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute page_deleted webhook (algoliaClient.deletePage)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute page_deleted webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/page_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/page_updated.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type PageUpdated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookPageUpdated } from "../../../../webhooks/definitions/page-updated";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -98,11 +99,12 @@ export const handler: NextJsWebhookHandler<PageUpdated> = async (req, res, conte
         return;
       }
 
-      logger.error("Failed to execute page_updated webhook (algoliaClient.updatePage)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute page_updated webhook (algoliaClient.updatePage)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute page_updated webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/product_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_created.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductCreated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductCreated } from "../../../../webhooks/definitions/product-created";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -93,11 +94,12 @@ export const handler: NextJsWebhookHandler<ProductCreated> = async (req, res, co
         return;
       }
 
-      logger.error("Failed to execute product_created webhook (algoliaClient.createProduct)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute product_created webhook (algoliaClient.createProduct)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute product_created webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_deleted.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductDeleted } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductDeleted } from "../../../../webhooks/definitions/product-deleted";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -65,11 +66,12 @@ export const handler: NextJsWebhookHandler<ProductDeleted> = async (req, res, co
         return;
       }
 
-      logger.error("Failed to execute product_deleted webhook (algoliaClient.deleteProduct)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute product_deleted webhook (algoliaClient.deleteProduct)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute product_deleted webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_updated.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductUpdated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductUpdated } from "../../../../webhooks/definitions/product-updated";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -91,11 +92,12 @@ export const handler: NextJsWebhookHandler<ProductUpdated> = async (req, res, co
         return;
       }
 
-      logger.error("Failed to execute product_updated webhook (algoliaClient.updateProduct)", {
+      return handleAlgoliaWebhookError({
         error: e,
+        logger,
+        message: "Failed to execute product_updated webhook (algoliaClient.updateProduct)",
+        res,
       });
-
-      return res.status(500).send("Operation failed due to error");
     }
   } catch (e) {
     logger.error("Failed to execute product_updated webhook (createWebhookContext)", { error: e });

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_back_in_stock.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductVariantBackInStock } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductVariantBackInStock } from "../../../../webhooks/definitions/product-variant-back-in-stock";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -67,12 +68,13 @@ export const handler: NextJsWebhookHandler<ProductVariantBackInStock> = async (
         return;
       }
 
-      logger.error(
-        "Failed to execute product_variant_back_in_stock webhook (algoliaClient.updateProductVariant)",
-        { error: e },
-      );
-
-      return res.status(500).send("Operation failed due to error");
+      return handleAlgoliaWebhookError({
+        error: e,
+        logger,
+        message:
+          "Failed to execute product_variant_back_in_stock webhook (algoliaClient.updateProductVariant)",
+        res,
+      });
     }
   } catch (e) {
     logger.error("Failed to execute product_variant_back_in_stock webhook (createWebhookContext)", {

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_created.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductVariantCreated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductVariantCreated } from "../../../../webhooks/definitions/product-variant-created";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -90,12 +91,13 @@ export const handler: NextJsWebhookHandler<ProductVariantCreated> = async (req, 
         return;
       }
 
-      logger.error(
-        "Failed to execute product_variant_created webhook (algoliaClient.createProductVariant)",
-        { error: e },
-      );
-
-      return res.status(500).send("Operation failed due to error");
+      return handleAlgoliaWebhookError({
+        error: e,
+        logger,
+        message:
+          "Failed to execute product_variant_created webhook (algoliaClient.createProductVariant)",
+        res,
+      });
     }
   } catch (e) {
     logger.error("Failed to execute product_variant_created webhook (createWebhookContext)", {

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_deleted.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_deleted.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductVariantDeleted } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductVariantDeleted } from "../../../../webhooks/definitions/product-variant-deleted";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -63,12 +64,13 @@ export const handler: NextJsWebhookHandler<ProductVariantDeleted> = async (req, 
         return;
       }
 
-      logger.error(
-        "Failed to execute product_variant_deleted webhook (algoliaClient.deleteProductVariant)",
-        { error: e },
-      );
-
-      return res.status(500).send("Operation failed due to error");
+      return handleAlgoliaWebhookError({
+        error: e,
+        logger,
+        message:
+          "Failed to execute product_variant_deleted webhook (algoliaClient.deleteProductVariant)",
+        res,
+      });
     }
   } catch (e) {
     logger.error("Failed to execute product_variant_deleted webhook (createWebhookContext)", {

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_out_of_stock.ts
@@ -8,6 +8,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductVariantOutOfStock } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductVariantOutOfStock } from "../../../../webhooks/definitions/product-variant-out-of-stock";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -67,12 +68,13 @@ export const handler: NextJsWebhookHandler<ProductVariantOutOfStock> = async (
         return;
       }
 
-      logger.error(
-        "Failed to execute product_variant_out_of_stock webhook (algoliaClient.updateProductVariant)",
-        { error: e },
-      );
-
-      return res.status(500).send("Operation failed due to error");
+      return handleAlgoliaWebhookError({
+        error: e,
+        logger,
+        message:
+          "Failed to execute product_variant_out_of_stock webhook (algoliaClient.updateProductVariant)",
+        res,
+      });
     }
   } catch (e) {
     logger.error("Failed to execute product_variant_out_of_stock webhook (createWebhookContext)", {

--- a/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
+++ b/apps/search/src/pages/api/webhooks/saleor/product_variant_updated.ts
@@ -11,6 +11,7 @@ import { loggerContext } from "../../../../lib/logger-context";
 import { type ProductVariantUpdated } from "../../../../lib/webhook-event-types";
 import { createSearchProblemReporter } from "../../../../modules/app-problems";
 import { webhookProductVariantUpdated } from "../../../../webhooks/definitions/product-variant-updated";
+import { handleAlgoliaWebhookError } from "../../../../webhooks/handle-algolia-webhook-error";
 import { handleInvalidAppIdError } from "../../../../webhooks/handle-invalid-app-id-error";
 import { createWebhookContext } from "../../../../webhooks/webhook-context";
 
@@ -88,12 +89,13 @@ export const handler: NextJsWebhookHandler<ProductVariantUpdated> = async (req, 
         return;
       }
 
-      logger.error(
-        "Failed to execute product_variant_updated webhook (algoliaClient.updateProductVariant)",
-        { error: e },
-      );
-
-      return res.status(500).send("Operation failed due to error");
+      return handleAlgoliaWebhookError({
+        error: e,
+        logger,
+        message:
+          "Failed to execute product_variant_updated webhook (algoliaClient.updateProductVariant)",
+        res,
+      });
     }
   } catch (e) {
     logger.error("Failed to execute product_variant_updated webhook (createWebhookContext)", {

--- a/apps/search/src/webhooks/handle-algolia-webhook-error.test.ts
+++ b/apps/search/src/webhooks/handle-algolia-webhook-error.test.ts
@@ -1,0 +1,58 @@
+import { type NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+
+import { handleAlgoliaWebhookError } from "./handle-algolia-webhook-error";
+
+const createLoggerMock = () => ({ warn: vi.fn(), error: vi.fn() });
+
+const createResponseMock = () => {
+  const send = vi.fn();
+  const status = vi.fn(() => ({ send }));
+
+  return { res: { status } as unknown as NextApiResponse, status, send };
+};
+
+describe("handleAlgoliaWebhookError", () => {
+  it("Warns and returns Algolia 4xx status, so Saleor doesn't retry a request that will never succeed", () => {
+    const logger = createLoggerMock();
+    const { res, status, send } = createResponseMock();
+    const error = {
+      status: 400,
+      message: "Too many indices (40>20), please remove unused indices before pushing more data.",
+    };
+
+    handleAlgoliaWebhookError({ error, logger, message: "Failed to execute webhook", res });
+
+    expect(logger.warn).toHaveBeenCalledWith("Failed to execute webhook", {
+      error,
+      algoliaStatusCode: 400,
+    });
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(400);
+    expect(send).toHaveBeenCalledWith(error.message);
+  });
+
+  it("Warns and returns Algolia 5xx status, so Saleor retries a transient failure", () => {
+    const logger = createLoggerMock();
+    const { res, status } = createResponseMock();
+    const error = { status: 503, message: "Service unavailable" };
+
+    handleAlgoliaWebhookError({ error, logger, message: "Failed to execute webhook", res });
+
+    expect(logger.warn).toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(503);
+  });
+
+  it("Logs error and returns 500 if error does not come from Algolia API", () => {
+    const logger = createLoggerMock();
+    const { res, status, send } = createResponseMock();
+    const error = new TypeError("Cannot read property of undefined");
+
+    handleAlgoliaWebhookError({ error, logger, message: "Failed to execute webhook", res });
+
+    expect(logger.error).toHaveBeenCalledWith("Failed to execute webhook", { error });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(500);
+    expect(send).toHaveBeenCalledWith("Operation failed due to error");
+  });
+});

--- a/apps/search/src/webhooks/handle-algolia-webhook-error.ts
+++ b/apps/search/src/webhooks/handle-algolia-webhook-error.ts
@@ -1,0 +1,43 @@
+import { type NextApiResponse } from "next";
+
+import { AlgoliaErrorParser } from "../lib/algolia/algolia-error-parser";
+
+type Logger = {
+  warn: (message: string, params?: Record<string, unknown>) => void;
+  error: (message: string, params?: Record<string, unknown>) => void;
+};
+
+/**
+ * Errors returned by the Algolia API are caused by the merchant's Algolia account
+ * (plan limits, quotas, rejected records) or by Algolia itself - not by a bug in this app,
+ * so they are logged as warnings instead of errors.
+ *
+ * Algolia status code is passed back to Saleor: 4xx means the request will never succeed,
+ * so Saleor should not retry it. 5xx is transient and worth retrying.
+ * Errors that don't come from Algolia are unexpected - they stay errors and return 500.
+ */
+export const handleAlgoliaWebhookError = ({
+  error: e,
+  logger,
+  message,
+  res,
+}: {
+  error: unknown;
+  logger: Logger;
+  message: string;
+  res: NextApiResponse;
+}) => {
+  const algoliaStatusCode = AlgoliaErrorParser.getStatusCode(e);
+
+  if (algoliaStatusCode === null) {
+    logger.error(message, { error: e });
+
+    res.status(500).send("Operation failed due to error");
+
+    return;
+  }
+
+  logger.warn(message, { error: e, algoliaStatusCode });
+
+  res.status(algoliaStatusCode).send(AlgoliaErrorParser.getErrorMessage(e));
+};

--- a/cspell.config.js
+++ b/cspell.config.js
@@ -84,7 +84,7 @@ export default {
     "Neue",
     "Segoe",
     "Undiscounted",
-    "OIDC", "oidc", "CANCELATION", "saleors", "GTIN"
+    "OIDC", "oidc", "CANCELATION", "saleors", "GTIN", "algoliasearch", "tslog"
   ],
   language: "en-US",
   useGitignore: true,


### PR DESCRIPTION
1. Algolia error no longer prints error log (and automate incidents)
2. Algolia 4xx doesnt return 5xx to Saleor (wrong config should not trigger retries)
3. Improved agents indexing