### PR TITLE
feat: drop Saleor 3.21 compatibility

### DIFF
--- a/.changeset/drop-saleor-321-support.md
+++ b/.changeset/drop-saleor-321-support.md
@@ -1,0 +1,13 @@
+---
+"saleor-app-avatax": minor
+"saleor-app-cms": minor
+"saleor-app-klaviyo": minor
+"saleor-app-payment-np-atobarai": minor
+"saleor-app-payment-stripe": minor
+"saleor-app-products-feed": minor
+"saleor-app-search": minor
+"saleor-app-segment": minor
+"saleor-app-smtp": minor
+---
+
+Dropped support for Saleor 3.21. Before, these apps could be installed on Saleor 3.21 and newer. Now, the minimum supported version is 3.22 - installing on an older Saleor will be rejected by the Dashboard. Saleor 3.21 users should stay on the previous app release until they upgrade their Saleor instance.

--- a/apps/avatax/e2e/utils/saleor-version-compatibility.ts
+++ b/apps/avatax/e2e/utils/saleor-version-compatibility.ts
@@ -1,5 +1,7 @@
 import { envE2e } from "../env-e2e";
 
+// TODO: dead helper - app requires Saleor >=3.22, so 3.20 is no longer tested against.
+
 export const isTestRunAgainstSaleor320AndLower = () => {
   const saleorVersion = envE2e.E2E_SALEOR_VERSION;
 

--- a/apps/avatax/src/app/api/manifest/route.ts
+++ b/apps/avatax/src/app/api/manifest/route.ts
@@ -63,7 +63,7 @@ const handler = createManifestHandler({
       id: env.MANIFEST_APP_ID,
       name: "AvaTax",
       permissions: ["HANDLE_TAXES", "MANAGE_ORDERS", "MANAGE_PRODUCTS"],
-      requiredSaleorVersion: ">=3.21 <4",
+      requiredSaleorVersion: ">=3.22 <4",
       supportUrl: "https://github.com/saleor/apps/discussions",
       tokenTargetUrl: `${apiBaseURL}/api/register`,
       version: packageJson.version,

--- a/apps/cms/src/pages/api/manifest.ts
+++ b/apps/cms/src/pages/api/manifest.ts
@@ -39,7 +39,7 @@ const handler = createManifestHandler({
       id: "saleor.app.cms2",
       name: "CMS",
       permissions: ["MANAGE_PRODUCTS"],
-      requiredSaleorVersion: ">=3.21 <4",
+      requiredSaleorVersion: ">=3.22 <4",
       supportUrl: "https://github.com/saleor/apps/discussions",
       tokenTargetUrl: `${apiBaseURL}/api/register`,
       version: packageJson.version,

--- a/apps/klaviyo/src/pages/api/manifest.ts
+++ b/apps/klaviyo/src/pages/api/manifest.ts
@@ -28,7 +28,7 @@ const handler = wrapWithLoggerContext(
               default: `${apiBaseURL}/logo.png`,
             },
           },
-          requiredSaleorVersion: ">=3.21 <4",
+          requiredSaleorVersion: ">=3.22 <4",
           dataPrivacyUrl: "https://saleor.io/legal/privacy/",
           homepageUrl: "https://github.com/saleor/apps",
           id: "saleor.app.klaviyo",

--- a/apps/np-atobarai/src/app/api/manifest/route.test.ts
+++ b/apps/np-atobarai/src/app/api/manifest/route.test.ts
@@ -55,7 +55,7 @@ describe("Manifest handler", async () => {
               "HANDLE_PAYMENTS",
               "MANAGE_ORDERS",
             ],
-            "requiredSaleorVersion": ">=3.21 <4",
+            "requiredSaleorVersion": ">=3.22 <4",
             "supportUrl": "https://saleor.io/discord",
             "tokenTargetUrl": "https://localhost:3000/api/register",
             "version": Any<String>,

--- a/apps/np-atobarai/src/app/api/manifest/route.ts
+++ b/apps/np-atobarai/src/app/api/manifest/route.ts
@@ -37,7 +37,7 @@ const handler = createManifestHandler({
        */
       name: env.APP_NAME,
       permissions: ["HANDLE_PAYMENTS", "MANAGE_ORDERS"],
-      requiredSaleorVersion: ">=3.21 <4",
+      requiredSaleorVersion: ">=3.22 <4",
       supportUrl: "https://saleor.io/discord",
       tokenTargetUrl: `${apiBaseUrl}/api/register`,
       version: packageJson.version,

--- a/apps/products-feed/src/pages/api/manifest.ts
+++ b/apps/products-feed/src/pages/api/manifest.ts
@@ -39,7 +39,7 @@ export default wrapWithLoggerContext(
           supportUrl: "https://github.com/saleor/apps/discussions",
           tokenTargetUrl: `${apiBaseURL}/api/register`,
           version: packageJson.version,
-          requiredSaleorVersion: ">=3.21 <4",
+          requiredSaleorVersion: ">=3.22 <4",
           webhooks: [appDeletedWebhook.getWebhookManifest(apiBaseURL)],
         };
 

--- a/apps/search/src/pages/api/manifest.ts
+++ b/apps/search/src/pages/api/manifest.ts
@@ -52,7 +52,7 @@ export default wrapWithLoggerContext(
             appDeletedWebhook.getWebhookManifest(apiBaseURL),
           ],
           author: "Saleor Commerce",
-          requiredSaleorVersion: ">=3.21 <4",
+          requiredSaleorVersion: ">=3.22 <4",
         };
 
         return manifest;

--- a/apps/segment/src/pages/api/manifest.ts
+++ b/apps/segment/src/pages/api/manifest.ts
@@ -31,7 +31,7 @@ export default wrapWithLoggerContext(
           id: env.MANIFEST_APP_ID,
           name: "Twilio Segment",
           permissions: ["MANAGE_ORDERS"],
-          requiredSaleorVersion: ">=3.21 <4",
+          requiredSaleorVersion: ">=3.22 <4",
           supportUrl: "https://github.com/saleor/apps/discussions",
           tokenTargetUrl: `${apiBaseURL}/api/register`,
           version: packageJson.version,

--- a/apps/smtp/src/components/manage-permissions-text-link.tsx
+++ b/apps/smtp/src/components/manage-permissions-text-link.tsx
@@ -19,7 +19,10 @@ export const ManagePermissionsTextLink = ({
   const { appBridgeState, appBridge } = useAppBridge();
   const dashboardVersion = appBridgeState?.dashboardVersion;
 
-  // Editing app permissions has been introduced in Saleor Dashboard 3.15
+  /*
+   * Editing app permissions has been introduced in Saleor Dashboard 3.15
+   * TODO: dead gate - app requires Saleor >=3.22, so any matching Dashboard supports this.
+   */
   const isPermissionManagementAvailable = dashboardVersion
     ? new SaleorVersionCompatibilityValidator(">=3.15").isValid(dashboardVersion)
     : false;

--- a/apps/smtp/src/lib/get-event-form-status.ts
+++ b/apps/smtp/src/lib/get-event-form-status.ts
@@ -8,6 +8,10 @@ interface getEventFormStatusArgs {
   appPermissions?: PermissionEnum[];
 }
 
+/*
+ * TODO: `requiredSaleorVersion` branches are dead - app requires Saleor >=3.22,
+ * so ORDER_REFUNDED (>=3.14) and GIFT_CARD_SENT (>=3.13) are always supported.
+ */
 export const getEventFormStatus = ({
   eventType,
   featureFlags,

--- a/apps/smtp/src/modules/feature-flag-service/get-feature-flags.ts
+++ b/apps/smtp/src/modules/feature-flag-service/get-feature-flags.ts
@@ -13,6 +13,9 @@ interface GetFeatureFlagsArgs {
 /*
  * Returns list of feature flags based on Saleor version.
  * `saleorVersion` is expected to be in Semver format, e.g. "3.13.0"
+ *
+ * TODO: dead flags - app requires Saleor >=3.22, so both are always true.
+ * Remove the feature-flag service along with getEventFormStatus's version branches.
  */
 export const getFeatureFlags = ({ saleorVersion }: GetFeatureFlagsArgs): FeatureFlagsState => {
   return {

--- a/apps/smtp/src/saleor-app.ts
+++ b/apps/smtp/src/saleor-app.ts
@@ -52,4 +52,4 @@ export const saleorApp = new SaleorApp({
   apl,
 });
 
-export const REQUIRED_SALEOR_VERSION = ">=3.11.7 <4";
+export const REQUIRED_SALEOR_VERSION = ">=3.22 <4";

--- a/apps/stripe/src/app/api/manifest/route.test.ts
+++ b/apps/stripe/src/app/api/manifest/route.test.ts
@@ -54,7 +54,7 @@ describe("Manifest handler", async () => {
             "permissions": [
               "HANDLE_PAYMENTS",
             ],
-            "requiredSaleorVersion": ">=3.21 <4",
+            "requiredSaleorVersion": ">=3.22 <4",
             "supportUrl": "https://saleor.io/discord",
             "tokenTargetUrl": "https://localhost:3000/api/register",
             "version": Any<String>,

--- a/apps/stripe/src/app/api/manifest/route.ts
+++ b/apps/stripe/src/app/api/manifest/route.ts
@@ -38,7 +38,7 @@ const handler = createManifestHandler({
        */
       name: env.APP_NAME,
       permissions: ["HANDLE_PAYMENTS"],
-      requiredSaleorVersion: ">=3.21 <4",
+      requiredSaleorVersion: ">=3.22 <4",
       supportUrl: "https://saleor.io/discord",
       tokenTargetUrl: `${apiBaseUrl}/api/register`,
       version: packageJson.version,

--- a/apps/stripe/src/app/api/webhooks/stripe/stripe-object-handlers/stripe-payment-intent-handler.ts
+++ b/apps/stripe/src/app/api/webhooks/stripe/stripe-object-handlers/stripe-payment-intent-handler.ts
@@ -51,6 +51,10 @@ type PossibleErrors =
  * Minimum Saleor version required for payment method details support.
  * Saleor 3.22 introduced the `paymentMethodDetails` field in the Transaction API.
  * See: https://github.com/saleor/saleor/releases/tag/3.22.0
+ *
+ * TODO: dead gate - app manifest now requires Saleor >=3.22, so this always passes.
+ * Remove the check and always fetch payment method details. Kept until stored
+ * transactions recorded on <3.22 are no longer in play.
  */
 const PAYMENT_METHOD_DETAILS_MIN_VERSION = "3.22";
 


### PR DESCRIPTION
Bump requiredSaleorVersion to ">=3.22 <4" in the apps still declaring ">=3.21 <4". SMTP's REQUIRED_SALEOR_VERSION was stuck at ">=3.11.7 <4", contradicting its own manifest, so it is realigned too.

Saleor 3.21 is EOL 
