### PR TITLE
feat: identify apps by User-Agent on Saleor GraphQL calls

### DIFF
--- a/.changeset/gentle-poems-listen.md
+++ b/.changeset/gentle-poems-listen.md
@@ -1,0 +1,19 @@
+---
+"@saleor/apps-shared": minor
+"saleor-app-avatax": patch
+"saleor-app-cms": patch
+"saleor-app-klaviyo": patch
+"saleor-app-payment-dummy": patch
+"saleor-app-shipping-dummy": patch
+"saleor-app-payment-np-atobarai": patch
+"saleor-app-products-feed": patch
+"saleor-app-search": patch
+"saleor-app-segment": patch
+"saleor-app-smtp": patch
+"saleor-app-payment-stripe": patch
+---
+
+Apps now identify themselves when they call the Saleor GraphQL API. Before, requests
+went out with the runtime's default `User-Agent`, so it was impossible to tell from
+Saleor's access logs which app produced them. Now every server-side request carries
+`User-Agent: <app-package-name>/<app-version>`, e.g. `saleor-app-avatax/3.1.0`.

--- a/apps/avatax/src/app/api/order-details/route.ts
+++ b/apps/avatax/src/app/api/order-details/route.ts
@@ -1,10 +1,10 @@
 import { verifyJWT } from "@saleor/app-sdk/auth";
 import { type ExtensionPOSTAttributes } from "@saleor/app-sdk/types";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { type TransactionModel } from "avatax/lib/models/TransactionModel";
 import { type NextRequest } from "next/server";
 
 import { metadataCache } from "@/lib/app-metadata-cache";
+import { createInstrumentedGraphqlClient } from "@/lib/create-instrumented-graphql-client";
 import { createLogger } from "@/logger";
 import { createSettingsManager } from "@/modules/app/metadata-manager";
 import { type AvataxConfig } from "@/modules/avatax/avatax-connection-schema";
@@ -86,7 +86,10 @@ const orderDetailsHandler = async (req: NextRequest) => {
     });
   }
 
