### PR TITLE
fix(search): always fetch channel-scoped stock in webhooks

### DIFF
--- a/.changeset/olive-pandas-repeat.md
+++ b/.changeset/olive-pandas-repeat.md
@@ -1,0 +1,9 @@
+---
+"saleor-app-search": patch
+---
+
+Fixed `inStock` still being indexed as `false` in Algolia after stock was restored in Saleor.
+
+Before: the previous fix fetched stock availability per channel, but only when `inStock` was listed among the app's enabled fields. `inStock` is always indexed and cannot be turned off in the app UI, so it never appeared on that list - the extra fetch was skipped on every webhook and the app fell back to the channel-less value from the webhook payload, which Saleor always resolves to 0. Setting stock to 0 looked correct, but restoring it left the product marked as out of stock until the next full index.
+
+After: stock availability is always fetched per channel when a webhook arrives, so restoring stock in Saleor marks the product as in stock in Algolia straight away.

--- a/apps/search/src/lib/algolia/algolia-search-provider.test.ts
+++ b/apps/search/src/lib/algolia/algolia-search-provider.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type ProductVariantWebhookPayloadFragment } from "../../../generated/graphql";
+import { AlgoliaSearchProvider } from "./algoliaSearchProvider";
+
+const saveObjects = vi.fn().mockResolvedValue(undefined);
+const deleteObjects = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("algoliasearch", () => ({
+  default: () => ({
+    initIndex: () => ({ saveObjects, deleteObjects }),
+  }),
+}));
+
+vi.mock("../logger", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+/**
+ * Webhook payloads have no channel context, so Saleor always resolves this to 0.
+ *
+ * @see createVariantsAvailabilityFetcher
+ */
+const variant = {
+  id: "variant-1",
+  name: "variant name",
+  trackInventory: true,
+  quantityAvailable: 0,
+  metadata: [],
+  attributes: [],
+  channelListings: [{ channel: { slug: "usd", currencyCode: "USD" } }],
+  product: {
+    id: "product-1",
+    name: "product name",
+    slug: "product-slug",
+    metadata: [],
+    attributes: [],
+    channelListings: [{ channel: { slug: "usd", currencyCode: "USD" }, visibleInListings: true }],
+  },
+} as unknown as ProductVariantWebhookPayloadFragment;
+
+/**
+ * `inStock` is not part of AlgoliaRootFieldsKeys - it is always indexed and can't be toggled off
+ * in the UI, so `enabledKeys` never contains it.
+ */
+const enabledKeys = ["attributes", "media", "categories"];
+
+const createProvider = (fetchVariantsAvailability = vi.fn()) =>
+  new AlgoliaSearchProvider({
+    appId: "app-id",
+    apiKey: "api-key",
+    channels: [{ slug: "usd", currencyCode: "USD" }],
+    enabledKeys,
+    pageEnabledKeys: [],
+    fetchVariantsAvailability,
+  });
+
+describe("AlgoliaSearchProvider inStock resolution", () => {
+  beforeEach(() => {
+    saveObjects.mockClear();
+    deleteObjects.mockClear();
+  });
+
+  it("Fetches channel-scoped availability even though `inStock` is not in enabledKeys", async () => {
+    const fetchVariantsAvailability = vi.fn().mockResolvedValue({ usd: { "variant-1": 7 } });
+
+    await createProvider(fetchVariantsAvailability).updateProductVariant(variant);
+
+    expect(fetchVariantsAvailability).toHaveBeenCalledWith({
+      variantIds: ["variant-1"],
+      channelSlugs: ["usd"],
+    });
+  });
+
+  it("Indexes inStock: true when the channel-scoped quantity is positive", async () => {
+    const fetchVariantsAvailability = vi.fn().mockResolvedValue({ usd: { "variant-1": 7 } });
+
+    await createProvider(fetchVariantsAvailability).updateProductVariant(variant);
+
+    expect(saveObjects).toHaveBeenCalledWith(
+      [expect.objectContaining({ inStock: true })],
+      expect.anything(),
+    );
+  });
+
+  it("Indexes inStock: false when the channel-scoped quantity is zero", async () => {
+    const fetchVariantsAvailability = vi.fn().mockResolvedValue({ usd: { "variant-1": 0 } });
+
+    await createProvider(fetchVariantsAvailability).updateProductVariant(variant);
+
+    expect(saveObjects).toHaveBeenCalledWith(
+      [expect.objectContaining({ inStock: false })],
+      expect.anything(),
+    );
+  });
+});

--- a/apps/search/src/lib/algolia/algoliaSearchProvider.ts
+++ b/apps/search/src/lib/algolia/algoliaSearchProvider.ts
@@ -106,10 +106,14 @@ export class AlgoliaSearchProvider implements SearchProvider {
     this.#fetchVariantsAvailability = fetchVariantsAvailability;
   }
 
+  /**
+   * `inStock` is always indexed - it is not part of `AlgoliaRootFieldsKeys`, so it can never appear
+   * in `enabledKeys` and must not be guarded by it.
+   */
   async #getVariantsAvailability(
     variants: ProductVariantWebhookPayloadFragment[],
   ): Promise<VariantsAvailability | undefined> {
-    if (!this.#fetchVariantsAvailability || !this.#enabledKeys.includes("inStock")) {
+    if (!this.#fetchVariantsAvailability) {
       return undefined;
     }
 


### PR DESCRIPTION
The per-channel `quantityAvailable` fetch added in #2427 never ran. It was guarded by `enabledKeys.includes("inStock")`, but `inStock` is not part of `AlgoliaRootFieldsKeys` - it is always indexed and has no UI toggle, so it can never appear in `enabledKeys`. The guard was permanently true.

Every webhook therefore fell back to the payload's `quantityAvailable`, which Saleor resolves without channel context. Where that yields 0, records were written as `inStock: false` and stayed that way once stock was restored, until the next full index.

Drop the `enabledKeys` condition and keep only the fetcher presence check - bulk sync legitimately has no fetcher because its query is already channel-scoped.
