### PR TITLE
fix(cms): preserve non-Error rejections from providers

### DIFF
--- a/.changeset/gentle-moons-tap.md
+++ b/.changeset/gentle-moons-tap.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-cms": patch
+---
+
+Fixed error reporting when a CMS provider fails with a non-standard error. Previously such failures were logged as `Error: [object Object]`, hiding the actual reason (for example an expired Strapi token) and causing them to be reported as generic sync failures. Now the original error payload is preserved, so the message is visible and authentication problems are correctly reported as auth errors.

--- a/apps/cms/src/modules/webhooks-operations/webhooks-processors-delegator.test.ts
+++ b/apps/cms/src/modules/webhooks-operations/webhooks-processors-delegator.test.ts
@@ -277,6 +277,39 @@ describe("WebhooksProcessorsDelegator", () => {
       expect(mockReporter.reportProviderAuthError).toHaveBeenCalled();
     });
 
+    it("preserves payload of non-Error rejections (e.g. strapi-sdk-js) instead of [object Object]", async () => {
+      const appConfig = prepareFilledAppConfig();
+      const mockReporter = createMockProblemReporter();
+
+      const failingProcessor: ProductWebhooksProcessor = {
+        onProductUpdated: vi.fn(),
+        onProductVariantCreated: vi.fn(),
+        onProductVariantDeleted: vi.fn(),
+        onProductVariantUpdated: vi.fn().mockRejectedValue({
+          data: null,
+          error: { status: 401, name: "UnauthorizedError", message: "Missing or invalid token" },
+        }),
+      };
+
+      const delegator = new WebhooksProcessorsDelegator({
+        injectProcessorFactory: () => failingProcessor,
+        problemReporter: mockReporter,
+        context: {
+          connections: appConfig.connections
+            .getConnections()
+            .filter((c) => c.channelSlug === "test"),
+          providers: appConfig.providers.getProviders(),
+        },
+      });
+
+      await expect(
+        delegator.delegateVariantUpdatedOperations(getMockProductVariantWebhookFragment()),
+      ).rejects.toThrow(/Missing or invalid token/);
+
+      // payload is readable, so the 401 is classified as auth instead of generic sync failure
+      expect(mockReporter.reportProviderAuthError).toHaveBeenCalled();
+    });
+
     it("clears problems on successful processing", async () => {
       const appConfig = prepareFilledAppConfig();
       const mockReporter = createMockProblemReporter();

--- a/apps/cms/src/modules/webhooks-operations/webhooks-processors-delegator.ts
+++ b/apps/cms/src/modules/webhooks-operations/webhooks-processors-delegator.ts
@@ -1,3 +1,5 @@
+import { inspect } from "node:util";
+
 import { createLogger } from "@/logger";
 import { type CmsProblemReporter } from "@/modules/app-problems/cms-problem-reporter";
 
@@ -99,8 +101,15 @@ export class WebhooksProcessorsDelegator {
       involvedProviderIds.add(providerConfig.id);
 
       if (result.status === "rejected") {
+        /**
+         * Some SDKs reject with plain objects instead of Errors (e.g. strapi-sdk-js throws
+         * `{ data, error: { status, message } }`). String() would turn them into "[object Object]",
+         * losing the payload in Sentry and breaking error classification.
+         */
         const error =
-          result.reason instanceof Error ? result.reason : new Error(String(result.reason));
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(inspect(result.reason, { depth: 5 }), { cause: result.reason });
 
         errors.push(error);
 


### PR DESCRIPTION
Provider SDKs that reject with plain objects (strapi-sdk-js throws `{ data, error: { status, message } }`) were stringified to "[object Object]", losing the payload in Sentry and making classifyError fall through to sync-failure for auth errors.

## Scope of the PR

<!-- Describe briefly the changes made in this PR -->

## Related issues

<!-- If any, mention issues that are connected with this PR -->

## Checklist

- [ ] I added changesets and [read good practices](/.changeset/README.md).