-  const client = createGraphQLClient({ token: authData.token, saleorApiUrl: saleorApiUrl });
+  const client = createInstrumentedGraphqlClient({
+    token: authData.token,
+    saleorApiUrl: saleorApiUrl,
+  });
 
   const orderMetadata = await client.query(OrderAvataxIdDocument, {
     id: orderId,

--- a/apps/avatax/src/app/api/webhooks/order-cancelled/route.ts
+++ b/apps/avatax/src/app/api/webhooks/order-cancelled/route.ts
@@ -2,7 +2,6 @@ import { SpanKind, SpanStatusCode } from "@opentelemetry/api";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributesAppRouter } from "@saleor/apps-otel/src/with-span-attributes";
 import { compose } from "@saleor/apps-shared/compose";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { captureException, setTag } from "@sentry/nextjs";
 import { after } from "next/server";
 
@@ -10,6 +9,7 @@ import { AppConfig } from "@/lib/app-config";
 import { AppConfigExtractor } from "@/lib/app-config-extractor";
 import { AppConfigurationLogger } from "@/lib/app-configuration-logger";
 import { metadataCache, wrapWithMetadataCache } from "@/lib/app-metadata-cache";
+import { createInstrumentedGraphqlClient } from "@/lib/create-instrumented-graphql-client";
 import { SubscriptionPayloadErrorChecker } from "@/lib/error-utils";
 import { appExternalTracer } from "@/lib/otel/tracing";
 import { withFlushOtelMetrics } from "@/lib/otel/with-flush-otel-metrics";
@@ -50,7 +50,7 @@ const handler = orderCancelledAsyncWebhook.createHandler(async (_req, ctx) => {
       const { payload } = ctx;
 
       const logWriter = logsWriterFactory.createWriter(ctx.authData);
-      const client = createGraphQLClient({
+      const client = createInstrumentedGraphqlClient({
         saleorApiUrl: ctx.authData.saleorApiUrl,
         token: ctx.authData.token,
       });

--- a/apps/avatax/src/lib/create-instrumented-graphql-client.ts
+++ b/apps/avatax/src/lib/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../package.json";
 import { appInternalTracer } from "./otel/tracing";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appInternalTracer })],
     },

--- a/apps/cms/src/modules/configuration/app-config-metadata-manager.ts
+++ b/apps/cms/src/modules/configuration/app-config-metadata-manager.ts
@@ -1,8 +1,8 @@
 import { type AuthData } from "@saleor/app-sdk/APL";
 import { type SettingsManager } from "@saleor/app-sdk/settings-manager";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 
 import { ENCRYPTED_METADATA_KEYS } from "../../lib/encrypted-metadata-keys";
+import { createInstrumentedGraphqlClient } from "../trpc/create-instrumented-graphql-client";
 import { AppConfig } from "./app-config";
 import { createSettingsManager } from "./metadata-manager";
 
@@ -26,7 +26,7 @@ export class AppConfigMetadataManager {
 
   static createFromAuthData(authData: AuthData): AppConfigMetadataManager {
     const settingsManager = createSettingsManager(
-      createGraphQLClient({
+      createInstrumentedGraphqlClient({
         saleorApiUrl: authData.saleorApiUrl,
         token: authData.token,
       }),

--- a/apps/cms/src/modules/trpc/create-instrumented-graphql-client.ts
+++ b/apps/cms/src/modules/trpc/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../../package.json";
 import { appRootTracer } from "../otel/app-root-tracer";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appRootTracer })],
     },

--- a/apps/dummy-payment-app/src/server/procedure/procedure-with-graphql-client.ts
+++ b/apps/dummy-payment-app/src/server/procedure/procedure-with-graphql-client.ts
@@ -2,6 +2,7 @@ import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 
 import { invariant } from "@/lib/invariant";
 
+import packageJson from "../../../package.json";
 import { attachAppToken } from "../middleware/attach-app-token";
 import { procedure } from "../server";
 
@@ -15,6 +16,7 @@ export const procedureWithGraphqlClient = procedure
     const client = createGraphQLClient({
       saleorApiUrl: ctx.saleorApiUrl,
       token: ctx.appToken,
+      userAgent: `${packageJson.name}/${packageJson.version}`,
     });
 
     return next({

--- a/apps/dummy-shipping-app/src/pages/api/webhooks/shipping-list-methods-for-checkout.ts
+++ b/apps/dummy-shipping-app/src/pages/api/webhooks/shipping-list-methods-for-checkout.ts
@@ -7,6 +7,7 @@ import {
   type ShippingListMethodsPayloadFragment,
 } from "@/generated/graphql";
 import { DummyExternalShippingAPI } from "@/lib/dummy-shipping";
+import packageJson from "@/package.json";
 import { saleorApp } from "@/saleor-app";
 
 const ShippingListMethodsPayload = gql`
@@ -58,6 +59,7 @@ export default shippingListMethodsForCheckoutWebhook.createHandler(async (_req, 
   const client = createGraphQLClient({
     saleorApiUrl: authData.saleorApiUrl,
     token: authData.token,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
   });
 
   await client

--- a/apps/klaviyo/src/lib/graphql-client.ts
+++ b/apps/klaviyo/src/lib/graphql-client.ts
@@ -1,0 +1,15 @@
+import {
+  createGraphQLClient,
+  type CreateGraphQLClientArgs,
+} from "@saleor/apps-shared/create-graphql-client";
+
+import packageJson from "../../package.json";
+
+/**
+ * Wraps the shared client so every Saleor request identifies this app in access logs.
+ */
+export const createSaleorGraphqlClient = (props: Omit<CreateGraphQLClientArgs, "userAgent">) =>
+  createGraphQLClient({
+    ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
+  });

--- a/apps/klaviyo/src/pages/api/configuration.ts
+++ b/apps/klaviyo/src/pages/api/configuration.ts
@@ -6,9 +6,9 @@ import { type SettingsManager } from "@saleor/app-sdk/settings-manager";
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 
 import { saleorApp } from "../../../saleor-app";
+import { createSaleorGraphqlClient } from "../../lib/graphql-client";
 import { createSettingsManager } from "../../lib/metadata";
 import { createLogger } from "../../logger";
 import { loggerContext } from "../../logger-context";
@@ -59,7 +59,7 @@ const handler: NextJsProtectedApiHandler = async (request, res, ctx) => {
 
   logger.info("Configuration handler called");
 
-  const client = createGraphQLClient({
+  const client = createSaleorGraphqlClient({
     saleorApiUrl,
     token,
   });

--- a/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/customer-created.ts
@@ -2,7 +2,6 @@ import { type NextJsWebhookHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/h
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { gql } from "urql";
 
 import {
@@ -10,6 +9,7 @@ import {
   UntypedCustomerCreatedDocument,
 } from "../../../../generated/graphql";
 import { saleorApp } from "../../../../saleor-app";
+import { createSaleorGraphqlClient } from "../../../lib/graphql-client";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
 import { createLogger } from "../../../logger";
@@ -78,7 +78,7 @@ const handler: NextJsWebhookHandler<CustomerCreatedWebhookPayloadFragment> = asy
 
   logger.info("customerCreatedWebhook handler called");
 
-  const client = createGraphQLClient({
+  const client = createSaleorGraphqlClient({
     saleorApiUrl,
     token,
   });

--- a/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/fulfillment-created.ts
@@ -2,7 +2,6 @@ import { type NextJsWebhookHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/h
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { gql } from "urql";
 
 import {
@@ -10,6 +9,7 @@ import {
   UntypedFulfillmentCreatedDocument,
 } from "../../../../generated/graphql";
 import { saleorApp } from "../../../../saleor-app";
+import { createSaleorGraphqlClient } from "../../../lib/graphql-client";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
 import { createLogger } from "../../../logger";
@@ -84,7 +84,7 @@ const handler: NextJsWebhookHandler<FulfillmentCreatedWebhookPayloadFragment> = 
 
   logger.info("fulfillmentCreatedWebhook handler called");
 
-  const client = createGraphQLClient({
+  const client = createSaleorGraphqlClient({
     saleorApiUrl,
     token,
   });

--- a/apps/klaviyo/src/pages/api/webhooks/order-created.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-created.ts
@@ -2,7 +2,6 @@ import { type NextJsWebhookHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/h
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { gql } from "urql";
 
 import {
@@ -10,6 +9,7 @@ import {
   UntypedOrderCreatedDocument,
 } from "../../../../generated/graphql";
 import { saleorApp } from "../../../../saleor-app";
+import { createSaleorGraphqlClient } from "../../../lib/graphql-client";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
 import { createLogger } from "../../../logger";
@@ -54,7 +54,7 @@ const handler: NextJsWebhookHandler<OrderCreatedWebhookPayloadFragment> = async 
 
   logger.info("orderCreatedWebhook handler called");
 
-  const client = createGraphQLClient({
+  const client = createSaleorGraphqlClient({
     saleorApiUrl,
     token,
   });

--- a/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
+++ b/apps/klaviyo/src/pages/api/webhooks/order-fully-paid.ts
@@ -2,7 +2,6 @@ import { type NextJsWebhookHandler, SaleorAsyncWebhook } from "@saleor/app-sdk/h
 import { wrapWithLoggerContext } from "@saleor/apps-logger/node";
 import { ObservabilityAttributes } from "@saleor/apps-otel/src/observability-attributes";
 import { withSpanAttributes } from "@saleor/apps-otel/src/with-span-attributes";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { gql } from "urql";
 
 import {
@@ -10,6 +9,7 @@ import {
   UntypedOrderFullyPaidDocument,
 } from "../../../../generated/graphql";
 import { saleorApp } from "../../../../saleor-app";
+import { createSaleorGraphqlClient } from "../../../lib/graphql-client";
 import { Klaviyo } from "../../../lib/klaviyo";
 import { createSettingsManager } from "../../../lib/metadata";
 import { createLogger } from "../../../logger";
@@ -54,7 +54,7 @@ const handler: NextJsWebhookHandler<OrderFullyPaidWebhookPayloadFragment> = asyn
 
   logger.info("orderFullyPaidWebhook handler called");
 
-  const client = createGraphQLClient({
+  const client = createSaleorGraphqlClient({
     saleorApiUrl,
     token,
   });

--- a/apps/np-atobarai/src/lib/graphql-client.ts
+++ b/apps/np-atobarai/src/lib/graphql-client.ts
@@ -4,13 +4,16 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "@/package.json";
+
 import { appInternalTracer } from "./tracing";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appInternalTracer })],
     },

--- a/apps/products-feed/src/lib/create-instrumented-graphql-client.ts
+++ b/apps/products-feed/src/lib/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../package.json";
 import { appRootTracer } from "./app-root-tracer";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appRootTracer })],
     },

--- a/apps/search/src/lib/create-instrumented-graphql-client.ts
+++ b/apps/search/src/lib/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../package.json";
 import { appRootTracer } from "./app-root-tracer";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appRootTracer })],
     },

--- a/apps/search/src/modules/configuration/app-config-metadata-manager.ts
+++ b/apps/search/src/modules/configuration/app-config-metadata-manager.ts
@@ -1,7 +1,7 @@
 import { type AuthData } from "@saleor/app-sdk/APL";
 import { type SettingsManager } from "@saleor/app-sdk/settings-manager";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 
+import { createInstrumentedGraphqlClient } from "../../lib/create-instrumented-graphql-client";
 import { ENCRYPTED_METADATA_KEYS } from "../../lib/encrypted-metadata-keys";
 import { createSettingsManager } from "../../lib/metadata";
 import { AppConfig } from "./configuration";
@@ -27,7 +27,7 @@ export class AppConfigMetadataManager {
 
   static createFromAuthData(authData: AuthData): AppConfigMetadataManager {
     const settingsManager = createSettingsManager(
-      createGraphQLClient({
+      createInstrumentedGraphqlClient({
         saleorApiUrl: authData.saleorApiUrl,
         token: authData.token,
       }),

--- a/apps/segment/src/lib/create-instrumented-graphql-client.ts
+++ b/apps/segment/src/lib/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../package.json";
 import { appRootTracer } from "./app-root-tracer";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appRootTracer })],
     },

--- a/apps/segment/src/modules/trpc/protected-client-procedure.ts
+++ b/apps/segment/src/modules/trpc/protected-client-procedure.ts
@@ -1,9 +1,9 @@
 import { verifyJWT } from "@saleor/app-sdk/auth";
 import { type Permission } from "@saleor/app-sdk/types";
-import { createGraphQLClient } from "@saleor/apps-shared/create-graphql-client";
 import { setSentrySaleorUser } from "@saleor/sentry-utils";
 import { TRPCError } from "@trpc/server";
 
+import { createInstrumentedGraphqlClient } from "@/lib/create-instrumented-graphql-client";
 import { createLogger } from "@/logger";
 import { saleorApp } from "@/saleor-app";
 
@@ -116,7 +116,10 @@ export const protectedClientProcedure = procedure
   .use(attachAppToken)
   .use(validateClientToken)
   .use(async ({ ctx, next }) => {
-    const client = createGraphQLClient({ saleorApiUrl: ctx.saleorApiUrl, token: ctx.appToken });
+    const client = createInstrumentedGraphqlClient({
+      saleorApiUrl: ctx.saleorApiUrl,
+      token: ctx.appToken,
+    });
 
     return next({
       ctx: {

--- a/apps/smtp/src/lib/create-instrumented-graphql-client.ts
+++ b/apps/smtp/src/lib/create-instrumented-graphql-client.ts
@@ -4,13 +4,15 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "../../package.json";
 import { appRootTracer } from "./app-root-tracer";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appRootTracer })],
     },

--- a/apps/stripe/src/lib/graphql-client.ts
+++ b/apps/stripe/src/lib/graphql-client.ts
@@ -4,13 +4,16 @@ import {
   type CreateGraphQLClientArgs,
 } from "@saleor/apps-shared/create-graphql-client";
 
+import packageJson from "@/package.json";
+
 import { appInternalTracer } from "./tracing";
 
-type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts">;
+type CreateGraphQLClientProps = Omit<CreateGraphQLClientArgs, "opts" | "userAgent">;
 
 export const createInstrumentedGraphqlClient = (props: CreateGraphQLClientProps) =>
   createGraphQLClient({
     ...props,
+    userAgent: `${packageJson.name}/${packageJson.version}`,
     opts: {
       prependingFetchExchanges: [createOtelUrqlExchange({ tracer: appInternalTracer })],
     },

--- a/packages/shared/src/create-graphql-client.test.ts
+++ b/packages/shared/src/create-graphql-client.test.ts
@@ -1,0 +1,60 @@
+import { gql } from "urql";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createGraphQLClient } from "./create-graphql-client";
+
+const TestQuery = gql`
+  query TestQuery {
+    shop {
+      name
+    }
+  }
+`;
+
+const mockFetch = () =>
+  vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ data: { shop: { name: "Shop" } } }), {
+      headers: { "content-type": "application/json" },
+    }),
+  );
+
+const getSentHeaders = (fetchSpy: ReturnType<typeof mockFetch>) =>
+  (fetchSpy.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+
+describe("createGraphQLClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends User-Agent next to the auth header", async () => {
+    const fetchSpy = mockFetch();
+
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await createGraphQLClient({
+      saleorApiUrl: "https://example.saleor.cloud/graphql/",
+      token: "token",
+      userAgent: "saleor-app-example/1.2.3",
+    })
+      .query(TestQuery, {})
+      .toPromise();
+
+    // urql lowercases header names before handing them to fetch
+    expect(getSentHeaders(fetchSpy)).toMatchObject({
+      "user-agent": "saleor-app-example/1.2.3",
+      "authorization-bearer": "token",
+    });
+  });
+
+  it("does not send User-Agent when not provided", async () => {
+    const fetchSpy = mockFetch();
+
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await createGraphQLClient({ saleorApiUrl: "https://example.saleor.cloud/graphql/" })
+      .query(TestQuery, {})
+      .toPromise();
+
+    expect(getSentHeaders(fetchSpy)).not.toHaveProperty("user-agent");
+  });
+});

--- a/packages/shared/src/create-graphql-client.ts
+++ b/packages/shared/src/create-graphql-client.ts
@@ -1,9 +1,21 @@
 import { authExchange } from "@urql/exchange-auth";
-import { cacheExchange, createClient as urqlCreateClient, Exchange, fetchExchange } from "urql";
+import {
+  cacheExchange,
+  createClient as urqlCreateClient,
+  type Exchange,
+  fetchExchange,
+} from "urql";
 
 export interface CreateGraphQLClientArgs {
   saleorApiUrl: string;
   token?: string;
+  /**
+   * Identifies the calling app in Saleor's access logs. Apps should pass
+   * `${packageJson.name}/${packageJson.version}`.
+   *
+   * Browsers forbid overriding User-Agent, so this only takes effect server-side.
+   */
+  userAgent?: string;
   opts?: {
     prependingFetchExchanges?: Exchange[];
   };
@@ -20,7 +32,12 @@ export interface CreateGraphQLClientArgs {
  *
  * In the context of developing Apps, the two first options are recommended.
  */
-export const createGraphQLClient = ({ saleorApiUrl, token, opts }: CreateGraphQLClientArgs) => {
+export const createGraphQLClient = ({
+  saleorApiUrl,
+  token,
+  userAgent,
+  opts,
+}: CreateGraphQLClientArgs) => {
   const beforeFetch = [];
 
   if (opts?.prependingFetchExchanges) {
@@ -29,6 +46,7 @@ export const createGraphQLClient = ({ saleorApiUrl, token, opts }: CreateGraphQL
 
   return urqlCreateClient({
     url: saleorApiUrl,
+    fetchOptions: userAgent ? { headers: { "User-Agent": userAgent } } : undefined,
     exchanges: [
       cacheExchange,
       authExchange(async (utils) => {


### PR DESCRIPTION
Requests to the Saleor GraphQL API went out with the runtime's default User-Agent, so access logs could not attribute traffic to a specific app.

`createGraphQLClient` now takes an optional `userAgent`, and every app that calls Saleor server-side passes `<package-name>/<version>`. Apps with an existing client wrapper set it there once; klaviyo gains a wrapper for its five callsites. Five server callsites that bypassed their app's wrapper now go through it, picking up otel instrumentation as well.

Browser-only clients and one-off scripts are left alone — browsers forbid overriding User-Agent, so setting it there would do nothing.
