### PR TITLE
fix(avatax): stop logging client tRPC errors as error

### DIFF
--- a/apps/avatax/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/avatax/src/modules/trpc/protected-client-procedure.ts
@@ -112,20 +112,7 @@ const validateClientToken = middleware(async ({ ctx, next, meta }) => {
  * TODO Rethink middleware composition to enable safe server-side router calls
  */
 
-const logErrors = middleware(async ({ next }) => {
-  const logger = createLogger("trpcServer");
-
-  const result = await next();
-
-  if (!result.ok) {
-    logger.error(`[TRPC Error] ${result.error.message}`, { error: result.error });
-  }
-
-  return result;
-});
-
 export const protectedClientProcedure = procedure
-  .use(logErrors)
   .use(attachAppToken)
   .use(validateClientToken)
   .use(async ({ ctx, next }) => {


### PR DESCRIPTION
duplicated errors that spam monitors, logs are already printed in other places